### PR TITLE
feat(pen): add keyboard shortcuts during pen creation

### DIFF
--- a/packages/drawnix/src/plugins/pen/__tests__/with-pen-create.test.ts
+++ b/packages/drawnix/src/plugins/pen/__tests__/with-pen-create.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PlaitBoard } from '@plait/core';
+import { PenShape } from '../type';
+
+const {
+  insertNodeMock,
+  clearSelectedElementMock,
+  addSelectedElementMock,
+} = vi.hoisted(() => ({
+  insertNodeMock: vi.fn((board: TestBoard, node: unknown) => {
+    board.children.push(node);
+  }),
+  clearSelectedElementMock: vi.fn(),
+  addSelectedElementMock: vi.fn(),
+}));
+
+vi.mock('@plait/core', () => ({
+  DEFAULT_COLOR: '#000000',
+  ThemeColorMode: {
+    default: 'default',
+    colorful: 'colorful',
+    soft: 'soft',
+    retro: 'retro',
+    dark: 'dark',
+    starry: 'starry',
+  },
+  PlaitBoard: {
+    getPointer: (board: TestBoard) => board.pointer,
+    getElementHost: (board: TestBoard) => board.host,
+  },
+  Transforms: {
+    insertNode: insertNodeMock,
+  },
+  toViewBoxPoint: (_board: TestBoard, point: [number, number]) => point,
+  toHostPoint: (_board: TestBoard, x: number, y: number) => [x, y],
+  throttleRAF: (_board: TestBoard, _key: string, callback: () => void) => callback(),
+  clearSelectedElement: clearSelectedElementMock,
+  addSelectedElement: addSelectedElementMock,
+  createG: () => document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+}));
+
+vi.mock('../utils', () => ({
+  createPenPath: (_board: TestBoard, anchors: unknown[], closed = false) => ({
+    id: 'pen-path-1',
+    type: 'pen-path',
+    anchors,
+    closed,
+  }),
+  isHitStartAnchor: () => false,
+  updatePenPathPoints: vi.fn(),
+}));
+
+vi.mock('../bezier-utils', () => ({
+  createSymmetricHandles: vi.fn(),
+  distanceBetweenPoints: () => 0,
+}));
+
+vi.mock('../pen.generator', () => ({
+  drawPenPreview: (anchors: unknown[]) => {
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    g.classList.add('pen-preview');
+    anchors.forEach(() => {
+      const anchor = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      anchor.classList.add('pen-anchor');
+      g.appendChild(anchor);
+    });
+    return g;
+  },
+}));
+
+vi.mock('../pen-settings', () => ({
+  getPenSettings: () => ({
+    defaultAnchorType: 'smooth',
+  }),
+}));
+
+import { withPenCreate } from '../with-pen-create';
+
+type TestBoard = PlaitBoard & {
+  pointer: string;
+  children: unknown[];
+  host: SVGGElement;
+  pointerDown: (event: PointerEvent) => void;
+  pointerMove: (event: PointerEvent) => void;
+  pointerUp: (event: PointerEvent) => void;
+  globalPointerUp: (event: PointerEvent) => void;
+  keyDown: (event: KeyboardEvent) => void;
+  globalKeyDown: (event: KeyboardEvent) => void;
+};
+
+function createBoard(): TestBoard {
+  const host = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  return {
+    pointer: PenShape.pen,
+    children: [],
+    host,
+    pointerDown: vi.fn(),
+    pointerMove: vi.fn(),
+    pointerUp: vi.fn(),
+    globalPointerUp: vi.fn(),
+    keyDown: vi.fn(),
+    globalKeyDown: vi.fn(),
+  } as unknown as TestBoard;
+}
+
+function createPointerEvent(x: number, y: number, target: EventTarget | null): PointerEvent {
+  return {
+    x,
+    y,
+    target,
+  } as PointerEvent;
+}
+
+function addAnchor(board: TestBoard, x: number, y: number) {
+  const event = createPointerEvent(x, y, board.host);
+  board.pointerDown(event);
+  board.pointerUp(event);
+}
+
+function getPreviewAnchorCount(board: TestBoard) {
+  return board.host.querySelectorAll('.pen-preview .pen-anchor').length;
+}
+
+function createKeyboardEvent(
+  key: string,
+  target?: EventTarget | null
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key });
+  if (target !== undefined) {
+    Object.defineProperty(event, 'target', {
+      configurable: true,
+      value: target,
+    });
+  }
+  return event;
+}
+
+describe('withPenCreate', () => {
+  beforeEach(() => {
+    insertNodeMock.mockClear();
+    clearSelectedElementMock.mockClear();
+    addSelectedElementMock.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it('removes the last anchor when Backspace is pressed via globalKeyDown during creation', () => {
+    const board = withPenCreate(createBoard()) as TestBoard;
+
+    addAnchor(board, 100, 100);
+    addAnchor(board, 200, 120);
+
+    expect(getPreviewAnchorCount(board)).toBe(2);
+
+    board.globalKeyDown(createKeyboardEvent('Backspace'));
+
+    expect(getPreviewAnchorCount(board)).toBe(1);
+  });
+
+  it('finishes the path when Enter is pressed via globalKeyDown during creation', () => {
+    const board = withPenCreate(createBoard()) as TestBoard;
+
+    addAnchor(board, 100, 100);
+    addAnchor(board, 200, 120);
+
+    expect(getPreviewAnchorCount(board)).toBe(2);
+
+    board.globalKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+    expect(insertNodeMock).toHaveBeenCalledTimes(1);
+    expect(board.children).toHaveLength(1);
+    expect(getPreviewAnchorCount(board)).toBe(0);
+  });
+
+  it('does not handle Backspace or Enter when the event target is an input element', () => {
+    const board = withPenCreate(createBoard()) as TestBoard;
+    const input = document.createElement('input');
+
+    addAnchor(board, 100, 100);
+    addAnchor(board, 200, 120);
+
+    board.globalKeyDown(createKeyboardEvent('Backspace', input));
+    expect(getPreviewAnchorCount(board)).toBe(2);
+    expect(insertNodeMock).not.toHaveBeenCalled();
+
+    board.globalKeyDown(createKeyboardEvent('Enter', input));
+    expect(getPreviewAnchorCount(board)).toBe(2);
+    expect(insertNodeMock).not.toHaveBeenCalled();
+    expect(board.children).toHaveLength(0);
+  });
+});

--- a/packages/drawnix/src/plugins/pen/with-pen-create.ts
+++ b/packages/drawnix/src/plugins/pen/with-pen-create.ts
@@ -295,7 +295,68 @@ function checkAndFinishOnToolSwitch(board: PlaitBoard) {
  * 扩展钢笔工具创建功能
  */
 export const withPenCreate = (board: PlaitBoard) => {
-  const { pointerDown, pointerMove, pointerUp, globalPointerUp, keyDown } = board;
+  const { pointerDown, pointerMove, pointerUp, globalPointerUp, keyDown, globalKeyDown } = board;
+
+  const isEditableTarget = (target: EventTarget | null): boolean => {
+    return (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    );
+  };
+
+  const handlePenShortcut = (event: KeyboardEvent): boolean => {
+    if (event.defaultPrevented || !isPenPointerType(board) || isEditableTarget(event.target)) {
+      return false;
+    }
+
+    const state = getPenState(board);
+    if (!state.isCreating) {
+      return false;
+    }
+
+    // Enter 键完成路径
+    if (event.key === 'Enter') {
+      finishPath(board, false);
+      event.preventDefault();
+      return true;
+    }
+
+    // Escape 键取消创建
+    if (event.key === 'Escape') {
+      resetPenState(board);
+      event.preventDefault();
+      return true;
+    }
+
+    // Cmd+Z / Ctrl+Z 撤销上一个锚点（在钢笔创建过程中）
+    if (isHotkey(['mod+z'], { byKey: true })(event)) {
+      if (state.anchors.length > 0) {
+        state.anchors.pop();
+        updatePreview(board);
+      }
+      if (state.anchors.length === 0) {
+        resetPenState(board);
+      }
+      event.preventDefault();
+      return true;
+    }
+
+    // Backspace/Delete 删除最后一个锚点
+    if (event.key === 'Backspace' || event.key === 'Delete') {
+      if (state.anchors.length > 0) {
+        state.anchors.pop();
+        updatePreview(board);
+      }
+      if (state.anchors.length === 0) {
+        resetPenState(board);
+      }
+      event.preventDefault();
+      return true;
+    }
+
+    return false;
+  };
 
   board.pointerDown = (event: PointerEvent) => {
     // 检测工具切换，如果正在创建路径且切换到其他工具，完成或取消
@@ -418,54 +479,17 @@ export const withPenCreate = (board: PlaitBoard) => {
     globalPointerUp(event);
   };
 
+  board.globalKeyDown = (event: KeyboardEvent) => {
+    if (handlePenShortcut(event)) {
+      return;
+    }
+    globalKeyDown(event);
+  };
+
   board.keyDown = (event: KeyboardEvent) => {
-    if (!isPenPointerType(board)) {
-      keyDown(event);
+    if (handlePenShortcut(event)) {
       return;
     }
-
-    const state = getPenState(board);
-
-    // Enter 键完成路径
-    if (event.key === 'Enter' && state.isCreating) {
-      finishPath(board, false);
-      event.preventDefault();
-      return;
-    }
-
-    // Escape 键取消创建
-    if (event.key === 'Escape' && state.isCreating) {
-      resetPenState(board);
-      event.preventDefault();
-      return;
-    }
-
-    // Cmd+Z / Ctrl+Z 撤销上一个锚点（在钢笔创建过程中）
-    if (isHotkey(['mod+z'], { byKey: true })(event) && state.isCreating) {
-      if (state.anchors.length > 0) {
-        state.anchors.pop();
-        updatePreview(board);
-      }
-      if (state.anchors.length === 0) {
-        resetPenState(board);
-      }
-      event.preventDefault();
-      return;
-    }
-
-    // Backspace/Delete 删除最后一个锚点
-    if ((event.key === 'Backspace' || event.key === 'Delete') && state.isCreating) {
-      if (state.anchors.length > 0) {
-        state.anchors.pop();
-        updatePreview(board);
-      }
-      if (state.anchors.length === 0) {
-        resetPenState(board);
-      }
-      event.preventDefault();
-      return;
-    }
-
     keyDown(event);
   };
 

--- a/packages/drawnix/src/plugins/with-hotkey.test.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PlaitBoard } from '@plait/core';
+
+const {
+  updatePointerTypeMock,
+  setCreationModeMock,
+  updateAppStateMock,
+  globalKeyDownMock,
+  keyDownMock,
+  getMovingPointInBoardMock,
+  isMovingPointInBoardMock,
+  hasBeenTextEditingMock,
+  getSelectedElementsMock,
+} = vi.hoisted(() => ({
+  updatePointerTypeMock: vi.fn(),
+  setCreationModeMock: vi.fn(),
+  updateAppStateMock: vi.fn(),
+  globalKeyDownMock: vi.fn(),
+  keyDownMock: vi.fn(),
+  getMovingPointInBoardMock: vi.fn(),
+  isMovingPointInBoardMock: vi.fn(),
+  hasBeenTextEditingMock: vi.fn(),
+  getSelectedElementsMock: vi.fn(),
+}));
+
+vi.mock('@plait/core', () => ({
+  BoardTransforms: {
+    updatePointerType: updatePointerTypeMock,
+  },
+  getSelectedElements: getSelectedElementsMock,
+  PlaitBoard: {
+    getMovingPointInBoard: getMovingPointInBoardMock,
+    isMovingPointInBoard: isMovingPointInBoardMock,
+    hasBeenTextEditing: hasBeenTextEditingMock,
+    isPointer: vi.fn(),
+  },
+  PlaitPointerType: {
+    hand: 'hand',
+    selection: 'selection',
+  },
+}));
+
+vi.mock('@plait/common', () => ({
+  BoardCreationMode: {
+    drawing: 'drawing',
+    dnd: 'dnd',
+  },
+  setCreationMode: setCreationModeMock,
+}));
+
+vi.mock('@plait/mind', () => ({
+  MindPointerType: {
+    mind: 'mind',
+  },
+}));
+
+vi.mock('./freehand/type', () => ({
+  FreehandShape: {
+    feltTipPen: 'felt-tip-pen',
+    eraser: 'eraser',
+    laserPointer: 'laser-pointer',
+  },
+}));
+
+vi.mock('./pen/type', () => ({
+  PenShape: {
+    pen: 'pen',
+  },
+}));
+
+vi.mock('@plait/draw', () => ({
+  ArrowLineShape: {
+    straight: 'arrow-straight',
+  },
+  BasicShapes: {
+    rectangle: 'rectangle',
+    ellipse: 'ellipse',
+    text: 'text',
+  },
+}));
+
+vi.mock('../utils/image', () => ({
+  addImage: vi.fn(),
+  saveAsImage: vi.fn(),
+}));
+
+vi.mock('../data/json', () => ({
+  saveAsJSON: vi.fn(),
+}));
+
+vi.mock('../transforms/alignment', () => ({
+  AlignmentTransforms: {
+    alignLeft: vi.fn(),
+    alignCenter: vi.fn(),
+    alignRight: vi.fn(),
+    alignTop: vi.fn(),
+    alignMiddle: vi.fn(),
+    alignBottom: vi.fn(),
+  },
+}));
+
+vi.mock('../transforms/distribute', () => ({
+  DistributeTransforms: {
+    distributeHorizontal: vi.fn(),
+    distributeVertical: vi.fn(),
+    autoArrange: vi.fn(),
+  },
+}));
+
+vi.mock('../transforms/boolean', () => ({
+  BooleanTransforms: {
+    union: vi.fn(),
+    subtract: vi.fn(),
+    intersect: vi.fn(),
+    exclude: vi.fn(),
+    flatten: vi.fn(),
+  },
+}));
+
+vi.mock('./with-frame', () => ({
+  FramePointerType: 'frame',
+}));
+
+vi.mock('./with-lasso-selection', () => ({
+  LassoPointerType: 'lasso',
+}));
+
+import { buildDrawnixHotkeyPlugin } from './with-hotkey';
+
+type TestBoard = PlaitBoard & {
+  globalKeyDown: (event: KeyboardEvent) => void;
+  keyDown: (event: KeyboardEvent) => void;
+  undo: () => void;
+  redo: () => void;
+};
+
+function createBoard(): TestBoard {
+  return {
+    globalKeyDown: globalKeyDownMock,
+    keyDown: keyDownMock,
+    undo: vi.fn(),
+    redo: vi.fn(),
+  } as unknown as TestBoard;
+}
+
+describe('buildDrawnixHotkeyPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMovingPointInBoardMock.mockReturnValue([0, 0]);
+    isMovingPointInBoardMock.mockReturnValue(false);
+    hasBeenTextEditingMock.mockReturnValue(false);
+    getSelectedElementsMock.mockReturnValue([]);
+  });
+
+  it('switches to vector pen on Shift+P', () => {
+    const board = buildDrawnixHotkeyPlugin(updateAppStateMock)(createBoard()) as TestBoard;
+    const event = new KeyboardEvent('keydown', {
+      key: 'P',
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    board.globalKeyDown(event);
+
+    expect(setCreationModeMock).toHaveBeenCalledWith(board, 'drawing');
+    expect(updatePointerTypeMock).toHaveBeenCalledWith(board, 'pen');
+    expect(updateAppStateMock).toHaveBeenCalledWith({ pointer: 'pen' });
+    expect(event.defaultPrevented).toBe(true);
+    expect(globalKeyDownMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -168,6 +168,19 @@ export const buildDrawnixHotkeyPlugin = (
 
         // Note: 复制图片粘贴功能由 with-image.tsx 中的 insertFragment 方法处理
         // 不需要在这里手动处理 Ctrl+V，让 Plait 框架的原生粘贴机制工作
+        if (
+          !event.altKey &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          isHotkey(['shift+p'], { byKey: true })(event)
+        ) {
+          setCreationMode(board, BoardCreationMode.drawing);
+          BoardTransforms.updatePointerType(board, PenShape.pen);
+          updateAppState({ pointer: PenShape.pen });
+          event.preventDefault();
+          return;
+        }
+
         if (!event.altKey && !event.metaKey && !event.ctrlKey && !event.shiftKey) {
           if (event.key === 'l') {
             setCreationMode(board, BoardCreationMode.drawing);
@@ -208,17 +221,10 @@ export const buildDrawnixHotkeyPlugin = (
             updateAppState({ pointer: FreehandShape.eraser });
           }
           if (event.key === 'p') {
-            if (event.shiftKey) {
-              // Shift+P for vector pen tool
-              setCreationMode(board, BoardCreationMode.drawing);
-              BoardTransforms.updatePointerType(board, PenShape.pen);
-              updateAppState({ pointer: PenShape.pen });
-            } else {
-              // P for freehand pen
-              setCreationMode(board, BoardCreationMode.drawing);
-              BoardTransforms.updatePointerType(board, FreehandShape.feltTipPen);
-              updateAppState({ pointer: FreehandShape.feltTipPen });
-            }
+            // P for freehand pen
+            setCreationMode(board, BoardCreationMode.drawing);
+            BoardTransforms.updatePointerType(board, FreehandShape.feltTipPen);
+            updateAppState({ pointer: FreehandShape.feltTipPen });
           }
           if (event.key === 'a' && !isHotkey(['mod+a'])(event)) {
             // will trigger editing text


### PR DESCRIPTION
## Summary
- support Enter, Escape, Backspace/Delete, and mod+z while creating a vector pen path via global keyboard handling
- restore `Shift+P` as the vector pen shortcut while keeping `P` mapped to the freehand pen
- add focused tests for pen creation shortcuts and the pen hotkey switch

## Test Plan
- `cd packages/drawnix && pnpm vitest run src/plugins/pen/__tests__/with-pen-create.test.ts src/plugins/with-hotkey.test.ts`