### PR TITLE
feat:隐藏原生滚动条

### DIFF
--- a/packages/react-board/src/styles/index.scss
+++ b/packages/react-board/src/styles/index.scss
@@ -19,6 +19,14 @@
         width: 100%;
         height: 100%;
         overflow: auto;
+        // 空画布也有约 2 倍视口的可滚动区（Plait 最小 viewBox）；隐藏原生条，平移靠滚轮/手掌工具。
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+        &::-webkit-scrollbar {
+            display: none;
+            width: 0;
+            height: 0;
+        }
     }
 
     &.disabled-scroll {


### PR DESCRIPTION
Closes #136 
原因说明：
画布里用的是 Plait 的视口模型：内部用带 overflow: auto 的 .viewport-container + 滚动位置来对应画布平移。就算没有元素，也会套一层最小 viewBox（大约半屏）再加上 75% 视口大小的边距，算出来的 SVG 尺寸大约是可视区域的 两倍，所以仍然会出现可滚动区域和滚动条。
触控：react-board 里在 .viewport-container 上对 touchstart 做了 preventDefault()（避免和画布指针/绘图抢手势），整块区域上的手指滑动不会像普通网页那样去滚那个 div。平移要靠左侧 手掌工具 拖动画布。
鼠标 / 触控板：在画布区域（没有被对话框挡住）用滚轮或双指滑动，一般会触发该容器的滚动并联动视口；初始化时中间有 「灵感创意」大弹窗，指针在弹窗上时，滚轮会先作用在对话框上，看起来就像「页面不跟着动」。
已在 packages/react-board/src/styles/index.scss 里对 .viewport-container 隐藏原生滚动条（保留 overflow: auto，滚轮和程序滚动逻辑不变）。这样空画布时不会再出现容易误解成「整页滚动条」的细条；需要平移时仍可用 滚轮/触控板在画布空白处 或 手掌工具拖拽。