### PR TITLE
feat(image): 接入香蕉生图异步模型

### DIFF
--- a/packages/drawnix/src/constants/model-config.ts
+++ b/packages/drawnix/src/constants/model-config.ts
@@ -1,9 +1,9 @@
 /**
  * 统一的模型配置文件
- * 
+ *
  * 所有图片、视频和文本模型的配置都在这里定义
  * 被 ModelSelector、settings-dialog、ai-image-generation、ai-video-generation 等组件使用
- * 
+ *
  * 参数配置用于 SmartSuggestionPanel 的 - 参数提示功能
  */
 
@@ -99,9 +99,9 @@ export interface ModelConfig {
  * 模型类型对应的颜色
  */
 export const MODEL_TYPE_COLORS = {
-  image: '#E53935',  // 红色
-  video: '#FF9800',  // 橙色
-  text: '#4CAF50',   // 绿色
+  image: '#E53935', // 红色
+  video: '#FF9800', // 橙色
+  text: '#4CAF50', // 绿色
 } as const;
 
 // ============================================
@@ -242,7 +242,50 @@ export const IMAGE_MODEL_MORE_OPTIONS: ModelConfig[] = [
     supportsTools: true,
     imageDefaults: IMAGE_4K_DEFAULT_PARAMS,
   },
+  {
+    id: 'gemini-3-pro-image-preview-async',
+    label: 'gemini-3-pro-image-preview-async (1k 异步)',
+    shortLabel: 'nb2-async',
+    shortCode: 'nb2a',
+    description: '异步 1K 图片生成（轮询获取结果）',
+    type: 'image',
+    supportsTools: false,
+    imageDefaults: IMAGE_DEFAULT_PARAMS,
+  },
+  {
+    id: 'gemini-3-pro-image-preview-2k-async',
+    label: 'gemini-3-pro-image-preview-2k-async (2k 异步)',
+    shortLabel: 'nb22k-async',
+    shortCode: 'nb22ka',
+    description: '异步 2K 图片生成（轮询获取结果）',
+    type: 'image',
+    supportsTools: false,
+    imageDefaults: IMAGE_2K_DEFAULT_PARAMS,
+  },
+  {
+    id: 'gemini-3-pro-image-preview-4k-async',
+    label: 'gemini-3-pro-image-preview-4k-async (4k 异步)',
+    shortLabel: 'nb24k-async',
+    shortCode: 'nb24ka',
+    description: '异步 4K 图片生成（轮询获取结果）',
+    type: 'image',
+    supportsTools: false,
+    imageDefaults: IMAGE_4K_DEFAULT_PARAMS,
+  },
 ];
+
+/** 异步图片模型 ID 列表 */
+export const ASYNC_IMAGE_MODEL_IDS = [
+  'gemini-3-pro-image-preview-async',
+  'gemini-3-pro-image-preview-2k-async',
+  'gemini-3-pro-image-preview-4k-async',
+];
+
+export function isAsyncImageModel(modelId?: string): boolean {
+  if (!modelId) return false;
+  const lower = modelId.toLowerCase();
+  return ASYNC_IMAGE_MODEL_IDS.some((id) => lower.includes(id.toLowerCase()));
+}
 
 /**
  * 所有图片模型
@@ -457,14 +500,14 @@ export const ALL_MODELS: ModelConfig[] = [
  * 根据类型获取模型列表
  */
 export function getModelsByType(type: ModelType): ModelConfig[] {
-  return ALL_MODELS.filter(model => model.type === type);
+  return ALL_MODELS.filter((model) => model.type === type);
 }
 
 /**
  * 获取模型配置
  */
 export function getModelConfig(modelId: string): ModelConfig | undefined {
-  return ALL_MODELS.find(model => model.id === modelId);
+  return ALL_MODELS.find((model) => model.id === modelId);
 }
 
 /**
@@ -479,7 +522,7 @@ export function getModelType(modelId: string): ModelType | undefined {
  */
 export function getModelIds(type?: ModelType): string[] {
   const models = type ? getModelsByType(type) : ALL_MODELS;
-  return models.map(model => model.id);
+  return models.map((model) => model.id);
 }
 
 /**
@@ -519,7 +562,7 @@ export function getModelTypeColor(type: ModelType): string {
 /**
  * 图片模型选项（用于 Select 组件）
  */
