### PR TITLE
feat:新增插入画布开关

### DIFF
--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -1381,6 +1381,23 @@ const userOutputType = (userNote.metadata?.outputType as 'image' | 'text' | 'vid
       // Fallback: 主线程执行（仅当 SW 不可用时）
       console.log('[AIInputBar] Fallback: Executing workflow in main thread:', workflow.steps.length, 'steps');
 
+      // 工作流已提交，立即保存历史、清空输入并解锁，步骤执行在后台继续
+      if (prompt.trim()) {
+        const hasSelection = allContent.length > 0;
+        const modelTypeForHistory = generationType === 'text' ? 'agent' : generationType;
+        addPromptHistory(prompt.trim(), hasSelection, modelTypeForHistory);
+      }
+      setPrompt('');
+      setSelectedContent([]);
+      setUploadedContent([]);
+      if (submitCooldownRef.current) {
+        clearTimeout(submitCooldownRef.current);
+      }
+      submitCooldownRef.current = setTimeout(() => {
+        setIsSubmitting(false);
+        submitCooldownRef.current = null;
+      }, 1000);
+
       const createdTaskIds: string[] = [];
 
       // 收集动态添加的步骤（用于后续执行）
@@ -1608,14 +1625,6 @@ const userOutputType = (userNote.metadata?.outputType as 'image' | 'text' | 'vid
         }
       }
 
-      // 保存提示词到历史记录（只保存有实际内容的提示词）
-      if (prompt.trim()) {
-        const hasSelection = allContent.length > 0;
-        // 将 generationType 'text' 映射为 'agent' 用于历史记录
-        const modelTypeForHistory = generationType === 'text' ? 'agent' : generationType;
-        addPromptHistory(prompt.trim(), hasSelection, modelTypeForHistory);
-      }
-
       // 检查工作流是否已完成（所有步骤都是 completed 或 failed/skipped）
       // 如果没有创建任务（createdTaskIds 为空），则立即删除 WorkZone
       const finalWorkflow = workflowControl.getWorkflow();
@@ -1653,12 +1662,6 @@ const userOutputType = (userNote.metadata?.outputType as 'image' | 'text' | 'vid
         }
       }
 
-      // 清空输入，保持面板打开以便用户继续创作
-      setPrompt('');
-      setSelectedContent([]);
-      setUploadedContent([]); // 同时清空用户上传内容
-      // 不关闭面板，让用户可以继续输入
-      setIsSubmitting(false);
     } catch (error) {
       console.error('Failed to create generation task:', error);
       workflowControl.abortWorkflow();

--- a/packages/drawnix/src/components/settings-dialog/settings-dialog.scss
+++ b/packages/drawnix/src/components/settings-dialog/settings-dialog.scss
@@ -106,6 +106,12 @@ $brand-orange-light: rgba(243, 156, 18, 0.1);
     min-width: 0;
   }
 
