### PR TITLE
feat(project-drawer): 添加双击重命名功能

### DIFF
--- a/packages/drawnix/src/components/project-drawer/ProjectDrawer.tsx
+++ b/packages/drawnix/src/components/project-drawer/ProjectDrawer.tsx
@@ -83,11 +83,14 @@ const ProjectDrawerContent: React.FC<{
 }) => {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
-  
+
   // Drag state
   const [dragData, setDragData] = useState<DragData | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
   const [dropPosition, setDropPosition] = useState<DropPosition>(null);
+
+  // Click delay timer for distinguishing single/double click
+  const clickTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Auto-select text when input is focused
   const handleInputFocus = useCallback((_value: string, context: { e: React.FocusEvent<HTMLInputElement> }) => {
@@ -271,7 +274,14 @@ const ProjectDrawerContent: React.FC<{
           draggable={!isEditing}
           onClick={() => {
             if (!isEditing) {
-              toggleFolderExpanded(folder.id);
+              // Clear any existing timer
+              if (clickTimerRef.current) {
+                clearTimeout(clickTimerRef.current);
+              }
+              // Delay folder toggle to allow double-click to work
+              clickTimerRef.current = setTimeout(() => {
+                toggleFolderExpanded(folder.id);
+              }, 200);
             }
           }}
           onDragStart={(e) => handleDragStart(e, 'folder', folder.id)}
@@ -309,7 +319,20 @@ const ProjectDrawerContent: React.FC<{
               }}
             />
           ) : (
-            <span className="project-drawer-node__label">{folder.name}</span>
+            <span
+              className="project-drawer-node__label"
+              onDoubleClick={(e) => {
+                e.stopPropagation();
+                // Clear single-click timer
+                if (clickTimerRef.current) {
+                  clearTimeout(clickTimerRef.current);
+                  clickTimerRef.current = null;
+                }
+                startEditing(folder.id, folder.name);
+              }}
+            >
+              {folder.name}
+            </span>
           )}
 
           <div className="project-drawer-node__actions" onClick={(e) => e.stopPropagation()}>
@@ -369,7 +392,14 @@ const ProjectDrawerContent: React.FC<{
           draggable={!isEditing}
           onClick={() => {
             if (!isEditing) {
-              onBoardClick(board);
+              // Clear any existing timer
+              if (clickTimerRef.current) {
+                clearTimeout(clickTimerRef.current);
+              }
+              // Delay board click to allow double-click to work
+              clickTimerRef.current = setTimeout(() => {
+                onBoardClick(board);
+              }, 200);
             }
           }}
           onDragStart={(e) => handleDragStart(e, 'board', board.id)}
@@ -402,7 +432,20 @@ const ProjectDrawerContent: React.FC<{
               }}
             />
           ) : (
-            <span className="project-drawer-node__label">{board.name}</span>
+            <span
+              className="project-drawer-node__label"
+              onDoubleClick={(e) => {
+                e.stopPropagation();
+                // Clear single-click timer
+                if (clickTimerRef.current) {
+                  clearTimeout(clickTimerRef.current);
+                  clickTimerRef.current = null;
+                }
+                startEditing(board.id, board.name);
+              }}
+            >
+              {board.name}
+            </span>
           )}
 
           <div className="project-drawer-node__actions" onClick={(e) => e.stopPropagation()}>

--- a/packages/drawnix/src/components/project-drawer/project-drawer.scss
+++ b/packages/drawnix/src/components/project-drawer/project-drawer.scss
@@ -185,6 +185,14 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     font-size: 14px;
+    cursor: text;
+    padding: 2px 4px;
+    border-radius: 3px;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background: var(--td-bg-color-container-hover);
+    }
   }
 
   &__drag-count {


### PR DESCRIPTION
- 为文件夹和画板名称添加双击编辑功能
- 实现单击和双击事件的区分（200ms延迟）
- 添加事件冒泡阻止，避免触发父元素事件
- 优化标签样式，添加 hover 效果和 cursor: text 提示
- 标签 hover 时显示浅色背景，提示可编辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)