-export const IMAGE_MODEL_SELECT_OPTIONS = IMAGE_MODELS.map(model => ({
+export const IMAGE_MODEL_SELECT_OPTIONS = IMAGE_MODELS.map((model) => ({
   label: model.label,
   value: model.id,
 }));
@@ -530,14 +573,14 @@ export const IMAGE_MODEL_SELECT_OPTIONS = IMAGE_MODELS.map(model => ({
 export const IMAGE_MODEL_GROUPED_SELECT_OPTIONS = [
   {
     group: '推荐',
-    children: IMAGE_MODEL_VIP_OPTIONS.map(model => ({
+    children: IMAGE_MODEL_VIP_OPTIONS.map((model) => ({
       label: model.label,
       value: model.id,
     })),
   },
   {
     group: '更多',
-    children: IMAGE_MODEL_MORE_OPTIONS.map(model => ({
+    children: IMAGE_MODEL_MORE_OPTIONS.map((model) => ({
       label: model.label,
       value: model.id,
     })),
@@ -547,7 +590,7 @@ export const IMAGE_MODEL_GROUPED_SELECT_OPTIONS = [
 /**
  * 视频模型选项（用于 Select 组件）
  */
-export const VIDEO_MODEL_SELECT_OPTIONS = VIDEO_MODELS.map(model => ({
+export const VIDEO_MODEL_SELECT_OPTIONS = VIDEO_MODELS.map((model) => ({
   label: model.label,
   value: model.id,
 }));
@@ -555,7 +598,7 @@ export const VIDEO_MODEL_SELECT_OPTIONS = VIDEO_MODELS.map(model => ({
 /**
  * 文本模型选项（用于 Select 组件）
  */
-export const TEXT_MODEL_SELECT_OPTIONS = TEXT_MODELS.map(model => ({
+export const TEXT_MODEL_SELECT_OPTIONS = TEXT_MODELS.map((model) => ({
   label: model.label,
   value: model.id,
 }));
@@ -622,7 +665,13 @@ export const DEFAULT_TEXT_MODEL = DEFAULT_TEXT_MODEL_ID;
 // ============================================
 
 /** Veo 系列模型 ID（标清，只支持 8 秒） */
-const VEO_MODEL_IDS = ['veo3', 'veo3-pro', 'veo3.1', 'veo3.1-pro', 'veo3.1-components'];
+const VEO_MODEL_IDS = [
+  'veo3',
+  'veo3-pro',
+  'veo3.1',
+  'veo3.1-pro',
+  'veo3.1-components',
+];
 
 /** Veo 4K 系列模型 ID（4K分辨率，只支持 8 秒） */
 const VEO_4K_MODEL_IDS = ['veo3.1-4k', 'veo3.1-components-4k', 'veo3.1-pro-4k'];
@@ -640,12 +689,12 @@ const SORA_2_PRO_MODEL_IDS = ['sora-2-pro'];
 const GPT_IMAGE_MODEL_IDS = ['gpt-image-1.5'];
 
 /** Gemini 图片模型 ID（支持完整尺寸） */
-const GEMINI_IMAGE_MODEL_IDS = IMAGE_MODELS
-  .filter(m => !GPT_IMAGE_MODEL_IDS.includes(m.id))
-  .map(m => m.id);
+const GEMINI_IMAGE_MODEL_IDS = IMAGE_MODELS.filter(
+  (m) => !GPT_IMAGE_MODEL_IDS.includes(m.id)
+).map((m) => m.id);
 
 /** 所有图片模型 ID */
-const ALL_IMAGE_MODEL_IDS = IMAGE_MODELS.map(m => m.id);
+const ALL_IMAGE_MODEL_IDS = IMAGE_MODELS.map((m) => m.id);
 
 /**
  * 视频参数配置
@@ -659,9 +708,7 @@ export const VIDEO_PARAMS: ParamConfig[] = [
     shortLabel: '时长',
     description: '生成视频的时长（秒）',
     valueType: 'enum',
-    options: [
-      { value: '8', label: '8秒' },
-    ],
+    options: [{ value: '8', label: '8秒' }],
     defaultValue: '8',
     compatibleModels: ALL_VEO_MODEL_IDS,
     modelType: 'video',
@@ -798,16 +845,13 @@ export const IMAGE_PARAMS: ParamConfig[] = [
 /**
  * 所有参数配置
  */
-export const ALL_PARAMS: ParamConfig[] = [
-  ...VIDEO_PARAMS,
-  ...IMAGE_PARAMS,
-];
+export const ALL_PARAMS: ParamConfig[] = [...VIDEO_PARAMS, ...IMAGE_PARAMS];
 
 /**
  * 根据模型类型获取参数列表
  */
 export function getParamsByModelType(modelType: ModelType): ParamConfig[] {
-  return ALL_PARAMS.filter(param => param.modelType === modelType);
+  return ALL_PARAMS.filter((param) => param.modelType === modelType);
 }
 
 /**
@@ -816,8 +860,8 @@ export function getParamsByModelType(modelType: ModelType): ParamConfig[] {
 export function getCompatibleParams(modelId: string): ParamConfig[] {
   const modelConfig = getModelConfig(modelId);
   if (!modelConfig) return [];
-  
-  return ALL_PARAMS.filter(param => {
+
+  return ALL_PARAMS.filter((param) => {
     // 检查模型类型是否匹配
     if (param.modelType !== modelConfig.type) return false;
     // 检查是否在兼容列表中（空数组表示所有模型都兼容）
@@ -830,7 +874,7 @@ export function getCompatibleParams(modelId: string): ParamConfig[] {
  * 获取参数配置
  */
 export function getParamConfig(paramId: string): ParamConfig | undefined {
-  return ALL_PARAMS.find(param => param.id === paramId);
+  return ALL_PARAMS.find((param) => param.id === paramId);
 }
 
 /**
@@ -838,7 +882,7 @@ export function getParamConfig(paramId: string): ParamConfig | undefined {
  */
 export function getParamIds(modelType?: ModelType): string[] {
   const params = modelType ? getParamsByModelType(modelType) : ALL_PARAMS;
-  return params.map(param => param.id);
+  return params.map((param) => param.id);
 }
 
 /**
@@ -846,9 +890,11 @@ export function getParamIds(modelType?: ModelType): string[] {
  * @param modelId 模型 ID
  * @returns 尺寸选项列表，包含 value 和 label
  */
-export function getSizeOptionsForModel(modelId: string): Array<{ value: string; label: string }> {
+export function getSizeOptionsForModel(
+  modelId: string
+): Array<{ value: string; label: string }> {
   const params = getCompatibleParams(modelId);
-  const sizeParam = params.find(p => p.id === 'size');
+  const sizeParam = params.find((p) => p.id === 'size');
   return sizeParam?.options || [];
 }
 
@@ -859,6 +905,6 @@ export function getSizeOptionsForModel(modelId: string): Array<{ value: string; 
  */
 export function getDefaultSizeForModel(modelId: string): string {
   const params = getCompatibleParams(modelId);
-  const sizeParam = params.find(p => p.id === 'size');
+  const sizeParam = params.find((p) => p.id === 'size');
   return sizeParam?.defaultValue || 'auto';
 }

--- a/packages/drawnix/src/services/async-image-api-service.ts
+++ b/packages/drawnix/src/services/async-image-api-service.ts
@@ -1,0 +1,254 @@
+/**
+ * Async Image API Service
+ *
+ * Handles async image generation for nano-banana models (异步香蕉格式)。
+ * 提交任务后通过轮询查询结果，返回图片下载链接。
+ */
+
+import { geminiSettings } from '../utils/settings-manager';
+import { getFileExtension } from '@aitu/utils';
+
+export interface AsyncImageGenerationParams {
+  model: string;
+  prompt: string;
+  size?: string; // 接口的尺寸/比例字段（枚举 1:1、4:5 等）
+  // TODO: 支持参考图/多图提交，如有需求可补充 input_reference
+}
+
+export interface AsyncImageSubmitResponse {
+  id: string;
+  object: string;
+  model: string;
+  status: 'queued' | 'in_progress' | 'completed' | 'failed';
+  progress: number;
+  created_at: number;
+  error?: string | { code: string; message: string };
+}
+
+export interface AsyncImageQueryResponse {
+  id: string;
+  object: string;
+  model: string;
+  status: 'queued' | 'in_progress' | 'completed' | 'failed';
+  progress?: number;
+  created_at: number;
+  video_url?: string; // 实际为图片地址，沿用接口字段
+  url?: string;
+  error?: string | { code: string; message: string };
+}
+
+interface PollingOptions {
+  interval?: number;
+  maxAttempts?: number;
+  onProgress?: (progress: number, status: string) => void;
+  onSubmitted?: (taskId: string) => void;
+}
+
+class AsyncImageAPIService {
+  private baseUrl: string;
+
+  constructor() {
+    this.baseUrl = 'https://api.tu-zi.com';
+  }
+
+  private async submit(
+    params: AsyncImageGenerationParams
+  ): Promise<AsyncImageSubmitResponse> {
+    const settings = geminiSettings.get();
+    const apiKey = settings.apiKey;
+
+    if (!apiKey) {
+      throw new Error('API Key 未配置');
+    }
+
+    const formData = new FormData();
+    formData.append('model', params.model);
+    formData.append('prompt', params.prompt);
+    if (params.size) {
+      formData.append('size', params.size);
+    }
+
+    const response = await fetch(`${this.baseUrl}/v1/videos`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      const error = new Error(
+        `图片任务提交失败: ${response.status} - ${errorText}`
+      );
+      (error as any).apiErrorBody = errorText;
+      (error as any).httpStatus = response.status;
+      throw error;
+    }
+
+    return response.json();
+  }
+
+  private async query(id: string): Promise<AsyncImageQueryResponse> {
+    const settings = geminiSettings.get();
+    const apiKey = settings.apiKey;
+
+    if (!apiKey) {
+      throw new Error('API Key 未配置');
+    }
+
+    const response = await fetch(`${this.baseUrl}/v1/videos/${id}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      const error = new Error(
+        `图片任务查询失败: ${response.status} - ${errorText}`
+      );
+      (error as any).apiErrorBody = errorText;
+      (error as any).httpStatus = response.status;
+      throw error;
+    }
+
+    return response.json();
+  }
+
+  async generateWithPolling(
+    params: AsyncImageGenerationParams,
+    options: PollingOptions = {}
+  ): Promise<AsyncImageQueryResponse> {
+    const {
+      interval = 5000,
+      maxAttempts = 1080,
+      onProgress,
+      onSubmitted,
+    } = options;
+
+    const submitResp = await this.submit(params);
+
+    if (onSubmitted) {
+      onSubmitted(submitResp.id);
+    }
+
+    if (onProgress) {
+      onProgress(submitResp.progress ?? 0, submitResp.status);
+    }
+
+    if (submitResp.status === 'failed') {
+      const message =
+        typeof submitResp.error === 'string'
+          ? submitResp.error
+          : (submitResp.error as any)?.message || '图片生成失败';
+      throw new Error(message);
+    }
+
+    return this.pollUntilComplete(submitResp.id, {
+      interval,
+      maxAttempts,
+      onProgress,
+    });
+  }
+
+  async resumePolling(
+    id: string,
+    options: PollingOptions = {}
+  ): Promise<AsyncImageQueryResponse> {
+    const { onProgress } = options;
+
+    const immediate = await this.query(id);
+    const immediateProgress =
+      immediate.progress ??
+      (immediate.status === 'failed'
+        ? 100
+        : immediate.status === 'completed'
+        ? 100
+        : 0);
+
+    if (onProgress) {
+      onProgress(immediateProgress, immediate.status);
+    }
+
+    if (immediate.status === 'completed' || immediate.status === 'failed') {
+      return immediate;
+    }
+
+    return this.pollUntilComplete(id, options);
+  }
+
+  private async pollUntilComplete(
+    id: string,
+    options: PollingOptions = {}
+  ): Promise<AsyncImageQueryResponse> {
+    const { interval = 5000, maxAttempts = 1080, onProgress } = options;
+
+    let attempts = 0;
+    let consecutiveErrors = 0;
+    const maxConsecutiveErrors = 10;
+
+    while (attempts < maxAttempts) {
+      await this.sleep(interval);
+      attempts += 1;
+
+      try {
+        const status = await this.query(id);
+        const progress =
+          status.progress ??
+          (status.status === 'failed'
+            ? 100
+            : status.status === 'completed'
+            ? 100
+            : 0);
+
+        if (onProgress) {
+          onProgress(progress, status.status);
+        }
+
+        if (status.status === 'completed') {
+          return status;
+        }
+
+        if (status.status === 'failed') {
+          const message =
+            typeof status.error === 'string'
+              ? status.error
+              : (status.error as any)?.message || '图片生成失败';
+          throw new Error(message);
+        }
+
+        consecutiveErrors = 0; // reset on success
+      } catch (error) {
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= maxConsecutiveErrors) {
+          throw error;
+        }
+      }
+    }
+
+    throw new Error('图片生成超时');
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * 辅助：从结果中提取最终图片 URL 和格式
+   */
+  extractUrlAndFormat(result: AsyncImageQueryResponse): {
+    url: string;
+    format: string;
+  } {
+    const url = result.video_url || result.url;
+    if (!url) {
+      throw new Error('API 未返回有效的图片 URL');
+    }
+    const format = getFileExtension(url) || 'jpg';
+    return { url, format };
+  }
+}
+
+export const asyncImageAPIService = new AsyncImageAPIService();

--- a/packages/drawnix/src/utils/gemini-api/config.ts
+++ b/packages/drawnix/src/utils/gemini-api/config.ts
@@ -24,6 +24,9 @@ export const VIDEO_DEFAULT_CONFIG: Partial<GeminiConfig> = {
 export const NON_STREAM_MODELS: string[] = [
   'seedream-4-0-250828',
   'seedream-v4',
+  'gemini-3-pro-image-preview-async',
+  'gemini-3-pro-image-preview-2k-async',
+  'gemini-3-pro-image-preview-4k-async',
 ];
 
 /**
@@ -32,5 +35,7 @@ export const NON_STREAM_MODELS: string[] = [
 export function shouldUseNonStreamMode(modelName: string): boolean {
   if (!modelName) return false;
   const lowerModelName = modelName.toLowerCase();
-  return NON_STREAM_MODELS.some(m => lowerModelName.includes(m.toLowerCase()));
+  return NON_STREAM_MODELS.some((m) =>
+    lowerModelName.includes(m.toLowerCase())
+  );
 }


### PR DESCRIPTION
## 摘要
- 将异步图像模型（1k/2k/4k）添加到配置和非流列表中
- 通过 /v1/videos 路由异步图像任务，并支持大小枚举和多输入引用
- 支持任务执行器/存储中异步图像任务的恢复/轮询；修复 baseUrl 规范化