+  &__divider {
+    height: 1px;
+    background: #f3f4f6;
+    margin: 8px 0;
+  }
+
   &__actions {
     display: flex;
     justify-content: flex-end;

--- a/packages/drawnix/src/components/settings-dialog/settings-dialog.tsx
+++ b/packages/drawnix/src/components/settings-dialog/settings-dialog.tsx
@@ -4,8 +4,9 @@ import './settings-dialog.scss';
 import { useI18n } from '../../i18n';
 import { useState, useEffect } from 'react';
 import { geminiSettings } from '../../utils/settings-manager';
-import { Tooltip } from 'tdesign-react';
+import { Tooltip, Checkbox } from 'tdesign-react';
 import { InfoCircleIcon } from 'tdesign-icons-react';
+import { LS_KEYS } from '../../constants/storage-keys';
 import { ModelDropdown } from '../ai-input-bar/ModelDropdown';
 import {
   IMAGE_MODEL_GROUPED_SELECT_OPTIONS,
@@ -33,8 +34,7 @@ export const SettingsDialog = ({
   const [imageModelName, setImageModelName] = useState('');
   const [videoModelName, setVideoModelName] = useState('');
   const [textModelName, setTextModelName] = useState('');
-
-
+  const [showWorkZoneCard, setShowWorkZoneCard] = useState(true);
 
   // 加载当前配置
   useEffect(() => {
@@ -45,6 +45,11 @@ export const SettingsDialog = ({
       setImageModelName(config.imageModelName || getDefaultImageModel());
       setVideoModelName(config.videoModelName || getDefaultVideoModel());
       setTextModelName(config.textModelName || getDefaultTextModel());
+      try {
+        setShowWorkZoneCard(localStorage.getItem(LS_KEYS.WORKZONE_CARD_VISIBLE) !== 'false');
+      } catch {
+        setShowWorkZoneCard(true);
+      }
     }
   }, [appState.openSettings]);
 
@@ -65,6 +70,14 @@ export const SettingsDialog = ({
     });
 
     // 配置随任务传递，无需同步到 SW
+
+    // 保存 WorkZone 卡片显示设置
+    try {
+      localStorage.setItem(LS_KEYS.WORKZONE_CARD_VISIBLE, String(showWorkZoneCard));
+      window.dispatchEvent(new CustomEvent('workzone-visibility-changed'));
+    } catch {
+      // localStorage not available
+    }
 
     // 关闭弹窗
     setAppState({ ...appState, openSettings: false });
@@ -206,6 +219,16 @@ export const SettingsDialog = ({
             </div>
           </div>
 
+          <div className="settings-dialog__divider" />
+          <div className="settings-dialog__field">
+            <label className="settings-dialog__label">画布显示</label>
+            <Checkbox
+              checked={showWorkZoneCard}
+              onChange={(checked) => setShowWorkZoneCard(checked as boolean)}
+            >
+              显示任务进度卡片
+            </Checkbox>
+          </div>
 
         </form>
         <div className="settings-dialog__actions">

--- a/packages/drawnix/src/components/ttd-dialog/ai-image-generation.scss
+++ b/packages/drawnix/src/components/ttd-dialog/ai-image-generation.scss
@@ -115,6 +115,18 @@
   &.unified-action-bar {
     gap: 8px;
   }
+
+  .action-bar-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .auto-insert-checkbox {
+    font-size: 13px;
+    white-space: nowrap;
+    user-select: none;
+  }
 }
 
 .task-sidebar {

--- a/packages/drawnix/src/components/ttd-dialog/ai-image-generation.tsx
+++ b/packages/drawnix/src/components/ttd-dialog/ai-image-generation.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '../../i18n';
 import { type Language } from '../../constants/prompts';
 import { useTaskQueue } from '../../hooks/useTaskQueue';
 import { TaskType } from '../../types/task.types';
-import { MessagePlugin } from 'tdesign-react';
+import { MessagePlugin, Checkbox, Tooltip } from 'tdesign-react';
 import { useGenerationHistory } from '../../hooks/useGenerationHistory';
 import { ModelDropdown } from '../ai-input-bar/ModelDropdown';
 import { ParametersDropdown } from '../ai-input-bar/ParametersDropdown';
@@ -28,6 +28,7 @@ import {
   convertAspectRatioToSize,
 } from '../../constants/image-aspect-ratios';
 import { DialogTaskList } from '../task-queue/DialogTaskList';
+import { LS_KEYS } from '../../constants/storage-keys';
 import { geminiSettings } from '../../utils/settings-manager';
 import { promptForApiKey } from '../../utils/gemini-api';
 import { buildMJPromptSuffix } from '../../utils/mj-params';
@@ -74,6 +75,14 @@ const AIImageGeneration = ({
   const [error, setError] = useState<string | null>(null);
   const [uploadedImages, setUploadedImages] =
     useState<ReferenceImage[]>(initialImages);
+  const [autoInsertToCanvas, setAutoInsertToCanvas] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LS_KEYS.AI_IMAGE_AUTO_INSERT);
+      return saved !== 'false';
+    } catch {
+      return true;
+    }
+  });
 
   // 任务列表面板状态 - 使用像素宽度
   const [isTaskListVisible, setIsTaskListVisible] = useState(true);
@@ -127,6 +136,15 @@ const AIImageGeneration = ({
   // 切换任务列表显示/隐藏
   const handleToggleTaskList = useCallback(() => {
     setIsTaskListVisible((prev) => !prev);
+  }, []);
+
+  const handleAutoInsertChange = useCallback((checked: boolean) => {
+    setAutoInsertToCanvas(checked);
+    try {
+      localStorage.setItem(LS_KEYS.AI_IMAGE_AUTO_INSERT, String(checked));
+    } catch {
+      // localStorage not available
+    }
   }, []);
 
   // 处理 props 变化，更新内部状态
@@ -381,7 +399,7 @@ const AIImageGeneration = ({
             batchId,
             batchIndex: i + 1,
             batchTotal: count,
-            autoInsertToCanvas: true,
+            autoInsertToCanvas,
             targetFrameId,
             targetFrameDimensions,
             ...(extraParams ? { params: extraParams } : {}),
@@ -447,7 +465,7 @@ const AIImageGeneration = ({
         model: currentImageModel,
         // 保存上传的图片（已转换为可序列化的格式）
         uploadedImages: convertedImages,
-        autoInsertToCanvas: true,
+        autoInsertToCanvas,
         // 始终包含 batchId 以跳过重复检测
         batchId: `image_single_${Date.now()}`,
         batchIndex: 1,
@@ -590,13 +608,27 @@ const AIImageGeneration = ({
             onGenerate={handleGenerate}
             onReset={handleReset}
             leftContent={
-              isMJModel ? null : (
-                <AspectRatioSelector
-                  value={aspectRatio}
-                  onChange={setAspectRatio}
-                  compact={true}
-                />
-              )
+              <>
+                <Tooltip
+                  content={language === 'zh' ? '生成后自动插入画布' : 'Auto insert to canvas after generation'}
+                  theme="light"
+                >
+                  <Checkbox
+                    checked={autoInsertToCanvas}
+                    onChange={handleAutoInsertChange}
+                    className="auto-insert-checkbox"
+                  >
+                    {language === 'zh' ? '插入画布' : 'Insert'}
+                  </Checkbox>
+                </Tooltip>
+                {!isMJModel && (
+                  <AspectRatioSelector
+                    value={aspectRatio}
+                    onChange={setAspectRatio}
+                    compact={true}
+                  />
+                )}
+              </>
             }
           />
         </div>

--- a/packages/drawnix/src/components/workzone-element/WorkZoneContent.tsx
+++ b/packages/drawnix/src/components/workzone-element/WorkZoneContent.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo, useEffect, useRef, useState, useCallback } from 'react';
-import { Trash2, RotateCcw } from 'lucide-react';
+import { Trash2, RotateCcw, EyeOff } from 'lucide-react';
 import type { WorkflowMessageData } from '../../types/chat.types';
 import './workzone-content.scss';
 
@@ -32,6 +32,8 @@ interface WorkZoneContentProps {
   onWorkflowStateChange?: (workflowId: string, status: 'completed' | 'failed', error?: string) => void;
   /** 从失败步骤重试工作流 */
   onRetry?: (workflow: WorkflowMessageData, stepIndex: number) => Promise<void>;
+  /** 永远不再显示 WorkZone 卡片 */
+  onHideForever?: () => void;
 }
 
 export const WorkZoneContent: React.FC<WorkZoneContentProps> = ({
@@ -40,10 +42,12 @@ export const WorkZoneContent: React.FC<WorkZoneContentProps> = ({
   onDelete,
   onWorkflowStateChange,
   onRetry,
+  onHideForever,
 }) => {
   // 用于追踪是否已经尝试 claim
   const hasClaimedRef = useRef(false);
   const [isRetrying, setIsRetrying] = useState(false);
+  const [showHideConfirm, setShowHideConfirm] = useState(false);
 
   // 页面刷新后，尝试接管工作流或同步状态
   // 注意：只对"旧"工作流执行 claim，新创建的工作流不需要 claim
@@ -234,6 +238,19 @@ export const WorkZoneContent: React.FC<WorkZoneContentProps> = ({
     }
   }, [onRetry, workflow, firstFailedStepIndex, isRetrying]);
 
+  const handleHideForeverClick = useCallback(() => {
+    setShowHideConfirm(true);
+  }, []);
+
+  const handleHideConfirm = useCallback(() => {
+    setShowHideConfirm(false);
+    onHideForever?.();
+  }, [onHideForever]);
+
+  const handleHideCancel = useCallback(() => {
+    setShowHideConfirm(false);
+  }, []);
+
   return (
     <div
       className={`workzone-content workzone-content--${workflowStatus.status} ${className}`}
@@ -245,6 +262,32 @@ export const WorkZoneContent: React.FC<WorkZoneContentProps> = ({
         <span className={`workzone-content__status workzone-content__status--${workflowStatus.status}`}>
           {statusLabel}
         </span>
+        {/* 不再显示按钮 */}
+        {onHideForever && (
+          <button
+            className="workzone-content__hide-btn"
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            onPointerUp={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              handleHideForeverClick();
+            }}
+            onMouseDown={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            title="不再显示"
+          >
+            <EyeOff size={14} />
+          </button>
+        )}
         {/* 删除按钮 - 始终显示（如果有 onDelete 回调） */}
         {onDelete && (
           <button
@@ -352,6 +395,43 @@ export const WorkZoneContent: React.FC<WorkZoneContentProps> = ({
       {workflowStatus.status === 'completed' && (
         <div className="workzone-content__success">
           ✨ 已完成
+        </div>
+      )}
+
+      {/* 二次确认弹窗 */}
+      {showHideConfirm && (
+        <div
+          className="workzone-content__confirm-overlay"
+          onPointerDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
+          onMouseDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
+        >
+          <div className="workzone-content__confirm-dialog">
+            <p className="workzone-content__confirm-text">
+              确定不再显示进度卡片？
+              <br />
+              <span className="workzone-content__confirm-hint">任务仍会在后台执行，可在设置中恢复显示</span>
+            </p>
+            <div className="workzone-content__confirm-actions">
+              <button
+                className="workzone-content__confirm-btn workzone-content__confirm-btn--cancel"
+                onPointerDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
+                onPointerUp={(e) => { e.stopPropagation(); e.preventDefault(); handleHideCancel(); }}
+                onMouseDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
+                onClick={(e) => { e.stopPropagation(); e.preventDefault(); }}
+              >
+                取消
+              </button>
+              <button
+                className="workzone-content__confirm-btn workzone-content__confirm-btn--confirm"
+                onPointerDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
+                onPointerUp={(e) => { e.stopPropagation(); e.preventDefault(); handleHideConfirm(); }}
+                onMouseDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
+                onClick={(e) => { e.stopPropagation(); e.preventDefault(); }}
+              >
+                确定
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/packages/drawnix/src/components/workzone-element/workzone-content.scss
+++ b/packages/drawnix/src/components/workzone-element/workzone-content.scss
@@ -87,6 +87,36 @@
   }
 }
 
+// 不再显示按钮
+.workzone-content__hide-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: #f3f4f6;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-left: 4px;
+  position: relative;
+  z-index: 10;
+  pointer-events: auto !important;
+  flex-shrink: 0;
+
+  &:hover {
+    background: #fef3c7;
+    color: #d97706;
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
 // 删除按钮
 .workzone-content__delete-btn {
   display: flex;
@@ -301,4 +331,79 @@
 @keyframes workzone-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.85; }
+}
+
+// 二次确认弹窗
+.workzone-content__confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+  border-radius: 8px;
+  pointer-events: auto !important;
+}
+
+.workzone-content__confirm-dialog {
+  text-align: center;
+  padding: 12px;
+}
+
+.workzone-content__confirm-text {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1f2937;
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.workzone-content__confirm-hint {
+  font-size: 11px;
+  font-weight: 400;
+  color: #9ca3af;
+}
+
+.workzone-content__confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.workzone-content__confirm-btn {
+  padding: 4px 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  pointer-events: auto !important;
+  position: relative;
+  z-index: 10;
+  border: 1px solid #d1d5db;
+
+  &--cancel {
+    background: #fff;
+    color: #6b7280;
+
+    &:hover {
+      background: #f3f4f6;
+    }
+  }
+
+  &--confirm {
+    background: #f59e0b;
+    color: #fff;
+    border-color: #f59e0b;
+
+    &:hover {
+      background: #d97706;
+      border-color: #d97706;
+    }
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
 }

--- a/packages/drawnix/src/constants/storage-keys.ts
+++ b/packages/drawnix/src/constants/storage-keys.ts
@@ -31,6 +31,10 @@ export const LS_KEYS = {
   AI_IMAGE_QUANTITY: 'aitu_image_generation_quantity',
   /** 视频生成数量记忆 */
   AI_VIDEO_QUANTITY: 'aitu_video_generation_quantity',
+  /** 图片生成后是否自动插入画布 */
+  AI_IMAGE_AUTO_INSERT: 'aitu_image_auto_insert_canvas',
+  /** 是否显示画布上的 WorkZone 进度卡片 */
+  WORKZONE_CARD_VISIBLE: 'aitu_workzone_card_visible',
 
   // ---- 抽屉状态（轻量 UI 状态，保留在 LocalStorage） ----
   /** 聊天抽屉状态 */

--- a/packages/drawnix/src/plugins/with-workzone.ts
+++ b/packages/drawnix/src/plugins/with-workzone.ts
@@ -28,12 +28,23 @@ import type { WorkflowMessageData } from '../types/chat.types';
 import { WorkZoneContent } from '../components/workzone-element/WorkZoneContent';
 import { ToolProviderWrapper } from '../components/toolbox-drawer/ToolProviderWrapper';
 import { workflowStatusSyncService } from '../services/workflow-status-sync';
+import { LS_KEYS } from '../constants/storage-keys';
 
 /**
  * 判断是否为 WorkZone 元素
  */
 export function isWorkZoneElement(element: any): element is PlaitWorkZone {
   return element && element.type === 'workzone';
+}
+
+const WORKZONE_VISIBILITY_EVENT = 'workzone-visibility-changed';
+
+function isWorkZoneCardVisible(): boolean {
+  try {
+    return localStorage.getItem(LS_KEYS.WORKZONE_CARD_VISIBLE) !== 'false';
+  } catch {
+    return true;
+  }
 }
 
 /**
@@ -76,7 +87,8 @@ export class WorkZoneComponent extends CommonElementFlavour<PlaitWorkZone, Plait
     // 渲染 React 内容
     this.renderContent();
 
-    // console.log('[WorkZone] Element initialized:', this.element.id);
+    // 监听全局可见性变化事件
+    window.addEventListener(WORKZONE_VISIBILITY_EVENT, this.handleVisibilityChange);
   }
 
   /**
@@ -161,6 +173,23 @@ export class WorkZoneComponent extends CommonElementFlavour<PlaitWorkZone, Plait
   };
 
   /**
+   * 永远不再显示 WorkZone 卡片
+   */
+  private handleHideForever = (): void => {
+    try {
+      localStorage.setItem(LS_KEYS.WORKZONE_CARD_VISIBLE, 'false');
+    } catch {
+      // localStorage not available
+    }
+    window.dispatchEvent(new CustomEvent(WORKZONE_VISIBILITY_EVENT));
+  };
+
+  private handleVisibilityChange = (): void => {
+    if (!this.container) return;
+    this.container.style.display = isWorkZoneCardVisible() ? '' : 'none';
+  };
+
+  /**
    * 处理工作流重试（从失败步骤开始）
    */
   private handleRetry = async (workflow: WorkflowMessageData, stepIndex: number): Promise<void> => {
@@ -179,6 +208,9 @@ export class WorkZoneComponent extends CommonElementFlavour<PlaitWorkZone, Plait
   private renderContent(): void {
     if (!this.container) return;
 
+    // 根据设置控制初始可见性
+    this.container.style.display = isWorkZoneCardVisible() ? '' : 'none';
+
     // 创建 React root
     this.reactRoot = createRoot(this.container);
     this.reactRoot.render(
@@ -188,6 +220,7 @@ export class WorkZoneComponent extends CommonElementFlavour<PlaitWorkZone, Plait
           onDelete: this.handleDelete,
           onWorkflowStateChange: this.handleWorkflowStateChange,
           onRetry: this.handleRetry,
+          onHideForever: this.handleHideForever,
         })
       )
     );
@@ -226,6 +259,7 @@ export class WorkZoneComponent extends CommonElementFlavour<PlaitWorkZone, Plait
               onDelete: this.handleDelete,
               onWorkflowStateChange: this.handleWorkflowStateChange,
               onRetry: this.handleRetry,
+              onHideForever: this.handleHideForever,
             })
           )
         );
@@ -286,7 +320,7 @@ export class WorkZoneComponent extends CommonElementFlavour<PlaitWorkZone, Plait
    * 销毁
    */
   destroy(): void {
-    // console.log('[WorkZone] destroy() called for:', this.element?.id);
+    window.removeEventListener(WORKZONE_VISIBILITY_EVENT, this.handleVisibilityChange);
 
     // 取消状态同步订阅
     if (this.statusSyncUnsubscribe) {


### PR DESCRIPTION
close #85 
1. 图片生成：新增"插入画布"开关
图片生成对话框底部新增 Checkbox，控制生成后是否自动插入画布
默认开启，状态持久化到 localStorage（key: aitu_image_auto_insert_canvas）
涉及文件：ai-image-generation.tsx、ai-image-generation.scss、storage-keys.ts
2. WorkZone 进度卡片：支持隐藏与恢复
每个 WorkZone 卡片新增"不再显示"按钮（EyeOff 图标），点击后弹出二次确认
确认后通过 localStorage（key: aitu_workzone_card_visible）+ 自定义事件 workzone-visibility-changed 同步隐藏所有卡片
设置对话框新增"画布显示 → 显示任务进度卡片" Checkbox，保存后派发同一事件，已隐藏的卡片立即恢复，无需刷新页面
涉及文件：WorkZoneContent.tsx、workzone-content.scss、with-workzone.ts、settings-dialog.tsx、settings-dialog.scss、storage-keys.ts