### PR TITLE
feat: improve markdown image resizing and placement

### DIFF
--- a/packages/drawnix/src/components/MarkdownEditor/MarkdownEditor.css
+++ b/packages/drawnix/src/components/MarkdownEditor/MarkdownEditor.css
@@ -68,6 +68,118 @@
 
 /* ===== asset-embed 插件样式 ===== */
 
+.collimind-markdown-editor .milkdown-image-block.collimind-markdown-image-block {
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: top;
+  margin: 8px 12px 8px 0;
+  max-width: 100%;
+}
+
+.collimind-markdown-editor .milkdown-image-block.collimind-markdown-image-block:last-child {
+  margin-right: 0;
+}
+
+.collimind-markdown-image-block__shell {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 100%;
+  cursor: grab;
+}
+
+.collimind-markdown-image-block__frame {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  justify-content: stretch;
+  min-width: 80px;
+  min-height: 80px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f8fafc;
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+
+.collimind-markdown-image-block__shell.is-selected .collimind-markdown-image-block__frame {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.45);
+}
+
+.collimind-markdown-image-block__image {
+  display: block;
+  max-width: 100%;
+}
+
+.collimind-markdown-image-block__caption {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #64748b;
+}
+
+.collimind-markdown-image-block__handle {
+  position: absolute;
+  border: none;
+  background: #f97316;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.92);
+  opacity: 0.96;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.collimind-markdown-image-block__handle--right {
+  top: 50%;
+  right: -5px;
+  width: 10px;
+  height: 56px;
+  border-radius: 999px;
+  transform: translateY(-50%);
+  cursor: ew-resize;
+}
+
+.collimind-markdown-image-block__handle--bottom {
+  left: 50%;
+  bottom: -5px;
+  width: 56px;
+  height: 10px;
+  border-radius: 999px;
+  transform: translateX(-50%);
+  cursor: ns-resize;
+}
+
+.collimind-markdown-image-block__handle--corner {
+  right: -6px;
+  bottom: -6px;
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  cursor: nwse-resize;
+}
+
+.collimind-markdown-image-block__loading,
+.collimind-markdown-image-block__missing {
+  min-width: 180px;
+  min-height: 96px;
+  border-radius: 12px;
+}
+
+.collimind-markdown-image-block__loading {
+  background: linear-gradient(90deg, #f1f5f9 25%, #e2e8f0 50%, #f1f5f9 75%);
+  background-size: 200% 100%;
+  animation: asset-embed-shimmer 1.5s ease-in-out infinite;
+}
+
+.collimind-markdown-image-block__missing {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  border: 1px dashed #cbd5e1;
+  background: #f8fafc;
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .collimind-asset-embed {
   margin: 8px 0;
   max-width: 100%;

--- a/packages/drawnix/src/components/MarkdownEditor/asset-embed-plugin/remark-plugin.ts
+++ b/packages/drawnix/src/components/MarkdownEditor/asset-embed-plugin/remark-plugin.ts
@@ -1,5 +1,5 @@
 /**
- * remark 插件：将 asset:// 素材引用转换为 assetEmbed 自定义节点
+ * remark 插件：将 asset:// 音频/视频素材引用转换为 assetEmbed 自定义节点
  *
  * 本插件注册在 Crepe 内置 remarkImageBlockPlugin 之后运行，
  * 需要同时匹配两种 MDAST 节点：
@@ -8,6 +8,7 @@
  */
 import { $remark } from '@milkdown/kit/utils';
 import { ASSET_URI_PREFIX } from '../../../utils/markdown-asset-embeds';
+import { parseMarkdownImageAlt } from '../../../utils/markdown-image-blocks';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 interface MdastNode {
@@ -19,19 +20,14 @@ interface MdastNode {
   [key: string]: any;
 }
 
-function parseAlt(alt: string): { assetType: string; label: string } {
-  const pipeIdx = alt.indexOf('|');
-  return {
-    assetType: pipeIdx > 0 ? alt.slice(0, pipeIdx) : 'image',
-    label: pipeIdx > 0 ? alt.slice(pipeIdx + 1) : alt,
-  };
-}
-
 function tryConvertToAssetEmbed(node: MdastNode): MdastNode | null {
   const url = node.url;
   if (!url?.startsWith(ASSET_URI_PREFIX)) return null;
   const assetId = url.slice(ASSET_URI_PREFIX.length);
-  const { assetType, label } = parseAlt(node.alt || '');
+  const parsedAlt = parseMarkdownImageAlt(node.alt || '');
+  const assetType = parsedAlt.assetType || 'image';
+  if (assetType === 'image') return null;
+  const label = parsedAlt.label || parsedAlt.rawAlt;
   return { type: 'assetEmbed', assetId, assetType, label };
 }
 
@@ -83,4 +79,3 @@ function transformAssetImages(node: MdastNode): void {
 }
 
 export const remarkAssetEmbed = $remark('remarkAssetEmbed', () => () => transformAssetImages as any);
-

--- a/packages/drawnix/src/components/MarkdownEditor/image-block-plugin/index.ts
+++ b/packages/drawnix/src/components/MarkdownEditor/image-block-plugin/index.ts
@@ -1,0 +1,12 @@
+import type { MilkdownPlugin } from '@milkdown/kit/ctx';
+import { markdownImageBlockSchema } from './schema';
+import { markdownImageBlockView } from './view';
+
+export { markdownImageBlockSchema } from './schema';
+export { markdownImageBlockView } from './view';
+
+export const markdownImageBlockPlugins: MilkdownPlugin[] = [
+  markdownImageBlockSchema.node,
+  markdownImageBlockSchema.ctx,
+  markdownImageBlockView,
+].flat();

--- a/packages/drawnix/src/components/MarkdownEditor/image-block-plugin/schema.ts
+++ b/packages/drawnix/src/components/MarkdownEditor/image-block-plugin/schema.ts
@@ -1,0 +1,118 @@
+import { $nodeSchema } from '@milkdown/kit/utils';
+import {
+  buildMarkdownImageTitle,
+  isNumericImageRatioAlt,
+  parseMarkdownImageTitle,
+} from '../../../utils/markdown-image-blocks';
+
+function normalizeOptionalNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.round(value);
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+export const markdownImageBlockSchema = $nodeSchema('image-block', () => ({
+  inline: false,
+  group: 'block',
+  selectable: true,
+  draggable: true,
+  isolating: true,
+  marks: '',
+  atom: true,
+  priority: 100,
+  attrs: {
+    src: { default: '' },
+    alt: { default: '' },
+    caption: { default: '' },
+    ratio: { default: 1 },
+    width: { default: null },
+    height: { default: null },
+  },
+  parseMarkdown: {
+    match: ({ type }: { type: string }) => type === 'image-block',
+    runner: (state: any, node: any, type: any) => {
+      const rawAlt = typeof node.alt === 'string' ? node.alt : '';
+      const parsedTitle = parseMarkdownImageTitle(node.title as string | undefined);
+      const ratio = isNumericImageRatioAlt(rawAlt)
+        ? Number.parseFloat(rawAlt)
+        : 1;
+
+      state.addNode(type, {
+        src: node.url as string,
+        alt: isNumericImageRatioAlt(rawAlt) ? '' : rawAlt,
+        caption: parsedTitle.caption,
+        ratio: Number.isFinite(ratio) && ratio > 0 ? ratio : 1,
+        width: parsedTitle.width ?? null,
+        height: parsedTitle.height ?? null,
+      });
+    },
+  },
+  toMarkdown: {
+    match: (node: any) => node.type.name === 'image-block',
+    runner: (state: any, node: any) => {
+      const markdownTitle = buildMarkdownImageTitle({
+        width: normalizeOptionalNumber(node.attrs.width),
+        height: normalizeOptionalNumber(node.attrs.height),
+        caption: node.attrs.caption,
+      });
+
+      const markdownAlt = node.attrs.alt
+        || ((!node.attrs.width && !node.attrs.height && node.attrs.ratio && node.attrs.ratio !== 1)
+          ? `${Number.parseFloat(String(node.attrs.ratio)).toFixed(2)}`
+          : '');
+
+      state.openNode('paragraph');
+      state.addNode('image', undefined, undefined, {
+        title: markdownTitle,
+        url: node.attrs.src,
+        alt: markdownAlt,
+      });
+      state.closeNode();
+    },
+  },
+  toDOM: (node: any) => [
+    'div',
+    {
+      'data-type': 'opentu-image-block',
+      'data-src': node.attrs.src,
+      'data-alt': node.attrs.alt,
+      'data-caption': node.attrs.caption,
+      'data-ratio': node.attrs.ratio,
+      'data-width': node.attrs.width ?? '',
+      'data-height': node.attrs.height ?? '',
+    },
+  ],
+  parseDOM: [
+    {
+      tag: 'div[data-type="opentu-image-block"]',
+      getAttrs: (dom: HTMLElement) => ({
+        src: dom.getAttribute('data-src') || '',
+        alt: dom.getAttribute('data-alt') || '',
+        caption: dom.getAttribute('data-caption') || '',
+        ratio: Number(dom.getAttribute('data-ratio') ?? 1) || 1,
+        width: normalizeOptionalNumber(dom.getAttribute('data-width')),
+        height: normalizeOptionalNumber(dom.getAttribute('data-height')),
+      }),
+    },
+    {
+      tag: 'img[data-type="image-block"]',
+      getAttrs: (dom: HTMLElement) => ({
+        src: dom.getAttribute('src') || '',
+        alt: '',
+        caption: dom.getAttribute('caption') || '',
+        ratio: Number(dom.getAttribute('ratio') ?? 1) || 1,
+        width: null,
+        height: null,
+      }),
+    },
+  ],
+}));

--- a/packages/drawnix/src/components/MarkdownEditor/image-block-plugin/view.tsx
+++ b/packages/drawnix/src/components/MarkdownEditor/image-block-plugin/view.tsx
@@ -1,0 +1,430 @@
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { $view } from '@milkdown/kit/utils';
+import { imageBlockConfig, type ImageBlockConfig } from '@milkdown/kit/component/image-block';
+import { normalizeImageDataUrl } from '@aitu/utils';
+import { subscribeAssetMap, getAssetMapSnapshot } from '../../../stores/asset-map-store';
+import { AssetType } from '../../../types/asset.types';
+import { extractAssetIdFromUrl } from '../../../utils/markdown-asset-embeds';
+import { parseMarkdownImageAlt } from '../../../utils/markdown-image-blocks';
+import { markdownImageBlockSchema } from './schema';
+
+interface ImageBlockAttrs {
+  src: string;
+  alt: string;
+  caption: string;
+  ratio: number;
+  width: number | null;
+  height: number | null;
+}
+
+interface MarkdownImageBlockProps {
+  attrs: ImageBlockAttrs;
+  selected: boolean;
+  readonly: boolean;
+  config: ImageBlockConfig;
+  updateAttrs: (attrs: Partial<ImageBlockAttrs>) => void;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normalizeDimension(value: number | null | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+
+  return Math.round(value);
+}
+
+function EmptyImageBlock({
+  attrs,
+  readonly,
+  config,
+  updateAttrs,
+}: Pick<MarkdownImageBlockProps, 'attrs' | 'readonly' | 'config' | 'updateAttrs'>) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [currentLink, setCurrentLink] = useState(attrs.src || '');
+  const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    setCurrentLink(attrs.src || '');
+  }, [attrs.src]);
+
+  const confirmLink = useCallback(() => {
+    updateAttrs({ src: currentLink.trim() });
+  }, [currentLink, updateAttrs]);
+
+  const handleUpload = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      const uploadedSrc = await config.onUpload(file);
+      if (!uploadedSrc) {
+        return;
+      }
+      setCurrentLink(uploadedSrc);
+      updateAttrs({ src: uploadedSrc });
+    } catch (error) {
+      console.error('Failed to upload image block file', error);
+    } finally {
+      event.target.value = '';
+    }
+  }, [config, updateAttrs]);
+
+  return (
+    <div className="image-edit collimind-markdown-image-block__edit">
+      <div className="image-icon">{config.imageIcon || '🌌'}</div>
+      <div className={`link-importer ${isFocused ? 'focus' : ''}`}>
+        <input
+          className="link-input-area"
+          value={currentLink}
+          disabled={readonly}
+          onChange={(event) => setCurrentLink(event.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              confirmLink();
+            }
+          }}
+        />
+        {!currentLink && (
+          <div className="placeholder">
+            <input
+              ref={fileInputRef}
+              className="hidden"
+              type="file"
+              accept="image/*"
+              disabled={readonly}
+              onChange={handleUpload}
+            />
+            <button
+              type="button"
+              className="uploader"
+              disabled={readonly}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {config.uploadButton || 'Upload'}
+            </button>
+            <span className="text">{config.uploadPlaceholderText}</span>
+          </div>
+        )}
+      </div>
+      {!!currentLink && (
+        <button
+          type="button"
+          className="confirm"
+          disabled={readonly}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={confirmLink}
+        >
+          {config.confirmButton || 'Confirm'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function RenderedImageBlock({
+  attrs,
+  selected,
+  readonly,
+  updateAttrs,
+}: Pick<MarkdownImageBlockProps, 'attrs' | 'selected' | 'readonly' | 'updateAttrs'>) {
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const assetMap = useSyncExternalStore(subscribeAssetMap, getAssetMapSnapshot);
+  const [draftSize, setDraftSize] = useState<{ width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    setDraftSize(null);
+  }, [attrs.width, attrs.height]);
+
+  const assetId = useMemo(() => extractAssetIdFromUrl(attrs.src), [attrs.src]);
+  const asset = assetId ? assetMap.get(assetId) : undefined;
+  const parsedAlt = useMemo(() => parseMarkdownImageAlt(attrs.alt), [attrs.alt]);
+
+  const displayAlt = assetId
+    ? (parsedAlt.label || asset?.name || '素材图片')
+    : (attrs.alt || '图片');
+
+  const resolvedSrc = useMemo(() => {
+    if (assetId) {
+      if (!asset) {
+        return null;
+      }
+      if (asset.type !== AssetType.IMAGE) {
+        return null;
+      }
+      return normalizeImageDataUrl(asset.url);
+    }
+
+    return normalizeImageDataUrl(attrs.src);
+  }, [asset, assetId, attrs.src]);
+
+  const explicitWidth = draftSize?.width ?? normalizeDimension(attrs.width);
+  const explicitHeight = draftSize?.height ?? normalizeDimension(attrs.height);
+
+  const frameStyle = useMemo<CSSProperties>(() => {
+    const style: CSSProperties = {};
+    if (explicitWidth) {
+      style.width = `${explicitWidth}px`;
+    } else {
+      style.maxWidth = 'min(100%, 420px)';
+    }
+    if (explicitHeight) {
+      style.height = `${explicitHeight}px`;
+    }
+    return style;
+  }, [explicitHeight, explicitWidth]);
+
+  const imageStyle = useMemo<CSSProperties>(() => {
+    if (explicitWidth && explicitHeight) {
+      return {
+        width: '100%',
+        height: '100%',
+        objectFit: 'fill',
+      };
+    }
+
+    if (explicitWidth) {
+      return {
+        width: '100%',
+        height: 'auto',
+      };
+    }
+
+    if (explicitHeight) {
+      return {
+        width: 'auto',
+        height: '100%',
+      };
+    }
+
+    return {
+      width: '100%',
+      height: 'auto',
+    };
+  }, [explicitHeight, explicitWidth]);
+
+  const startResize = useCallback((handle: 'right' | 'bottom' | 'corner') => (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (readonly) {
+      return;
+    }
+
+    const frame = frameRef.current;
+    if (!frame) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const rect = frame.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return;
+    }
+
+    const editorRoot = frame.closest('.ProseMirror');
+    const maxWidth = Math.max(120, (editorRoot?.getBoundingClientRect().width ?? rect.width) - 32);
+    const startState = {
+      x: event.clientX,
+      y: event.clientY,
+      width: rect.width,
+      height: rect.height,
+    };
+
+    let nextSize = {
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    };
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const dx = moveEvent.clientX - startState.x;
+      const dy = moveEvent.clientY - startState.y;
+
+      const width = handle === 'bottom'
+        ? startState.width
+        : clamp(startState.width + dx, 80, maxWidth);
+      const height = handle === 'right'
+        ? startState.height
+        : clamp(startState.height + dy, 80, 1600);
+
+      nextSize = {
+        width: Math.round(width),
+        height: Math.round(height),
+      };
+      setDraftSize(nextSize);
+    };
+
+    const handlePointerUp = () => {
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerUp);
+      setDraftSize(nextSize);
+      updateAttrs({
+        width: nextSize.width,
+        height: nextSize.height,
+      });
+    };
+
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp, { once: true });
+  }, [readonly, updateAttrs]);
+
+  if (assetId && !asset && assetMap.size === 0) {
+    return <div className="collimind-markdown-image-block__loading" />;
+  }
+
+  if (!resolvedSrc) {
+    return (
+      <div className="collimind-markdown-image-block__missing">
+        {assetId ? `图片素材不存在或已删除 (${assetId.slice(0, 8)}…)` : '图片地址无效'}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`collimind-markdown-image-block__shell ${selected ? 'is-selected' : ''}`}
+      data-asset-id={assetId || undefined}
+    >
+      <div ref={frameRef} className="collimind-markdown-image-block__frame" style={frameStyle}>
+        <img
+          className="collimind-markdown-image-block__image"
+          src={resolvedSrc}
+          alt={displayAlt}
+          draggable={false}
+          style={imageStyle}
+        />
+        {!readonly && selected && (
+          <>
+            <button
+              type="button"
+              data-resize-handle="right"
+              className="collimind-markdown-image-block__handle collimind-markdown-image-block__handle--right"
+              onPointerDown={startResize('right')}
+              aria-label="调整图片宽度"
+            />
+            <button
+              type="button"
+              data-resize-handle="bottom"
+              className="collimind-markdown-image-block__handle collimind-markdown-image-block__handle--bottom"
+              onPointerDown={startResize('bottom')}
+              aria-label="调整图片高度"
+            />
+            <button
+              type="button"
+              data-resize-handle="corner"
+              className="collimind-markdown-image-block__handle collimind-markdown-image-block__handle--corner"
+              onPointerDown={startResize('corner')}
+              aria-label="同时调整图片宽高"
+            />
+          </>
+        )}
+      </div>
+      {attrs.caption && (
+        <div className="collimind-markdown-image-block__caption">{attrs.caption}</div>
+      )}
+    </div>
+  );
+}
+
+function MarkdownImageBlock(props: MarkdownImageBlockProps) {
+  if (!props.attrs.src) {
+    return <EmptyImageBlock {...props} />;
+  }
+
+  return <RenderedImageBlock {...props} />;
+}
+
+export const markdownImageBlockView = $view(markdownImageBlockSchema.node, (ctx) => {
+  const config = ctx.get(imageBlockConfig.key);
+
+  return (initialNode: any, view: any, getPos: () => number | undefined) => {
+    const dom = document.createElement('div');
+    dom.className = 'milkdown-image-block collimind-markdown-image-block';
+    dom.draggable = true;
+
+    let currentNode = initialNode;
+    let selected = false;
+    let reactRoot: Root | null = createRoot(dom);
+
+    const updateAttrs = (attrs: Partial<ImageBlockAttrs>) => {
+      if (!view.editable) {
+        return;
+      }
+
+      const pos = getPos();
+      if (pos == null) {
+        return;
+      }
+
+      view.dispatch(view.state.tr.setNodeMarkup(pos, undefined, {
+        ...currentNode.attrs,
+        ...attrs,
+      }));
+    };
+
+    const renderNode = () => {
+      reactRoot?.render(
+        <MarkdownImageBlock
+          attrs={currentNode.attrs as ImageBlockAttrs}
+          selected={selected}
+          readonly={!view.editable}
+          config={config}
+          updateAttrs={updateAttrs}
+        />
+      );
+    };
+
+    renderNode();
+
+    return {
+      dom,
+      update: (updatedNode: any) => {
+        if (updatedNode.type !== initialNode.type) {
+          return false;
+        }
+
+        currentNode = updatedNode;
+        renderNode();
+        return true;
+      },
+      stopEvent: (event: Event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+          return false;
+        }
+
+        return Boolean(
+          target.closest('.image-edit')
+          || target.closest('[data-resize-handle]')
+        );
+      },
+      selectNode: () => {
+        selected = true;
+        dom.classList.add('selected');
+        renderNode();
+      },
+      deselectNode: () => {
+        selected = false;
+        dom.classList.remove('selected');
+        renderNode();
+      },
+      destroy: () => {
+        if (reactRoot) {
+          const root = reactRoot;
+          reactRoot = null;
+          setTimeout(() => root.unmount(), 0);
+        }
+      },
+    };
+  };
+});

