### PR TITLE
fix: 修复视频插入画板后不显示的问题

### DIFF
--- a/packages/drawnix/src/data/video.ts
+++ b/packages/drawnix/src/data/video.ts
@@ -282,12 +282,17 @@ export const insertVideoFromUrl = async (
     // 使用图片元素，通过URL后缀识别为视频
     // 注意：使用 ObjectURL 在页面刷新后会失效
     // 但视频数据已缓存到 IndexedDB，后续可以实现从缓存恢复的逻辑
+    // 在 ObjectURL 后面添加 #video 标识符
+    // 因为 DrawTransforms.insertImage 可能不会保留自定义属性（如 isVideo）
+    // 通过 URL hash 来标识视频元素是最可靠的方式
     const videoAsImageElement = {
-      url: objectUrl,
+      url: `${objectUrl}#video`,
       width: displayDimensions.width,
       height: displayDimensions.height,
       // 存储原始 URL 以便后续从缓存恢复
       originalUrl: videoUrl,
+      // 显式标识为视频，因为 ObjectURL 没有扩展名无法通过后缀识别
+      isVideo: true,
     };
 
     console.log('Creating video as image element:', videoAsImageElement);

--- a/packages/drawnix/src/plugins/components/image.tsx
+++ b/packages/drawnix/src/plugins/components/image.tsx
@@ -2,15 +2,22 @@ import type { ImageProps } from '@plait/common';
 import classNames from 'classnames';
 import { Video } from './video';
 
-// 检查是否为视频元素（通过URL扩展名或者元数据）
+// 检查是否为视频元素（通过URL标识、扩展名或元数据）
 const isVideoElement = (imageItem: any): boolean => {
-  // 检查是否有视频标识
+  // 检查是否有视频标识属性
   if (imageItem.isVideo === true || imageItem.videoType) {
     return true;
   }
-  
-  // 检查URL扩展名
+
   const url = imageItem.url || '';
+
+  // 检查 URL hash 标识符（用于 ObjectURL 的视频识别）
+  // 格式：blob:http://...#video
+  if (url.includes('#video')) {
+    return true;
+  }
+
+  // 检查URL扩展名（用于普通 URL 的视频识别）
   const videoExtensions = ['.mp4', '.avi', '.mov', '.wmv', '.flv', '.webm', '.mkv'];
   return videoExtensions.some(ext => url.toLowerCase().includes(ext));
 };

--- a/packages/drawnix/src/plugins/components/video.tsx
+++ b/packages/drawnix/src/plugins/components/video.tsx
@@ -22,7 +22,10 @@ export const Video: React.FC<VideoProps> = (props: VideoProps) => {
   const [isLoading, setIsLoading] = useState(true);
 
   const { videoItem, isFocus = false, isSelected = false, readonly = false } = props;
-  const { url, poster, videoType } = videoItem;
+  const { url: rawUrl, poster, videoType } = videoItem;
+
+  // 清理 URL 中的 #video 标识符（用于视频类型识别，但不影响实际播放）
+  const url = rawUrl?.replace('#video', '') || '';
   
   useEffect(() => {
     const video = videoRef.current;

--- a/packages/drawnix/src/plugins/with-video.ts
+++ b/packages/drawnix/src/plugins/with-video.ts
@@ -55,16 +55,28 @@ export const withVideo = (board: PlaitBoard) => {
 
 /**
  * 检查元素是否为视频类型
- * 通过URL后缀名判断
+ * 通过URL标识符、扩展名或元数据判断
  */
 export function isVideoElement(element: any): boolean {
   if (!element || !element.url) {
     return false;
   }
-  
+
+  // 检查是否有视频标识属性
+  if (element.isVideo === true || element.videoType) {
+    return true;
+  }
+
   const url = element.url.toLowerCase();
+
+  // 检查 URL hash 标识符（用于 ObjectURL 的视频识别）
+  // 格式：blob:http://...#video
+  if (url.includes('#video')) {
+    return true;
+  }
+
+  // 检查URL扩展名（用于普通 URL 的视频识别）
   const videoExtensions = ['.mp4', '.mov', '.avi', '.mkv', '.webm', '.m4v', '.flv', '.wmv'];
-  
   return videoExtensions.some(ext => url.includes(ext));
 }
 


### PR DESCRIPTION
问题原因：
- DrawTransforms.insertImage 不保留自定义属性（如 isVideo）
- ObjectURL 格式（blob:http://...）没有扩展名，无法通过后缀识别为视频
- 导致视频被错误地用 <img> 标签渲染

解决方案：
- video.ts: 在 ObjectURL 后添加 #video 标识符
- image.tsx: isVideoElement() 检测 #video 标识符
- with-video.ts: isVideoElement() 检测 #video 标识符
- video.tsx: 播放时清理 #video 标识符