### PR TITLE
feat:优化知识库对话ai回答内容将其渲染为对应的markdown格式&优化skill生成的内容让外层文本框高度自适应内容高度

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "cSpell.words": [
         "drawnix"
     ],
-    "codingcopilot.enableCompletionLanguage": {}
+    "codingcopilot.enableCompletionLanguage": {},
+    "liveServer.settings.port": 5501
 }

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -3,7 +3,7 @@
 # 首页和HTML文件 - 允许iframe嵌入，禁用缓存
 /
   Cache-Control: public, max-age=0, must-revalidate
-  Content-Security-Policy: default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://wiki.tu-zi.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* *.localhost:* https://api.tu-zi.com;
+  Content-Security-Policy: upgrade-insecure-requests; default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://wiki.tu-zi.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* *.localhost:* https://api.tu-zi.com;
   X-Frame-Options: SAMEORIGIN
   X-Content-Type-Options: nosniff
   Referrer-Policy: origin-when-cross-origin

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -142,7 +142,7 @@ export default defineConfig({
     port: 7200,
     host: 'localhost',
     headers: {
-      'Content-Security-Policy': "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
+      'Content-Security-Policy': "upgrade-insecure-requests; default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
       'X-Frame-Options': 'ALLOWALL'
     }
   },
@@ -151,7 +151,7 @@ export default defineConfig({
     port: 4300,
     host: 'localhost',
     headers: {
-      'Content-Security-Policy': "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
+      'Content-Security-Policy': "upgrade-insecure-requests; default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
       'X-Frame-Options': 'ALLOWALL'
     }
   },

--- a/packages/drawnix/src/components/MarkdownEditor/MarkdownEditor.css
+++ b/packages/drawnix/src/components/MarkdownEditor/MarkdownEditor.css
@@ -147,13 +147,13 @@
 
 /* ===== Card 标签贴内嵌 MarkdownEditor 样式 ===== */
 
-/* Card 内嵌 MarkdownEditor：去掉边框和背景，紧凑布局，高度由内容撑开 */
+/* Card 内嵌 MarkdownEditor：去掉边框和背景，紧凑布局，高度由内容撑开，滚动由外层容器控制 */
 .collimind-markdown-editor.card-markdown-viewer {
   border: none;
   border-radius: 0;
   background: transparent;
   height: auto;
-  overflow-y: hidden;
+  overflow-y: visible;
 }
 
 /* Card 模式下 milkdown 不需要 flex 拉伸，跟随内容高度 */

--- a/packages/drawnix/src/components/MarkdownEditor/MarkdownEditor.css
+++ b/packages/drawnix/src/components/MarkdownEditor/MarkdownEditor.css
@@ -147,12 +147,18 @@
 
 /* ===== Card 标签贴内嵌 MarkdownEditor 样式 ===== */
 
-/* Card 内嵌 MarkdownEditor：去掉边框和背景，紧凑布局 */
+/* Card 内嵌 MarkdownEditor：去掉边框和背景，紧凑布局，高度由内容撑开 */
 .collimind-markdown-editor.card-markdown-viewer {
   border: none;
   border-radius: 0;
   background: transparent;
-  height: 100%;
+  height: auto;
+  overflow-y: hidden;
+}
+
+/* Card 模式下 milkdown 不需要 flex 拉伸，跟随内容高度 */
+.collimind-markdown-editor.card-markdown-viewer .milkdown {
+  flex: none;
 }
 
 /* Card 内容区 ProseMirror：减小内边距 */

--- a/packages/drawnix/src/components/card-element/CardElement.tsx
+++ b/packages/drawnix/src/components/card-element/CardElement.tsx
@@ -25,7 +25,6 @@ export const CardElement: React.FC<CardElementProps> = ({ element }) => {
     <div
       style={{
         width: '100%',
-        height: '100%',
         display: 'flex',
         flexDirection: 'column',
         borderRadius: 8,
@@ -60,8 +59,6 @@ export const CardElement: React.FC<CardElementProps> = ({ element }) => {
       )}
       <div
         style={{
-          flex: 1,
-          minHeight: 0,
           pointerEvents: 'auto',
         }}
         onMouseDown={(e) => e.stopPropagation()}

--- a/packages/drawnix/src/components/card-element/CardElement.tsx
+++ b/packages/drawnix/src/components/card-element/CardElement.tsx
@@ -4,9 +4,9 @@
  * 复用 MarkdownEditor 进行 Markdown 内容展示（只读模式）
  * Card 在画布上仅作只读展示，编辑通过知识库进行
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import { MarkdownEditor } from '../MarkdownEditor';
-import { getTitleColor, getBodyColor } from '../../constants/card-colors';
+import { getTitleColor, getBodyColor, CARD_BODY_MAX_HEIGHT } from '../../constants/card-colors';
 import type { PlaitCard } from '../../types/card.types';
 
 interface CardElementProps {
@@ -20,6 +20,16 @@ export const CardElement: React.FC<CardElementProps> = ({ element }) => {
   const hasTitle = !!(element.title && element.title.trim());
   const titleColor = getTitleColor(element.fillColor);
   const bodyColor = getBodyColor(element.fillColor);
+
+  const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+    const target = e.currentTarget;
+    const { scrollTop, scrollHeight, clientHeight } = target;
+    const atTop = scrollTop === 0 && e.deltaY < 0;
+    const atBottom = scrollTop + clientHeight >= scrollHeight - 1 && e.deltaY > 0;
+    if (!atTop && !atBottom) {
+      e.stopPropagation();
+    }
+  }, []);
 
   return (
     <div
@@ -60,9 +70,12 @@ export const CardElement: React.FC<CardElementProps> = ({ element }) => {
       <div
         style={{
           pointerEvents: 'auto',
+          maxHeight: CARD_BODY_MAX_HEIGHT,
+          overflowY: 'auto',
         }}
         onMouseDown={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
+        onWheel={handleWheel}
       >
         <MarkdownEditor
           markdown={element.body}

--- a/packages/drawnix/src/components/card-element/CardElement.tsx
+++ b/packages/drawnix/src/components/card-element/CardElement.tsx
@@ -6,8 +6,31 @@
  */
 import React, { useCallback } from 'react';
 import { MarkdownEditor } from '../MarkdownEditor';
-import { getTitleColor, getBodyColor, CARD_BODY_MAX_HEIGHT } from '../../constants/card-colors';
+import { getTitleColor, getBodyColor } from '../../constants/card-colors';
 import type { PlaitCard } from '../../types/card.types';
+
+const cardBodyElements = new Map<string, HTMLElement>();
+
+export function getCardBodyElement(cardId: string): HTMLElement | null {
+  return cardBodyElements.get(cardId) ?? null;
+}
+
+/**
+ * 临时去掉 flex 约束，测量 body 内容的真实高度。
+ * 同步读取，读完立即恢复，不会触发重绘。
+ */
+export function measureCardBodyContentHeight(cardId: string): number | null {
+  const el = cardBodyElements.get(cardId);
+  if (!el) return null;
+  const prevFlex = el.style.flex;
+  const prevMinH = el.style.minHeight;
+  el.style.flex = 'none';
+  el.style.minHeight = '0';
+  const h = el.scrollHeight;
+  el.style.flex = prevFlex;
+  el.style.minHeight = prevMinH;
+  return h;
+}
 
 interface CardElementProps {
   element: PlaitCard;
@@ -35,6 +58,7 @@ export const CardElement: React.FC<CardElementProps> = ({ element }) => {
     <div
       style={{
         width: '100%',
+        height: '100%',
         display: 'flex',
         flexDirection: 'column',
         borderRadius: 8,
@@ -68,9 +92,14 @@ export const CardElement: React.FC<CardElementProps> = ({ element }) => {
         </div>
       )}
       <div
+        ref={(el) => {
+          if (el) cardBodyElements.set(element.id, el);
+          else cardBodyElements.delete(element.id);
+        }}
         style={{
           pointerEvents: 'auto',
-          maxHeight: CARD_BODY_MAX_HEIGHT,
+          flex: 1,
+          minHeight: 0,
           overflowY: 'auto',
         }}
         onMouseDown={(e) => e.stopPropagation()}

--- a/packages/drawnix/src/components/card-element/card.component.ts
+++ b/packages/drawnix/src/components/card-element/card.component.ts
@@ -11,7 +11,10 @@ import {
   OnContextChanged,
   ACTIVE_STROKE_WIDTH,
   RectangleClient,
+  Transforms,
+  Point,
 } from '@plait/core';
+import { CARD_TITLE_HEIGHT, CARD_BODY_MIN_HEIGHT } from '../../constants/card-colors';
 import {
   CommonElementFlavour,
   createActiveGenerator,
@@ -52,6 +55,10 @@ export class CardComponent
     super.initialize();
     this.initializeGenerator();
 
+    this.cardGenerator.onHeightMeasured = (measuredHeight: number) => {
+      this.autoResizeIfNeeded(measuredHeight);
+    };
+
     const elementG = this.getElementG();
     this.renderedG = this.cardGenerator.processDrawing(this.element, elementG);
 
@@ -60,6 +67,25 @@ export class CardComponent
       PlaitBoard.getActiveHost(this.board),
       { selected: this.selected }
     );
+  }
+
+  private autoResizeIfNeeded(measuredHeight: number): void {
+    const currentRect = RectangleClient.getRectangleByPoints(this.element.points);
+    const minHeight = (this.element.title?.trim() ? CARD_TITLE_HEIGHT : 0) + CARD_BODY_MIN_HEIGHT;
+    const targetHeight = Math.max(measuredHeight, minHeight);
+    const heightDiff = Math.abs(currentRect.height - targetHeight);
+
+    if (heightDiff <= 5) return;
+
+    const newPoints: [Point, Point] = [
+      this.element.points[0],
+      [this.element.points[1][0], this.element.points[0][1] + targetHeight],
+    ];
+
+    const index = this.board.children.findIndex(el => el.id === this.element.id);
+    if (index !== -1) {
+      Transforms.setNode(this.board, { points: newPoints } as any, [index]);
+    }
   }
 
   onContextChanged(

--- a/packages/drawnix/src/components/card-element/card.component.ts
+++ b/packages/drawnix/src/components/card-element/card.component.ts
@@ -14,7 +14,7 @@ import {
   Transforms,
   Point,
 } from '@plait/core';
-import { CARD_TITLE_HEIGHT, CARD_BODY_MIN_HEIGHT } from '../../constants/card-colors';
+import { CARD_TITLE_HEIGHT, CARD_BODY_MIN_HEIGHT, CARD_BODY_MAX_HEIGHT } from '../../constants/card-colors';
 import {
   CommonElementFlavour,
   createActiveGenerator,
@@ -71,8 +71,10 @@ export class CardComponent
 
   private autoResizeIfNeeded(measuredHeight: number): void {
     const currentRect = RectangleClient.getRectangleByPoints(this.element.points);
-    const minHeight = (this.element.title?.trim() ? CARD_TITLE_HEIGHT : 0) + CARD_BODY_MIN_HEIGHT;
-    const targetHeight = Math.max(measuredHeight, minHeight);
+    const titleHeight = this.element.title?.trim() ? CARD_TITLE_HEIGHT : 0;
+    const minHeight = titleHeight + CARD_BODY_MIN_HEIGHT;
+    const maxHeight = titleHeight + CARD_BODY_MAX_HEIGHT;
+    const targetHeight = Math.min(Math.max(measuredHeight, minHeight), maxHeight);
     const heightDiff = Math.abs(currentRect.height - targetHeight);
 
     if (heightDiff <= 5) return;

--- a/packages/drawnix/src/components/card-element/card.component.ts
+++ b/packages/drawnix/src/components/card-element/card.component.ts
@@ -14,7 +14,9 @@ import {
   Transforms,
   Point,
 } from '@plait/core';
-import { CARD_TITLE_HEIGHT, CARD_BODY_MIN_HEIGHT, CARD_BODY_MAX_HEIGHT } from '../../constants/card-colors';
+import { CARD_TITLE_HEIGHT, CARD_BODY_MIN_HEIGHT } from '../../constants/card-colors';
+import { isCardManuallyResized } from '../../plugins/with-card-resize';
+import { measureCardBodyContentHeight } from './CardElement';
 import {
   CommonElementFlavour,
   createActiveGenerator,
@@ -55,8 +57,8 @@ export class CardComponent
     super.initialize();
     this.initializeGenerator();
 
-    this.cardGenerator.onHeightMeasured = (measuredHeight: number) => {
-      this.autoResizeIfNeeded(measuredHeight);
+    this.cardGenerator.onHeightMeasured = () => {
+      this.autoResizeIfNeeded();
     };
 
     const elementG = this.getElementG();
@@ -69,12 +71,16 @@ export class CardComponent
     );
   }
 
-  private autoResizeIfNeeded(measuredHeight: number): void {
+  private autoResizeIfNeeded(): void {
+    if (isCardManuallyResized(this.element.id)) return;
+
+    const bodyContentH = measureCardBodyContentHeight(this.element.id);
+    if (bodyContentH == null) return;
+
     const currentRect = RectangleClient.getRectangleByPoints(this.element.points);
     const titleHeight = this.element.title?.trim() ? CARD_TITLE_HEIGHT : 0;
     const minHeight = titleHeight + CARD_BODY_MIN_HEIGHT;
-    const maxHeight = titleHeight + CARD_BODY_MAX_HEIGHT;
-    const targetHeight = Math.min(Math.max(measuredHeight, minHeight), maxHeight);
+    const targetHeight = Math.max(titleHeight + bodyContentH, minHeight);
     const heightDiff = Math.abs(currentRect.height - targetHeight);
 
     if (heightDiff <= 5) return;

--- a/packages/drawnix/src/components/card-element/card.generator.ts
+++ b/packages/drawnix/src/components/card-element/card.generator.ts
@@ -55,6 +55,7 @@ export class CardGenerator {
     ) as HTMLElement;
     this.htmlContainer.style.cssText = `
       width: 100%;
+      height: 100%;
       pointer-events: none;
     `;
 

--- a/packages/drawnix/src/components/card-element/card.generator.ts
+++ b/packages/drawnix/src/components/card-element/card.generator.ts
@@ -14,6 +14,8 @@ export class CardGenerator {
   private foreignObject: SVGForeignObjectElement | null = null;
   private htmlContainer: HTMLElement | null = null;
   private reactRoot: Root | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  onHeightMeasured?: (height: number) => void;
 
   processDrawing(element: PlaitCard, parentG: SVGGElement): SVGGElement {
     const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -53,13 +55,13 @@ export class CardGenerator {
     ) as HTMLElement;
     this.htmlContainer.style.cssText = `
       width: 100%;
-      height: 100%;
       pointer-events: none;
-      overflow: hidden;
     `;
 
     this.foreignObject.appendChild(this.htmlContainer);
     g.appendChild(this.foreignObject);
+
+    this.setupResizeObserver();
 
     // 延迟渲染 React，确保 DOM 已挂载
     setTimeout(() => this.renderReact(element), 0);
@@ -74,6 +76,21 @@ export class CardGenerator {
     this.foreignObject.setAttribute('height', String(rect.height));
   }
 
+  private setupResizeObserver(): void {
+    if (!this.htmlContainer) return;
+
+    this.resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+        if (height > 0) {
+          this.onHeightMeasured?.(height);
+        }
+      }
+    });
+
+    this.resizeObserver.observe(this.htmlContainer);
+  }
+
   private renderReact(element: PlaitCard): void {
     if (!this.htmlContainer) return;
 
@@ -84,9 +101,23 @@ export class CardGenerator {
     this.reactRoot.render(
       React.createElement(CardElement, { element })
     );
+
+    // 兜底：foreignObject 内 ResizeObserver 可能不触发
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (this.htmlContainer && this.onHeightMeasured) {
+          const height = this.htmlContainer.offsetHeight;
+          if (height > 0) {
+            this.onHeightMeasured(height);
+          }
+        }
+      });
+    });
   }
 
   destroy(): void {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
     if (this.reactRoot) {
       try {
         this.reactRoot.unmount();

--- a/packages/drawnix/src/components/knowledge-base/KBKnowledgeExtraction.tsx
+++ b/packages/drawnix/src/components/knowledge-base/KBKnowledgeExtraction.tsx
@@ -206,7 +206,7 @@ export const KBKnowledgeExtraction: React.FC<KBKnowledgeExtractionProps> = ({
         {
           id: aiMsgId,
           role: 'model',
-          content: '',
+          content: '正在思考...',
           type: 'text',
           timestamp: Date.now(),
         },
@@ -376,22 +376,37 @@ export const KBKnowledgeExtraction: React.FC<KBKnowledgeExtractionProps> = ({
             </div>
             <div className="kb-message__body">
               <div className="kb-message__content">
-                {msg.type === 'text' ? (
-                  msg.role === 'model' && msg.content && msg.id !== streamingMsgId ? (
-                    <div className="kb-message__markdown-wrap">
-                      <MarkdownEditor
-                        markdown={msg.content}
-                        readOnly
-                        showModeSwitch={false}
-                        initialMode="wysiwyg"
-                        className="kb-extraction-markdown"
-                      />
-                    </div>
-                  ) : (
-                    <div className="kb-message__text">{msg.content}</div>
-                  )
+                {msg.role === 'model' ? (
+                  <div className="kb-message__content-scroll">
+                    {msg.type === 'text' ? (
+                      msg.id === streamingMsgId && (msg.content === '正在思考...' || msg.content === '正在分析笔记内容并提取知识点...') ? (
+                        <div className="kb-message__thinking" aria-label="思考中">
+                          <span className="kb-message__thinking-text">{msg.content.replace(/\.+$/, '')}</span>
+                          <span className="kb-message__thinking-dots">
+                            <span>.</span><span>.</span><span>.</span>
+                          </span>
+                        </div>
+                      ) : msg.content ? (
+                        <div className="kb-message__markdown-wrap">
+                          <MarkdownEditor
+                            markdown={msg.content}
+                            readOnly
+                            showModeSwitch={false}
+                            initialMode="wysiwyg"
+                            className="kb-extraction-markdown"
+                          />
+                        </div>
+                      ) : null
+                    ) : (
+                      <ExtractionResultView result={msg.data!} />
+                    )}
+                  </div>
                 ) : (
-                  <ExtractionResultView result={msg.data!} />
+                  msg.type === 'text' ? (
+                    <div className="kb-message__text">{msg.content}</div>
+                  ) : (
+                    <ExtractionResultView result={msg.data!} />
+                  )
                 )}
               </div>
               {msg.role === 'model' && (

--- a/packages/drawnix/src/components/knowledge-base/KBKnowledgeExtraction.tsx
+++ b/packages/drawnix/src/components/knowledge-base/KBKnowledgeExtraction.tsx
@@ -69,6 +69,7 @@ export const KBKnowledgeExtraction: React.FC<KBKnowledgeExtractionProps> = ({
   const [selectedModel, setSelectedModel] = useState(DEFAULT_MODEL);
   const [isLoading, setIsLoading] = useState(false);
   const [abortController, setAbortController] = useState<AbortController | null>(null);
+  const [streamingMsgId, setStreamingMsgId] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -199,6 +200,7 @@ export const KBKnowledgeExtraction: React.FC<KBKnowledgeExtractionProps> = ({
 
       // 添加一个临时的 AI 消息用于流式显示
       const aiMsgId = (Date.now() + 1).toString();
+      setStreamingMsgId(aiMsgId);
       setMessages((prev) => [
         ...prev,
         {
@@ -238,6 +240,7 @@ export const KBKnowledgeExtraction: React.FC<KBKnowledgeExtractionProps> = ({
     } finally {
       setIsLoading(false);
       setAbortController(null);
+      setStreamingMsgId(null);
     }
   }, [input, isLoading, messages, noteContent]);
 
@@ -374,7 +377,19 @@ export const KBKnowledgeExtraction: React.FC<KBKnowledgeExtractionProps> = ({
             <div className="kb-message__body">
               <div className="kb-message__content">
                 {msg.type === 'text' ? (
-                  <div className="kb-message__text">{msg.content}</div>
+                  msg.role === 'model' && msg.content && msg.id !== streamingMsgId ? (
+                    <div className="kb-message__markdown-wrap">
+                      <MarkdownEditor
+                        markdown={msg.content}
+                        readOnly
+                        showModeSwitch={false}
+                        initialMode="wysiwyg"
+                        className="kb-extraction-markdown"
+                      />
+                    </div>
+                  ) : (
+                    <div className="kb-message__text">{msg.content}</div>
+                  )
                 ) : (
                   <ExtractionResultView result={msg.data!} />
                 )}

--- a/packages/drawnix/src/components/knowledge-base/knowledge-base-extraction.scss
+++ b/packages/drawnix/src/components/knowledge-base/knowledge-base-extraction.scss
@@ -306,6 +306,11 @@
     white-space: pre-wrap;
   }
 
+  &__markdown-wrap {
+    min-width: 0;
+    overflow: hidden;
+  }
+
   &__body {
     display: flex;
     flex-direction: column;

--- a/packages/drawnix/src/components/knowledge-base/knowledge-base-extraction.scss
+++ b/packages/drawnix/src/components/knowledge-base/knowledge-base-extraction.scss
@@ -258,6 +258,31 @@
       border-radius: 12px 12px 12px 4px;
       border: 1px solid var(--td-component-border);
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+      padding-right: 4px; // 右侧留白，使内层滚动条完全落在平直区域内，不被圆角裁切
+    }
+
+    .kb-message__content-scroll {
+      max-height: 320px;
+      overflow-y: auto;
+      padding-right: 8px; // 滚动条与正文留白
+
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: transparent;
+        margin: 4px 0; // 上下留白，避免被圆角裁切
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: var(--td-scrollbar-color);
+        border-radius: 3px;
+
+        &:hover {
+          background-color: var(--td-scrollbar-color-hover, rgba(0, 0, 0, 0.25));
+        }
+      }
     }
   }
 
@@ -308,7 +333,7 @@
 
   &__markdown-wrap {
     min-width: 0;
-    overflow: hidden;
+    // overflow 由父级 .kb-message__content 控制，此处不限制以允许在 model 气泡内滚动
   }
 
   &__body {
@@ -424,6 +449,36 @@
   }
 }
 
+// 正在思考：小字号 + 动态省略号
+.kb-message__thinking {
+  display: inline-flex;
+  align-items: baseline;
+  font-size: 13px;
+  color: var(--td-text-color-secondary);
+}
+
+.kb-message__thinking-text {
+  margin-right: 0;
+}
+
+.kb-message__thinking-dots {
+  display: inline-flex;
+  gap: 1px;
+
+  span {
+    animation: kb-thinking-dot 1.4s ease-in-out infinite both;
+
+    &:nth-child(1) { animation-delay: 0s; }
+    &:nth-child(2) { animation-delay: 0.2s; }
+    &:nth-child(3) { animation-delay: 0.4s; }
+  }
+}
+
+@keyframes kb-thinking-dot {
+  0%, 80%, 100% { opacity: 0.3; }
+  40% { opacity: 1; }
+}
+
 .kb-loading-dots {
   font-style: italic;
   color: var(--td-text-color-secondary);
@@ -468,8 +523,9 @@
     overflow: visible !important;
   }
 
-  // Ensure headings are not too large in chat
-  h1 { font-size: 1.5em; }
-  h2 { font-size: 1.3em; }
-  h3 { font-size: 1.1em; }
+  // 标题字号略小于正文，避免在气泡内过大
+  h1 { font-size: 1.2em; font-weight: 600; }
+  h2 { font-size: 1.1em; font-weight: 600; }
+  h3 { font-size: 1.05em; font-weight: 600; }
+  p, li { font-size: 14px; }
 }

--- a/packages/drawnix/src/constants/card-colors.ts
+++ b/packages/drawnix/src/constants/card-colors.ts
@@ -23,8 +23,8 @@ export const CARD_TITLE_HEIGHT = 44;
 /** Card 正文区最小高度（像素） */
 export const CARD_BODY_MIN_HEIGHT = 80;
 
-/** Card 正文区最大高度（像素） */
-export const CARD_BODY_MAX_HEIGHT = 200;
+/** Card 正文区最大高度（像素），超出后正文区可滚动 */
+export const CARD_BODY_MAX_HEIGHT = 400;
 
 /** Card 圆角半径 */
 export const CARD_BORDER_RADIUS = 8;

--- a/packages/drawnix/src/plugins/with-card-resize.ts
+++ b/packages/drawnix/src/plugins/with-card-resize.ts
@@ -27,9 +27,18 @@ import {
   calculateResizedRect,
   getShiftKeyState,
 } from '../utils/resize-utils';
+import { CARD_TITLE_HEIGHT } from '../constants/card-colors';
+import { measureCardBodyContentHeight } from '../components/card-element/CardElement';
 
 /** Card 最小尺寸 */
 const CARD_MIN_SIZE = 120;
+
+/** 记录用户手动调整过尺寸的 Card ID */
+const manuallyResizedCards = new Set<string>();
+
+export function isCardManuallyResized(id: string): boolean {
+  return manuallyResizedCards.has(id);
+}
 
 /**
  * 命中测试辅助函数 - 检测点是否在缩放手柄上
@@ -38,7 +47,7 @@ function getHitRectangleResizeHandleRef(
   board: PlaitBoard,
   rectangle: RectangleClient,
   point: Point,
-  angle: number = 0
+  angle = 0
 ) {
   const centerPoint = RectangleClient.getCenterPoint(rectangle);
   const resizeHandleRefs = getRectangleResizeHandleRefs(
@@ -48,7 +57,7 @@ function getHitRectangleResizeHandleRef(
 
   if (angle) {
     const rotatedPoint = rotatePoint(point, centerPoint, -angle);
-    let result = resizeHandleRefs.find((resizeHandleRef) => {
+    const result = resizeHandleRefs.find((resizeHandleRef) => {
       return RectangleClient.isHit(
         RectangleClient.getRectangleByPoints([rotatedPoint, rotatedPoint]),
         resizeHandleRef.rectangle
@@ -121,6 +130,8 @@ function onResize(
 
   if (!startRectangle) return;
 
+  manuallyResizedCards.add(element.id);
+
   const dx = endPoint[0] - startPoint[0];
   const dy = endPoint[1] - startPoint[1];
 
@@ -132,6 +143,21 @@ function onResize(
     getShiftKeyState(),
     CARD_MIN_SIZE
   );
+
+  const titleHeight = element.title?.trim() ? CARD_TITLE_HEIGHT : 0;
+  const bodyContentH = measureCardBodyContentHeight(element.id);
+  const contentMaxHeight = bodyContentH != null
+    ? titleHeight + bodyContentH
+    : newRect.height;
+  if (newRect.height > contentMaxHeight) {
+    const isTopHandle = [ResizeHandle.NW, ResizeHandle.N, ResizeHandle.NE].includes(
+      handle as ResizeHandle
+    );
+    if (isTopHandle) {
+      newRect.y = newRect.y + newRect.height - contentMaxHeight;
+    }
+    newRect.height = contentMaxHeight;
+  }
 
   const newPoints: [Point, Point] = [
     [newRect.x, newRect.y],

--- a/packages/drawnix/src/services/agent/agent-executor.ts
+++ b/packages/drawnix/src/services/agent/agent-executor.ts
@@ -305,16 +305,16 @@ class AgentExecutor {
       let iterations = 0;
       let finalResponse = '';
 
-      // 获取全局设置的文本模型
+      // 优先使用调用方传入的模型（用户选择的模型），否则使用全局设置
       const globalSettings = geminiSettings.get();
-      const textModel = globalSettings.textModelName;
+      const textModel = model ?? globalSettings.textModelName;
       console.log('[AgentExecutor] 使用文本模型:', textModel, ', hasApiKey:', !!globalSettings.apiKey);
 
       while (iterations < maxIterations) {
         iterations++;
         console.log(`[AgentExecutor] 迭代 ${iterations}/${maxIterations}, 即将调用 sendChat...`);
 
-        // 调用 LLM，使用全局设置的文本模型
+        // 调用 LLM，使用指定或全局默认的文本模型
         let fullResponse = '';
         const t0 = Date.now();
         const response = await defaultGeminiClient.sendChat(
@@ -325,7 +325,7 @@ class AgentExecutor {
             onChunk?.(accumulatedContent);
           },
           signal,
-          textModel // 使用全局设置的文本模型
+          textModel
         );
         console.log(`[AgentExecutor] sendChat 返回, 耗时: ${Date.now() - t0}ms`);
 

--- a/packages/drawnix/src/utils/resize-utils.ts
+++ b/packages/drawnix/src/utils/resize-utils.ts
@@ -64,8 +64,8 @@ export function calculateResizedRect(
   handle: ResizeHandle | string,
   dx: number,
   dy: number,
-  lockAspectRatio: boolean = false,
-  minSize: number = 20
+  lockAspectRatio = false,
+  minSize = 20
 ): RectangleClient {
   let newX = startRectangle.x;
   let newY = startRectangle.y;
@@ -137,7 +137,6 @@ export function calculateResizedRect(
       if (widthChange > heightChange) {
         // 以宽度变化为主
         const targetHeight = newWidth / aspectRatio;
-        const heightDiff = targetHeight - startRectangle.height;
 
         switch (handle) {
           case ResizeHandle.NW:
@@ -155,7 +154,6 @@ export function calculateResizedRect(
       } else {
         // 以高度变化为主
         const targetWidth = newHeight * aspectRatio;
-        const widthDiff = targetWidth - startRectangle.width;
 
         switch (handle) {
           case ResizeHandle.NW:

--- a/test.html
+++ b/test.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>自定义可拖拽缩放文本框 Demo</title>
+  <style>
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+      color: #0f172a;
+      padding: 40px 20px;
+    }
+
+    .wrap {
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: 28px;
+    }
+
+    p.desc {
+      margin: 0 0 24px;
+      color: #475569;
+      line-height: 1.7;
+    }
+
+    .panel {
+      background: rgba(255,255,255,0.86);
+      border: 1px solid rgba(148,163,184,0.25);
+      border-radius: 20px;
+      box-shadow: 0 18px 50px rgba(15,23,42,0.08);
+      padding: 24px;
+      backdrop-filter: blur(8px);
+    }
+
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+      margin-bottom: 18px;
+      color: #334155;
+      font-size: 14px;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: #eef2ff;
+      border: 1px solid #c7d2fe;
+    }
+
+    .resizable-box {
+      --box-width: 520px;
+      --box-height: 180px;
+      --min-width: 280px;
+      --min-height: 120px;
+
+      position: relative;
+      width: var(--box-width);
+      height: var(--box-height);
+      min-width: var(--min-width);
+      min-height: var(--min-height);
+      max-width: min(92vw, 900px);
+      border: 1px solid #cbd5e1;
+      border-radius: 18px;
+      background: white;
+      box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+      overflow: hidden;
+      transition: box-shadow 0.15s ease;
+      user-select: none;
+    }
+
+    .resizable-box.active {
+      box-shadow: 0 0 0 3px rgba(99,102,241,0.14), 0 18px 40px rgba(15,23,42,0.12);
+    }
+
+    .textbox {
+      width: 100%;
+      height: 100%;
+      overflow: auto;
+      padding: 18px 20px;
+      outline: none;
+      line-height: 1.8;
+      color: #1e293b;
+      font-size: 15px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .textbox:focus {
+      background: #fcfcff;
+    }
+
+    .handle {
+      position: absolute;
+      z-index: 2;
+      background: transparent;
+    }
+
+    .handle-right {
+      top: 8px;
+      right: 0;
+      width: 14px;
+      height: calc(100% - 24px);
+      cursor: ew-resize;
+    }
+
+    .handle-bottom {
+      left: 8px;
+      bottom: 0;
+      width: calc(100% - 24px);
+      height: 14px;
+      cursor: ns-resize;
+    }
+
+    .handle-corner {
+      right: 0;
+      bottom: 0;
+      width: 18px;
+      height: 18px;
+      cursor: nwse-resize;
+    }
+
+    .handle-corner::before {
+      content: "";
+      position: absolute;
+      right: 4px;
+      bottom: 4px;
+      width: 10px;
+      height: 10px;
+      border-right: 2px solid #94a3b8;
+      border-bottom: 2px solid #94a3b8;
+      border-bottom-right-radius: 3px;
+    }
+
+    .note {
+      margin-top: 16px;
+      font-size: 13px;
+      color: #64748b;
+      line-height: 1.7;
+    }
+
+    .stats {
+      margin-top: 14px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      font-size: 13px;
+      color: #334155;
+    }
+
+    .stats span {
+      padding: 6px 10px;
+      border-radius: 10px;
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+    }
+
+    @media (max-width: 640px) {
+      .resizable-box {
+        width: min(100%, 520px);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>自定义可缩放文本框</h1>
+    <p class="desc">
+      文本框创建时有默认高度，内容较多时会出现滚动条。用户可以拖动右侧、底部和右下角来分别进行横向、纵向、对角缩放。
+      纵向放大时，最大高度会自动限制为刚好包住全部文字内容，不会再继续超过内容高度。
+    </p>
+
+    <div class="panel">
+      <div class="toolbar">
+        <span class="badge">默认高度：180px</span>
+        <span class="badge">支持横向拖放</span>
+        <span class="badge">支持纵向拖放</span>
+        <span class="badge">支持对角拖放</span>
+      </div>
+
+      <div class="resizable-box" id="box">
+        <div class="textbox" id="textbox" contenteditable="true">
+这是一个自定义的文本框 demo。你可以直接编辑这里的内容，也可以拖动文本框边缘来调整大小。
+
+需求点包括：
+1. 新建时指定默认高度；
+2. 内容很多时显示滚动条；
+3. 用户既可以放大，也可以缩小；
+4. 支持横向拖动；
+5. 支持纵向拖动；
+6. 支持右下角对角拖动；
+7. 高度向上拖大时，不能超过文字实际内容所需高度。
+
+为了更容易观察效果，这里特意放入了比较多的文字。
+当文本框高度小于内容高度时，内部会出现滚动条；
+当你继续向下拉大文本框时，会在“刚好展示完整内容”的高度停止。
+
+你还可以尝试：
+- 把宽度缩窄，这样文字会自动换行，内容总高度会变大；
+- 再向下拉高文本框，这时最大高度会重新根据当前宽度下的内容高度计算；
+- 修改文字内容后，最大高度也会动态更新。
+
+这类交互常见于富文本编辑器、备注输入框、聊天草稿区和可配置后台表单中。
+        </div>
+        <div class="handle handle-right" data-dir="x"></div>
+        <div class="handle handle-bottom" data-dir="y"></div>
+        <div class="handle handle-corner" data-dir="xy"></div>
+      </div>
+
+      <div class="stats">
+        <span id="sizeInfo">当前尺寸：520 × 180</span>
+        <span id="contentInfo">内容最大高度：--</span>
+      </div>
+
+      <div class="note">
+        提示：这个 demo 没有使用原生 <code>resize</code>，而是自己实现了拖拽逻辑，因此可以精确控制“高度不能超过内容”的规则。
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const box = document.getElementById('box');
+    const textbox = document.getElementById('textbox');
+    const sizeInfo = document.getElementById('sizeInfo');
+    const contentInfo = document.getElementById('contentInfo');
+
+    const MIN_WIDTH = 280;
+    const MIN_HEIGHT = 120;
+    const DEFAULT_WIDTH = 520;
+    const DEFAULT_HEIGHT = 180;
+
+    let state = null;
+
+    function getHorizontalLimit() {
+      const margin = 32;
+      return Math.min(900, window.innerWidth - margin);
+    }
+
+    function getContentMaxHeight() {
+      const prev = textbox.style.height;
+      textbox.style.height = 'auto';
+      const contentHeight = textbox.scrollHeight;
+      textbox.style.height = prev;
+      return Math.max(MIN_HEIGHT, Math.ceil(contentHeight));
+    }
+
+    function applySize(width, height) {
+      const maxWidth = Math.max(MIN_WIDTH, getHorizontalLimit());
+      const maxHeight = getContentMaxHeight();
+
+      const nextWidth = Math.max(MIN_WIDTH, Math.min(width, maxWidth));
+      const nextHeight = Math.max(MIN_HEIGHT, Math.min(height, maxHeight));
+
+      box.style.width = nextWidth + 'px';
+      box.style.height = nextHeight + 'px';
+
+      sizeInfo.textContent = `当前尺寸：${Math.round(nextWidth)} × ${Math.round(nextHeight)}`;
+      contentInfo.textContent = `内容最大高度：${Math.round(maxHeight)}px`;
+    }
+
+    function refresh() {
+      const width = box.getBoundingClientRect().width;
+      const height = box.getBoundingClientRect().height;
+      applySize(width, height);
+    }
+
+    function startResize(e) {
+      const dir = e.target.dataset.dir;
+      if (!dir) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const rect = box.getBoundingClientRect();
+      state = {
+        dir,
+        startX: e.clientX,
+        startY: e.clientY,
+        startWidth: rect.width,
+        startHeight: rect.height,
+      };
+
+      box.classList.add('active');
+      document.body.style.cursor = getCursor(dir);
+      document.body.style.userSelect = 'none';
+    }
+
+    function getCursor(dir) {
+      if (dir === 'x') return 'ew-resize';
+      if (dir === 'y') return 'ns-resize';
+      return 'nwse-resize';
+    }
+
+    function onMove(e) {
+      if (!state) return;
+
+      const dx = e.clientX - state.startX;
+      const dy = e.clientY - state.startY;
+
+      let width = state.startWidth;
+      let height = state.startHeight;
+
+      if (state.dir.includes('x')) width = state.startWidth + dx;
+      if (state.dir.includes('y')) height = state.startHeight + dy;
+
+      applySize(width, height);
+    }
+
+    function stopResize() {
+      if (!state) return;
+      state = null;
+      box.classList.remove('active');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      refresh();
+    }
+
+    document.querySelectorAll('.handle').forEach(handle => {
+      handle.addEventListener('mousedown', startResize);
+    });
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', stopResize);
+    window.addEventListener('resize', refresh);
+    textbox.addEventListener('input', refresh);
+
+    box.style.width = DEFAULT_WIDTH + 'px';
+    box.style.height = DEFAULT_HEIGHT + 'px';
+    refresh();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
1. Card 标签贴高度随内容自适应
问题：画布上的 Card 元素由创建时的 estimateCardHeight 估算高度，与 Markdown 实际渲染差异较大，导致卡片下方出现大块空白。
2. 知识库对话中 AI 回复的 Markdown 渲染
问题：知识库「知识提取 & 对话」侧边栏里，AI 回复的 Markdown（如 ###、**、列表等）以纯文本显示，未按格式渲染。