### PR TITLE
fix: autosize ai input textarea

### DIFF
--- a/apps/web-e2e/src/smoke/smoke.spec.ts
+++ b/apps/web-e2e/src/smoke/smoke.spec.ts
@@ -47,6 +47,44 @@ test.describe('@smoke 核心功能验证', () => {
     await expect(aiInput).toBeVisible();
     await aiInput.fill('测试输入');
     await expect(aiInput).toHaveValue('测试输入');
+
+    const getTextareaMetrics = () =>
+      aiInput.evaluate((element) => {
+        const textarea = element as HTMLTextAreaElement;
+        const styles = window.getComputedStyle(textarea);
+        const fontSize = Number.parseFloat(styles.fontSize) || 15;
+        const lineHeight =
+          Number.parseFloat(styles.lineHeight) || fontSize * 1.5;
+        const verticalSpacing =
+          Number.parseFloat(styles.paddingTop) +
+          Number.parseFloat(styles.paddingBottom) +
+          Number.parseFloat(styles.borderTopWidth) +
+          Number.parseFloat(styles.borderBottomWidth);
+
+        return {
+          height: textarea.getBoundingClientRect().height,
+          fourRowsHeight: lineHeight * 4 + verticalSpacing,
+          sixRowsHeight: lineHeight * 6 + verticalSpacing,
+          overflowY: styles.overflowY,
+        };
+      });
+
+    await page.waitForTimeout(250);
+    const fourRowsMetrics = await getTextareaMetrics();
+    expect(
+      Math.abs(fourRowsMetrics.height - fourRowsMetrics.fourRowsHeight)
+    ).toBeLessThanOrEqual(2);
+
+    await aiInput.fill('第1行\n第2行\n第3行\n第4行\n第5行\n第6行\n第7行');
+    await page.waitForTimeout(250);
+    const maxRowsMetrics = await getTextareaMetrics();
+    expect(maxRowsMetrics.height).toBeGreaterThanOrEqual(
+      maxRowsMetrics.sixRowsHeight - 2
+    );
+    expect(maxRowsMetrics.height).toBeLessThanOrEqual(
+      maxRowsMetrics.sixRowsHeight + 2
+    );
+    expect(maxRowsMetrics.overflowY).toBe('auto');
     
     // 5. 模型选择器（必须通过）
     const modelSelector = page.getByRole('button', { name: /#/ }).first();

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -19,6 +19,7 @@
 import React, {
   useState,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useRef,
   useMemo,
@@ -242,6 +243,55 @@ function getPromptLengthBucket(length: number): string {
   if (length <= 300) return '101-300';
   if (length <= 800) return '301-800';
   return '800+';
+}
+
+const AI_INPUT_COLLAPSED_ROWS = 1;
+const AI_INPUT_EXPANDED_ROWS = 4;
+const AI_INPUT_MAX_ROWS = 6;
+const AI_INPUT_LINE_HEIGHT = 1.5;
+
+function getTextareaHeightForRows(
+  textarea: HTMLTextAreaElement,
+  rows: number
+) {
+  const styles = window.getComputedStyle(textarea);
+  const fontSize = Number.parseFloat(styles.fontSize) || 15;
+  const lineHeight =
+    Number.parseFloat(styles.lineHeight) || fontSize * AI_INPUT_LINE_HEIGHT;
+  const verticalPadding =
+    Number.parseFloat(styles.paddingTop) +
+    Number.parseFloat(styles.paddingBottom);
+  const verticalBorder =
+    Number.parseFloat(styles.borderTopWidth) +
+    Number.parseFloat(styles.borderBottomWidth);
+
+  return Math.ceil(lineHeight * rows + verticalPadding + verticalBorder);
+}
+
+function resizeAIInputTextarea(
+  textarea: HTMLTextAreaElement | null,
+  isExpanded: boolean
+) {
+  if (!textarea) return;
+
+  if (!isExpanded) {
+    textarea.style.height = '';
+    textarea.style.overflowY = '';
+    return;
+  }
+
+  const minHeight = getTextareaHeightForRows(
+    textarea,
+    AI_INPUT_EXPANDED_ROWS
+  );
+  const maxHeight = getTextareaHeightForRows(textarea, AI_INPUT_MAX_ROWS);
+
+  textarea.style.height = 'auto';
+  const contentHeight = textarea.scrollHeight;
+  const nextHeight = Math.min(Math.max(contentHeight, minHeight), maxHeight);
+
+  textarea.style.height = `${nextHeight}px`;
+  textarea.style.overflowY = contentHeight > maxHeight ? 'auto' : 'hidden';
 }
 
 function findMatchingSelectableModel(
@@ -3537,6 +3587,10 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     const shouldKeepExpanded =
       isFocused || allContent.length > 0 || isPromptOptimizeOpen;
 
+    useLayoutEffect(() => {
+      resizeAIInputTextarea(inputRef.current, shouldKeepExpanded);
+    }, [shouldKeepExpanded, prompt]);
+
     return (
       <div
         ref={containerRef}
@@ -3735,7 +3789,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
               <textarea
                 ref={inputRef}
                 className={classNames('ai-input-bar__input', {
-                  'ai-input-bar__input--focused': isFocused,
+                  'ai-input-bar__input--focused': shouldKeepExpanded,
                 })}
                 value={prompt}
                 onChange={handleInputChange}
@@ -3767,7 +3821,11 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                         generationType === 'image' ? 'image' : 'video'
                       } you want to create`
                 }
-                rows={shouldKeepExpanded ? 4 : 1}
+                rows={
+                  shouldKeepExpanded
+                    ? AI_INPUT_EXPANDED_ROWS
+                    : AI_INPUT_COLLAPSED_ROWS
+                }
                 disabled={isSubmitting}
                 data-testid="ai-input-textarea"
               />

--- a/packages/drawnix/src/components/ai-input-bar/ai-input-bar.scss
+++ b/packages/drawnix/src/components/ai-input-bar/ai-input-bar.scss
@@ -15,6 +15,21 @@ $gray-medium: #9CA3AF;
 $gray-dark: #6B7280;
 $text-dark: #1F2937;
 $vip-color: #E91E63;
+$ai-input-font-size: 15px;
+$ai-input-line-height-ratio: 1.5;
+$ai-input-line-height: $ai-input-font-size * $ai-input-line-height-ratio;
+$ai-input-vertical-padding: 12px;
+$ai-input-expanded-min-height: $ai-input-line-height * 4 + $ai-input-vertical-padding;
+$ai-input-expanded-max-height: $ai-input-line-height * 6 + $ai-input-vertical-padding;
+$ai-input-mobile-font-size: 14px;
+$ai-input-mobile-line-height: $ai-input-mobile-font-size * $ai-input-line-height-ratio;
+$ai-input-mobile-vertical-padding: 8px;
+$ai-input-mobile-expanded-min-height: $ai-input-mobile-line-height * 4 + $ai-input-mobile-vertical-padding;
+$ai-input-mobile-expanded-max-height: $ai-input-mobile-line-height * 6 + $ai-input-mobile-vertical-padding;
+$ai-input-small-font-size: 13px;
+$ai-input-small-line-height: $ai-input-small-font-size * $ai-input-line-height-ratio;
+$ai-input-small-expanded-min-height: $ai-input-small-line-height * 4 + $ai-input-mobile-vertical-padding;
+$ai-input-small-expanded-max-height: $ai-input-small-line-height * 6 + $ai-input-mobile-vertical-padding;
 
 .ai-input-bar {
   position: fixed;
@@ -549,8 +564,8 @@ $vip-color: #E91E63;
     bottom: 0;
     padding: 6px 12px;
     padding-right: 20px;
-    font-size: 15px;
-    line-height: 1.5;
+    font-size: $ai-input-font-size;
+    line-height: $ai-input-line-height-ratio;
     letter-spacing: normal;
     word-spacing: normal;
     white-space: pre-wrap;
@@ -607,8 +622,8 @@ $vip-color: #E91E63;
     width: 100%;
     border: none;
     background: transparent;
-    font-size: 15px;
-    line-height: 1.5;
+    font-size: $ai-input-font-size;
+    line-height: $ai-input-line-height-ratio;
     letter-spacing: normal;
     word-spacing: normal;
     text-rendering: auto;
@@ -617,13 +632,13 @@ $vip-color: #E91E63;
     resize: none;
     outline: none;
     min-height: 24px;
-    max-height: 120px;
-    overflow-y: auto;
+    max-height: $ai-input-expanded-max-height;
+    overflow-y: hidden;
     padding: 6px 12px;
     padding-right: 20px;
     margin: 0;
     font-family: 'PingFang SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    transition: all 0.2s ease;
+    transition: height 0.2s ease, min-height 0.2s ease, max-height 0.2s ease;
     position: relative;
     z-index: 2;
     box-sizing: border-box;
@@ -670,10 +685,10 @@ $vip-color: #E91E63;
       opacity: 0.6;
     }
 
-    // When focused, expand height smoothly (controlled by parent container max-height)
+    // Focused input starts at 4 rows and grows to 6 rows via JS auto-resize.
     &--focused {
-      min-height: 80px; // 约 3-4 行
-      max-height: 160px; // 最大高度限制
+      min-height: $ai-input-expanded-min-height;
+      max-height: $ai-input-expanded-max-height;
     }
   }
 
@@ -1528,9 +1543,14 @@ $vip-color: #E91E63;
     }
 
     &__input {
-      font-size: 14px;
+      font-size: $ai-input-mobile-font-size;
       padding: 4px 8px;
       min-height: 20px;
+
+      &--focused {
+        min-height: $ai-input-mobile-expanded-min-height;
+        max-height: $ai-input-mobile-expanded-max-height;
+      }
     }
 
     &__send-btn {
@@ -1596,7 +1616,12 @@ $vip-color: #E91E63;
     }
 
     &__input {
-      font-size: 13px;
+      font-size: $ai-input-small-font-size;
+
+      &--focused {
+        min-height: $ai-input-small-expanded-min-height;
+        max-height: $ai-input-small-expanded-max-height;
+      }
     }
 
     // 隐藏一些次要元素节省空间


### PR DESCRIPTION
## Summary
- make the AI input textarea default to 4 rows when expanded
- grow the textarea with content up to 6 rows, then enable internal scrolling
- add smoke coverage for the 4-row default and 6-row max behavior

## Verification
- pnpm exec nx run web:typecheck
- pnpm exec nx run web:build-app