### PR TITLE
fix(ai-input): 优化尺寸参数优先级策略

### DIFF
--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -807,8 +807,8 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(({ className }) 
           .filter((item) => item.type === 'video' && item.url)
           .map((item) => item.url!),
         graphics: graphicsItems.map((item) => item.url!),
-        // 添加图片尺寸信息（如果有）
-        imageDimensions: imageDimensions.length > 0 ? imageDimensions : undefined,
+        // 添加图片尺寸信息（始终传递数组，避免下游处理 undefined）
+        imageDimensions: imageDimensions,
       };
 
       // 解析输入内容，使用选中的模型和尺寸

--- a/packages/drawnix/src/services/agent/agent-executor.ts
+++ b/packages/drawnix/src/services/agent/agent-executor.ts
@@ -43,22 +43,6 @@ function replacePlaceholdersWithUrls(
 }
 
 /**
- * 检测用户指令中是否包含明确的尺寸描述
- * 如果包含，AI 应该使用用户指令中的尺寸，忽略配置中的尺寸参数
- *
- * @param text 用户指令文本
- * @returns 是否包含明确的尺寸描述
- */
-function hasExplicitSizeInInstruction(text: string): boolean {
-  // 匹配明确的尺寸格式：16:9, 1:1, 9:16, 1920x1080 等
-  const patterns = [
-    /\d+:\d+/,              // 16:9, 1:1, 9:16
-    /\d+x\d+/i,             // 1920x1080, 1024x768
-  ];
-  return patterns.some(pattern => pattern.test(text));
-}
-
-/**
  * 构建结构化的用户消息
  * 使用 Markdown 格式清晰展示所有上下文信息
  */
@@ -72,10 +56,10 @@ function buildStructuredUserMessage(context: AgentExecutionContext): string {
   parts.push(`- **模型**: ${context.model.id} ${modelStatus}`);
   parts.push(`- **类型**: ${context.model.type === 'image' ? '图片生成' : '视频生成'}`);
   parts.push(`- **数量**: ${context.params.count}`);
-  // 只有当用户指令中没有明确尺寸描述时，才传递配置中的尺寸参数
-  // 这样 AI 会优先使用用户指令中的尺寸
-  if (context.params.size && !hasExplicitSizeInInstruction(context.userInstruction || '')) {
-    parts.push(`- **尺寸**: ${context.params.size}`);
+  // 始终传递配置的尺寸，但标注为默认值，让 AI 判断是否使用
+  // 优先级：用户指令中的尺寸描述 > 下拉框选择的尺寸 > 模型默认尺寸
+  if (context.params.size) {
+    parts.push(`- **尺寸**: ${context.params.size}（默认值，如用户指令中有尺寸描述则优先使用用户的）`);
   }
   if (context.params.duration) {
     parts.push(`- **时长**: ${context.params.duration}秒`);


### PR DESCRIPTION
1. 移除 hasExplicitSizeInInstruction 正则检测函数
   - 正则无法准确区分尺寸描述和时间格式（如 3:00）
   - 容易产生误判和漏判

2. 改为始终传递尺寸参数，让 AI 判断优先级
   - 优先级：用户指令中的尺寸描述 > 下拉框选择 > 模型默认
   - 在 prompt 中标注为"默认值"，提示 AI 优先使用用户指令

3. 修复 imageDimensions 为 undefined 导致的报错
   - 始终传递数组（可为空），避免下游处理 undefined