### PR TITLE
fix: autosize ai input bar from four to six rows

### DIFF
--- a/apps/web-e2e/src/features/features.spec.ts
+++ b/apps/web-e2e/src/features/features.spec.ts
@@ -3,9 +3,94 @@
  * 功能测试 - 基于实际页面元素和状态
  * 仅 3 次页面加载，覆盖所有核心功能
  */
+import type { Locator } from '@playwright/test';
 import { test, expect } from '../fixtures/test-base';
 
+async function getTextareaMetrics(textarea: Locator) {
+  return textarea.evaluate((node) => {
+    const textareaElement = node as HTMLTextAreaElement;
+    const styles = window.getComputedStyle(textareaElement);
+    const lineHeight = parseFloat(styles.lineHeight);
+    const paddingTop = parseFloat(styles.paddingTop);
+    const paddingBottom = parseFloat(styles.paddingBottom);
+    const clientHeight = textareaElement.clientHeight;
+    const scrollHeight = textareaElement.scrollHeight;
+
+    return {
+      clientHeight,
+      scrollHeight,
+      lineHeight,
+      paddingTop,
+      paddingBottom,
+      visibleRows:
+        (clientHeight - paddingTop - paddingBottom) / Math.max(lineHeight, 1),
+    };
+  });
+}
+
 test.describe('@feature 功能测试', () => {
+  test('AI 输入栏：展开后默认 4 行并自增到 6 行', async ({ page }) => {
+    await page.goto('/');
+    const drawnix = page.locator('.drawnix');
+    await expect(drawnix).toBeVisible({ timeout: 10000 });
+
+    const aiInput = page.locator('[data-testid="ai-input-textarea"]');
+    await expect(aiInput).toBeVisible();
+
+    const collapsedMetrics = await getTextareaMetrics(aiInput);
+    expect(collapsedMetrics.visibleRows).toBeGreaterThan(0.8);
+    expect(collapsedMetrics.visibleRows).toBeLessThan(1.4);
+
+    await aiInput.click();
+    await page.waitForTimeout(150);
+
+    const expandedMetrics = await getTextareaMetrics(aiInput);
+    expect(expandedMetrics.visibleRows).toBeGreaterThan(3.6);
+    expect(expandedMetrics.visibleRows).toBeLessThan(4.4);
+
+    await aiInput.fill('这是一段用于触发输入框自动换行的测试文本'.repeat(10));
+    await page.waitForTimeout(150);
+
+    const softWrapMetrics = await getTextareaMetrics(aiInput);
+    expect(softWrapMetrics.visibleRows).toBeGreaterThan(4.1);
+    expect(softWrapMetrics.visibleRows).toBeLessThan(6.4);
+
+    await aiInput.fill(
+      '第一行\n第二行\n第三行\n第四行\n第五行\n第六行\n第七行\n第八行'
+    );
+    await page.waitForTimeout(150);
+
+    const cappedMetrics = await getTextareaMetrics(aiInput);
+    expect(cappedMetrics.visibleRows).toBeGreaterThan(5.4);
+    expect(cappedMetrics.visibleRows).toBeLessThan(6.4);
+    expect(cappedMetrics.scrollHeight).toBeGreaterThan(
+      cappedMetrics.clientHeight + 1
+    );
+
+    await aiInput.fill('');
+    await page.waitForTimeout(150);
+
+    const clearedMetrics = await getTextareaMetrics(aiInput);
+    expect(clearedMetrics.visibleRows).toBeGreaterThan(3.6);
+    expect(clearedMetrics.visibleRows).toBeLessThan(4.4);
+
+    await aiInput.evaluate((node) => {
+      (node as HTMLTextAreaElement).blur();
+    });
+    await page.waitForTimeout(150);
+
+    const collapsedAgainMetrics = await getTextareaMetrics(aiInput);
+    expect(collapsedAgainMetrics.visibleRows).toBeGreaterThan(0.8);
+    expect(collapsedAgainMetrics.visibleRows).toBeLessThan(1.4);
+
+    await aiInput.click();
+    await page.waitForTimeout(150);
+
+    const refocusedMetrics = await getTextareaMetrics(aiInput);
+    expect(refocusedMetrics.visibleRows).toBeGreaterThan(3.6);
+    expect(refocusedMetrics.visibleRows).toBeLessThan(4.4);
+  });
+
   /**
    * 测试1：主画布交互功能
    * AI输入栏、模型选择、灵感板、绘图工具

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -214,6 +214,10 @@ interface SelectedContent {
   height?: number; // 图片/视频高度
 }
 
+const COLLAPSED_INPUT_ROWS = 1;
+const DEFAULT_EXPANDED_INPUT_ROWS = 4;
+const MAX_EXPANDED_INPUT_ROWS = 6;
+
 function getSelectionKeyForModel(
   model: Pick<ModelConfig, 'id' | 'selectionKey' | 'sourceProfileId'>
 ): string {
@@ -3511,6 +3515,51 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       []
     );
 
+    const shouldKeepExpanded =
+      isFocused || allContent.length > 0 || isPromptOptimizeOpen;
+
+    const syncTextareaHeight = useCallback(() => {
+      const textarea = inputRef.current;
+      if (!textarea) {
+        return;
+      }
+
+      if (!shouldKeepExpanded) {
+        textarea.style.height = '';
+        return;
+      }
+
+      const computedStyle = window.getComputedStyle(textarea);
+      const lineHeight = parseFloat(computedStyle.lineHeight);
+      const paddingTop = parseFloat(computedStyle.paddingTop);
+      const paddingBottom = parseFloat(computedStyle.paddingBottom);
+      const safeLineHeight = Number.isFinite(lineHeight) ? lineHeight : 0;
+      const safePaddingTop = Number.isFinite(paddingTop) ? paddingTop : 0;
+      const safePaddingBottom = Number.isFinite(paddingBottom)
+        ? paddingBottom
+        : 0;
+      const minHeight = Math.ceil(
+        safeLineHeight * DEFAULT_EXPANDED_INPUT_ROWS +
+          safePaddingTop +
+          safePaddingBottom
+      );
+      const maxHeight = Math.ceil(
+        safeLineHeight * MAX_EXPANDED_INPUT_ROWS +
+          safePaddingTop +
+          safePaddingBottom
+      );
+
+      textarea.style.height = 'auto';
+      textarea.style.height = `${Math.min(
+        maxHeight,
+        Math.max(minHeight, textarea.scrollHeight)
+      )}px`;
+    }, [shouldKeepExpanded]);
+
+    useEffect(() => {
+      syncTextareaHeight();
+    }, [prompt, shouldKeepExpanded, syncTextareaHeight]);
+
     const sendButtonTrackParams = useMemo(
       () =>
         JSON.stringify({
@@ -3534,8 +3583,6 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     const hasSelectedTextContent = selectedContent.some(
       (item) => item.type === 'text' && item.text?.trim()
     );
-    const shouldKeepExpanded =
-      isFocused || allContent.length > 0 || isPromptOptimizeOpen;
 
     return (
       <div
@@ -3767,7 +3814,11 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                         generationType === 'image' ? 'image' : 'video'
                       } you want to create`
                 }
-                rows={shouldKeepExpanded ? 6 : 1}
+                rows={
+                  shouldKeepExpanded
+                    ? DEFAULT_EXPANDED_INPUT_ROWS
+                    : COLLAPSED_INPUT_ROWS
+                }
                 disabled={isSubmitting}
                 data-testid="ai-input-textarea"
               />

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -3767,7 +3767,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                         generationType === 'image' ? 'image' : 'video'
                       } you want to create`
                 }
-                rows={shouldKeepExpanded ? 4 : 1}
+                rows={shouldKeepExpanded ? 6 : 1}
                 disabled={isSubmitting}
                 data-testid="ai-input-textarea"
               />

--- a/packages/drawnix/src/components/ai-input-bar/ai-input-bar.scss
+++ b/packages/drawnix/src/components/ai-input-bar/ai-input-bar.scss
@@ -376,7 +376,7 @@ $vip-color: #E91E63;
 
     // 展开状态
     &--expanded {
-      max-height: 200px; // 最大高度限制
+      max-height: 260px; // 允许输入框扩展到 6 行，同时保留上方预览空间
     }
   }
 
@@ -617,7 +617,7 @@ $vip-color: #E91E63;
     resize: none;
     outline: none;
     min-height: 24px;
-    max-height: 120px;
+    max-height: calc(15px * 1.5 * 6 + 12px);
     overflow-y: auto;
     padding: 6px 12px;
     padding-right: 20px;
@@ -672,8 +672,8 @@ $vip-color: #E91E63;
 
     // When focused, expand height smoothly (controlled by parent container max-height)
     &--focused {
-      min-height: 80px; // 约 3-4 行
-      max-height: 160px; // 最大高度限制
+      min-height: calc(15px * 1.5 * 4 + 12px);
+      max-height: calc(15px * 1.5 * 6 + 12px);
     }
   }
 


### PR DESCRIPTION
## Summary
- keep the collapsed AI input bar at 1 row
- show 4 rows by default once expanded
- auto-grow with content up to 6 rows
- keep overflow scrolling inside the textarea after 6 rows

## Verification
- `pnpm exec tsc -p apps/web/tsconfig.app.json --noEmit`
- `pnpm exec tsc -p apps/web-e2e/tsconfig.json --noEmit`
- `pnpm exec playwright test -c apps/web-e2e/playwright.config.ts --project=chromium -g "AI 输入栏：展开后默认 4 行并自增到 6 行"`