### PR TITLE
fixed:修复ppt新加的内容在上方的问题

### DIFF
--- a/packages/drawnix/src/mcp/tools/ppt-generation.ts
+++ b/packages/drawnix/src/mcp/tools/ppt-generation.ts
@@ -295,16 +295,15 @@ async function executePPTGeneration(
       ]);
     }
 
-    // 3. 逆序创建 Frame（因为 insertFrame 总是插入到 [0]，逆序创建可保持正确排列）
+    // 3. 按顺序创建 Frame（insertFrame 追加到末尾，故正序创建即可）
     const createdFrames: PlaitFrame[] = new Array(outline.pages.length);
     let createdCount = 0;
 
-    for (let i = outline.pages.length - 1; i >= 0; i--) {
+    for (let i = 0; i < outline.pages.length; i++) {
       const pageSpec = outline.pages[i];
       const pageIndex = i + 1;
       const framePosition = framePositions[i];
 
-      // 创建页面
       const frame = createPPTPage(board, pageSpec, pageIndex, framePosition);
       createdFrames[i] = frame;
 

--- a/packages/drawnix/src/plugins/with-frame.ts
+++ b/packages/drawnix/src/plugins/with-frame.ts
@@ -87,7 +87,7 @@ function isElementInFrame(board: PlaitBoard, element: PlaitElement, frame: Plait
  */
 export const FrameTransforms = {
   /**
-   * 插入一个新 Frame
+   * 插入一个新 Frame（始终追加到已有 Frame 列表末尾）
    */
   insertFrame(board: PlaitBoard, points: [Point, Point], name?: string): PlaitFrame {
     frameCounter++;
@@ -99,8 +99,14 @@ export const FrameTransforms = {
       children: [],
     };
 
-    // Frame 应该在最底层渲染（在其他元素之下）
-    Transforms.insertNode(board, frame, [0]);
+    let lastFrameIndex = -1;
+    for (let i = 0; i < board.children.length; i++) {
+      if (isFrameElement(board.children[i])) {
+        lastFrameIndex = i;
+      }
+    }
+    const insertIndex = lastFrameIndex + 1;
+    Transforms.insertNode(board, frame, [insertIndex]);
 
     return frame;
   },
@@ -191,7 +197,7 @@ export const withFrame: PlaitPlugin = (board: PlaitBoard) => {
   // 跟踪 Frame 移动
   let movingFrameId: string | null = null;
   let lastFramePoints: [Point, Point] | null = null;
-  let movingElementIds: Set<string> = new Set(); // 记录拖动开始时与 Frame 相交的元素 ID
+  const movingElementIds: Set<string> = new Set(); // 记录拖动开始时与 Frame 相交的元素 ID
 
   // 跟踪 Frame 创建
   let isCreatingFrame = false;


### PR DESCRIPTION
<img width="580" height="682" alt="549df9fbfe7c5477fef896facf17dcef" src="https://github.com/user-attachments/assets/a80244f0-4f71-4238-9ccd-d3a9a619bba9" />
insertFrame 去掉 position 参数，一律在已有 Frame 列表末尾插入（先找最后一个根级 Frame 的下标，再在其后 insertIndex 插入）。无论是弹窗里点「添加」、工具栏手绘 Frame，还是其它地方调用，新 Frame 都会出现在列表最下方。
