### PR TITLE
feat: 添加灵感创意板块的「不再提示」功能

### DIFF
--- a/packages/drawnix/src/components/inspiration-board/InspirationBoard.tsx
+++ b/packages/drawnix/src/components/inspiration-board/InspirationBoard.tsx
@@ -4,13 +4,15 @@
  * 灵感创意板块主组件，当画板为空时显示创意模版
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from 'tdesign-icons-react';
-import { Lightbulb } from 'lucide-react';
+import { Lightbulb, X } from 'lucide-react';
 import { InspirationCard } from './InspirationCard';
 import { INSPIRATION_TEMPLATES, ITEMS_PER_PAGE } from './constants';
 import type { InspirationBoardProps } from './types';
 import './inspiration-board.scss';
+
+const HIDE_INSPIRATION_KEY = 'aitu_hide_inspiration_board';
 
 export const InspirationBoard: React.FC<InspirationBoardProps> = ({
   isCanvasEmpty,
@@ -20,6 +22,15 @@ export const InspirationBoard: React.FC<InspirationBoardProps> = ({
   className = '',
 }) => {
   const [currentPage, setCurrentPage] = useState(0);
+  const [isHidden, setIsHidden] = useState(false);
+
+  // 组件加载时从 localStorage 读取用户设置
+  useEffect(() => {
+    const hidePreference = localStorage.getItem(HIDE_INSPIRATION_KEY);
+    if (hidePreference === 'true') {
+      setIsHidden(true);
+    }
+  }, []);
 
   // 计算总页数
   const totalPages = Math.ceil(INSPIRATION_TEMPLATES.length / ITEMS_PER_PAGE);
@@ -50,8 +61,16 @@ export const InspirationBoard: React.FC<InspirationBoardProps> = ({
     onSelectPrompt({ prompt, modelType: 'agent' });
   }, [onSelectPrompt]);
 
-  // 不显示的条件：画板不为空 或 外部控制隐藏
-  if (!isCanvasEmpty || !visible) {
+  // 处理"不再提示"按钮点击
+  const handleHide = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsHidden(true);
+    localStorage.setItem(HIDE_INSPIRATION_KEY, 'true');
+  }, []);
+
+  // 不显示的条件：画板不为空 或 外部控制隐藏 或 用户选择不再提示
+  if (!isCanvasEmpty || !visible || isHidden) {
     return null;
   }
 
@@ -62,6 +81,18 @@ export const InspirationBoard: React.FC<InspirationBoardProps> = ({
       {/* 头部：标题 + 提示词按钮 + 切换按钮 */}
       <div className="inspiration-board__header">
         <h3 className="inspiration-board__title">灵感创意</h3>
+
+        {/* 不再提示按钮 */}
+        <button
+          className="inspiration-board__hide-btn"
+          onClick={handleHide}
+          onMouseDown={(e) => e.preventDefault()}
+          title="不再提示"
+          data-track="inspiration_click_hide"
+        >
+          <X size={14} />
+          <span>不再提示</span>
+        </button>
 
         {/* 提示词工具按钮 */}
         {onOpenPromptTool && (

--- a/packages/drawnix/src/components/inspiration-board/inspiration-board.scss
+++ b/packages/drawnix/src/components/inspiration-board/inspiration-board.scss
@@ -44,6 +44,38 @@ $animation-duration: 0.3s;
     flex: 1; // 占据剩余空间，把右侧按钮推到最右边
   }
 
+  // 不再提示按钮
+  &__hide-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+
+    font-size: 12px;
+    font-weight: 500;
+    background: transparent;
+    color: var(--td-text-color-placeholder);
+    transition: all 0.2s ease;
+    margin-right: 8px;
+
+    &:hover {
+      background: var(--td-bg-color-container-hover);
+      color: var(--td-text-color-secondary);
+    }
+
+    &:active {
+      transform: scale(0.97);
+    }
+
+    svg {
+      flex-shrink: 0;
+    }
+  }
+
   // 提示词工具按钮
   &__prompt-btn {
     display: flex;


### PR DESCRIPTION
## 概述
在灵感创意板块头部添加「不再提示」按钮，允许用户永久隐藏该板块。

## 功能特性
- ✨ 在灵感创意板块头部添加「不再提示」按钮（带 X 图标）
- 💾 使用 `localStorage` 持久化用户的隐藏偏好
- 🔄 点击后立即隐藏板块，刷新页面后保持隐藏状态
- 🎨 按钮样式与现有设计风格保持一致
- 🧹 只有清除浏览器数据才能重置此设置

## 技术实现
- 使用 `useEffect` 在组件加载时读取 localStorage
- 使用 `useCallback` 优化事件处理函数性能
- localStorage key: `aitu_hide_inspiration_board`
- 添加数据埋点：`data-track="inspiration_click_hide"`

## 测试方法
1. 打开应用，确保画布为空
2. 查看灵感创意板块，应该看到「不再提示」按钮
3. 点击按钮，板块应该立即消失
4. 刷新页面，板块应该不再出现
5. 清除浏览器 localStorage 或删除 `aitu_hide_inspiration_board` key，板块重新显示

## 截图
（可以在审查时添加截图）

🤖 Generated with Claude Code