--- a/packages/drawnix/src/components/MarkdownEditor/index.tsx
+++ b/packages/drawnix/src/components/MarkdownEditor/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useCallback, memo, useState, useContext } from 'react';
 import { editorViewCtx } from '@milkdown/kit/core';
-import { replaceAll } from '@milkdown/kit/utils';
+import { insert, replaceAll } from '@milkdown/kit/utils';
 import { Crepe, CrepeFeature } from '@milkdown/crepe';
 import { Milkdown, MilkdownProvider, useEditor } from '@milkdown/react';
 import '@milkdown/crepe/theme/common/style.css';
@@ -11,6 +11,7 @@ import { AssetContext } from '../../contexts/asset-context-instance';
 import { AssetType, SelectionMode } from '../../types/asset.types';
 import { MediaLibraryModal } from '../media-library';
 import { assetEmbedPlugins } from './asset-embed-plugin';
+import { markdownImageBlockPlugins } from './image-block-plugin';
 import './MarkdownEditor.css';
 
 /** 编辑器模式 */
@@ -62,6 +63,7 @@ function handleImageUpload(file: File): Promise<string> {
 interface InternalEditorRef {
   getMarkdown: () => string;
   setMarkdown: (markdown: string) => void;
+  insertMarkdown: (markdown: string) => void;
   focus: () => void;
 }
 
@@ -113,6 +115,8 @@ function CrepeEditorCore({ markdown, onChange, placeholder, readOnly, editorRef,
       },
     });
 
+    crepe.editor.use(markdownImageBlockPlugins);
+
     // 注册 asset-embed 插件（remark + schema + view）
     if (enableAssetEmbeds) {
       crepe.editor.use(assetEmbedPlugins);
@@ -149,6 +153,9 @@ function CrepeEditorCore({ markdown, onChange, placeholder, readOnly, editorRef,
       getMarkdown: () => lastMarkdownRef.current,
       setMarkdown: (md: string) => {
         try { lastMarkdownRef.current = md; crepe.editor?.action(replaceAll(md)); } catch { /* 忽略 */ }
+      },
+      insertMarkdown: (md: string) => {
+        try { crepe.editor?.action(insert(md)); } catch { /* 忽略 */ }
       },
       focus: () => {
         try { crepe.editor?.ctx.get(editorViewCtx)?.focus(); } catch { /* 忽略 */ }
@@ -297,11 +304,13 @@ export const MarkdownEditor = memo(forwardRef<MarkdownEditorRef, MarkdownEditorP
         return;
       }
 
-      const prefix = current && !current.endsWith('\n') ? '\n\n' : current ? '\n' : '';
-      const next = `${current}${prefix}${snippet}\n`;
-      setSourceContent(next);
-      editorRef.current?.setMarkdown(next);
-      onChange?.(next);
+      editorRef.current?.insertMarkdown(snippet);
+      requestAnimationFrame(() => {
+        const next = editorRef.current?.getMarkdown();
+        if (typeof next === 'string') {
+          setSourceContent(next);
+        }
+      });
     }, [markdown, mode, onChange, sourceMarkdown]);
 
     useImperativeHandle(ref, () => ({

--- a/packages/drawnix/src/utils/__tests__/markdown-image-blocks.test.ts
+++ b/packages/drawnix/src/utils/__tests__/markdown-image-blocks.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMarkdownImageTitle,
+  parseMarkdownImageTitle,
+  parseMarkdownImageAlt,
+} from '../markdown-image-blocks';
+
+describe('markdown-image-blocks', () => {
+  it('builds and parses width and height metadata', () => {
+    const title = buildMarkdownImageTitle({ width: 320, height: 180 });
+
+    expect(title).toBe('opentu-image:w=320&h=180');
+    expect(parseMarkdownImageTitle(title)).toEqual({
+      caption: '',
+      width: 320,
+      height: 180,
+    });
+  });
+
+  it('preserves caption when width and height metadata are encoded in title', () => {
+    const title = buildMarkdownImageTitle({
+      width: 480,
+      height: 240,
+      caption: '示例说明',
+    });
+
+    expect(parseMarkdownImageTitle(title)).toEqual({
+      caption: '示例说明',
+      width: 480,
+      height: 240,
+    });
+  });
+
+  it('treats plain title as caption when there is no metadata prefix', () => {
+    expect(parseMarkdownImageTitle('普通标题')).toEqual({
+      caption: '普通标题',
+      width: undefined,
+      height: undefined,
+    });
+  });
+
+  it('parses asset image alt text and keeps normal alt text intact', () => {
+    expect(parseMarkdownImageAlt('image|封面图')).toEqual({
+      assetType: 'image',
+      label: '封面图',
+      rawAlt: 'image|封面图',
+      isAssetAlt: true,
+    });
+
+    expect(parseMarkdownImageAlt('普通图片说明')).toEqual({
+      assetType: null,
+      label: '普通图片说明',
+      rawAlt: '普通图片说明',
+      isAssetAlt: false,
+    });
+  });
+});

--- a/packages/drawnix/src/utils/markdown-image-blocks.ts
+++ b/packages/drawnix/src/utils/markdown-image-blocks.ts
@@ -1,0 +1,111 @@
+const IMAGE_TITLE_META_PREFIX = 'opentu-image:';
+
+export interface MarkdownImageTitleMeta {
+  caption: string;
+  width?: number;
+  height?: number;
+}
+
+export interface ParsedMarkdownImageAlt {
+  assetType: string | null;
+  label: string;
+  rawAlt: string;
+  isAssetAlt: boolean;
+}
+
+function parsePositiveInteger(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+export function buildMarkdownImageTitle(meta: {
+  width?: number | null;
+  height?: number | null;
+  caption?: string | null;
+}): string | undefined {
+  const width = parsePositiveInteger(meta.width == null ? null : String(meta.width));
+  const height = parsePositiveInteger(meta.height == null ? null : String(meta.height));
+  const caption = (meta.caption || '').trim();
+
+  if (!width && !height) {
+    return caption || undefined;
+  }
+
+  const params = new URLSearchParams();
+  if (width) {
+    params.set('w', String(width));
+  }
+  if (height) {
+    params.set('h', String(height));
+  }
+  if (caption) {
+    params.set('caption', caption);
+  }
+
+  return `${IMAGE_TITLE_META_PREFIX}${params.toString()}`;
+}
+
+export function parseMarkdownImageTitle(title?: string | null): MarkdownImageTitleMeta {
+  const normalized = (title || '').trim();
+
+  if (!normalized) {
+    return { caption: '', width: undefined, height: undefined };
+  }
+
+  if (!normalized.startsWith(IMAGE_TITLE_META_PREFIX)) {
+    return { caption: normalized, width: undefined, height: undefined };
+  }
+
+  const params = new URLSearchParams(normalized.slice(IMAGE_TITLE_META_PREFIX.length));
+  return {
+    caption: params.get('caption') || '',
+    width: parsePositiveInteger(params.get('w')),
+    height: parsePositiveInteger(params.get('h')),
+  };
+}
+
+export function parseMarkdownImageAlt(rawAlt?: string | null): ParsedMarkdownImageAlt {
+  const normalized = (rawAlt || '').trim();
+  const pipeIndex = normalized.indexOf('|');
+
+  if (pipeIndex <= 0) {
+    return {
+      assetType: null,
+      label: normalized,
+      rawAlt: normalized,
+      isAssetAlt: false,
+    };
+  }
+
+  const assetType = normalized.slice(0, pipeIndex).trim();
+  const label = normalized.slice(pipeIndex + 1).trim();
+
+  if (!assetType || !label) {
+    return {
+      assetType: null,
+      label: normalized,
+      rawAlt: normalized,
+      isAssetAlt: false,
+    };
+  }
+
+  return {
+    assetType,
+    label,
+    rawAlt: normalized,
+    isAssetAlt: true,
+  };
+}
+
+export function isNumericImageRatioAlt(rawAlt?: string | null): boolean {
+  const normalized = (rawAlt || '').trim();
+  return /^-?\d+(?:\.\d+)?$/.test(normalized);
+}


### PR DESCRIPTION
## Summary
- unify note images inserted from the + picker and media library into the same editable image block behavior
- support width-only, height-only, and freeform width+height resizing with persistent markdown metadata
- allow inserted images to sit side by side in one row and insert at the current caret position in WYSIWYG mode

## Test Plan
- pnpm exec vitest run packages/drawnix/src/utils/__tests__/markdown-image-blocks.test.ts packages/drawnix/src/utils/__tests__/markdown-asset-embeds.test.ts
- env NX_DAEMON=false pnpm start
- manual check at http://localhost:7200/ for + inserted images and media-library images