### PR TITLE
fix: 修复生图插入画布链路因为时机或状态不同步

### DIFF
--- a/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
+++ b/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
@@ -1,0 +1,327 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAutoInsertToCanvas, clearInsertedTaskIds } from '../useAutoInsertToCanvas';
+import { TaskStatus, TaskType, type Task } from '../../types/task.types';
+import { IMAGE_GENERATION_ANCHOR_RETRY_EVENT } from '../../types/image-generation-anchor.types';
+
+const mocks = vi.hoisted(() => {
+  const taskListeners: Array<(event: any) => void> = [];
+  const completionListeners: Array<(event: any) => void> = [];
+  const taskState = {
+    tasks: [] as any[],
+  };
+
+  return {
+    board: null as any,
+    taskListeners,
+    completionListeners,
+    taskState,
+    quickInsert: vi.fn(),
+    markAsInserted: vi.fn(),
+    registerTask: vi.fn(),
+    startPostProcessing: vi.fn(),
+    completePostProcessing: vi.fn(),
+    failPostProcessing: vi.fn(),
+    clearTask: vi.fn(),
+    getPostProcessingStatus: vi.fn(),
+    retryTask: vi.fn(),
+  };
+});
+
+vi.mock('../../services/task-queue', () => {
+  const taskQueueService = {
+    getAllTasks: () => mocks.taskState.tasks,
+    getTask: (taskId: string) =>
+      mocks.taskState.tasks.find((task) => task.id === taskId),
+    markAsInserted: mocks.markAsInserted,
+    retryTask: mocks.retryTask,
+    observeTaskUpdates: () => ({
+      subscribe: (listener: (event: any) => void) => {
+        mocks.taskListeners.push(listener);
+        return {
+          unsubscribe: () => {
+            const index = mocks.taskListeners.indexOf(listener);
+            if (index >= 0) {
+              mocks.taskListeners.splice(index, 1);
+            }
+          },
+        };
+      },
+    }),
+  };
+
+  return {
+    getTaskQueueService: () => taskQueueService,
+    taskQueueService,
+  };
+});
+
+vi.mock('../../services/workflow-completion-service', () => ({
+  workflowCompletionService: {
+    registerTask: mocks.registerTask,
+    startPostProcessing: mocks.startPostProcessing,
+    completePostProcessing: mocks.completePostProcessing,
+    failPostProcessing: mocks.failPostProcessing,
+    clearTask: mocks.clearTask,
+    getPostProcessingStatus: mocks.getPostProcessingStatus,
+    isPostProcessingCompleted: vi.fn(() => true),
+    observeCompletionEvents: () => ({
+      subscribe: (listener: (event: any) => void) => {
+        mocks.completionListeners.push(listener);
+        return {
+          unsubscribe: () => {
+            const index = mocks.completionListeners.indexOf(listener);
+            if (index >= 0) {
+              mocks.completionListeners.splice(index, 1);
+            }
+          },
+        };
+      },
+    }),
+  },
+}));
+
+vi.mock('../../services/canvas-operations', () => ({
+  getCanvasBoard: () => mocks.board,
+  executeCanvasInsertion: vi.fn(),
+  insertAIFlow: vi.fn(),
+  insertImageGroup: vi.fn(),
+  parseSizeToPixels: vi.fn(() => ({ width: 512, height: 512 })),
+  quickInsert: mocks.quickInsert,
+}));
+
+vi.mock('../../data/audio', () => ({
+  AUDIO_CARD_DEFAULT_HEIGHT: 144,
+  AUDIO_CARD_DEFAULT_WIDTH: 360,
+}));
+
+vi.mock('../../plugins/with-image-generation-anchor', () => ({
+  ImageGenerationAnchorTransforms: {
+    getAnchorByTaskId: vi.fn(() => null),
+    getAnchorByBatchSlot: vi.fn(() => null),
+    getAnchorsByWorkflowId: vi.fn(() => []),
+    updateAnchor: vi.fn(),
+    updateGeometry: vi.fn(),
+  },
+}));
+
+vi.mock('../../plugins/with-workzone', () => ({
+  WorkZoneTransforms: {
+    getAllWorkZones: vi.fn(() => []),
+    updateWorkflow: vi.fn(),
+    removeWorkZone: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/media-result-handler', () => ({
+  isGridImageTask: vi.fn(() => false),
+  isInspirationBoardTask: vi.fn(() => false),
+  handleSplitAndInsertTask: vi.fn(),
+}));
+
+vi.mock('../../utils/selection-utils', () => ({
+  getInsertionPointBelowBottommostElement: vi.fn(() => [100, 100]),
+}));
+
+vi.mock('../../utils/frame-insertion-utils', () => ({
+  insertMediaIntoFrame: vi.fn(),
+}));
+
+function createCompletedImageTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    type: TaskType.IMAGE,
+    status: TaskStatus.COMPLETED,
+    params: {
+      prompt: '生成一张图',
+      size: '1:1',
+      autoInsertToCanvas: true,
+    },
+    result: {
+      url: '/__aitu_cache__/image/task-1.png',
+      format: 'png',
+      size: 123,
+    },
+    createdAt: 1,
+    updatedAt: 2,
+    completedAt: 2,
+    insertedToCanvas: false,
+    ...overrides,
+  };
+}
+
+function emitTaskEvent(task: Task, type: 'taskUpdated' | 'taskCreated' = 'taskUpdated') {
+  mocks.taskListeners.forEach((listener) => {
+    listener({
+      type,
+      task,
+      timestamp: Date.now(),
+    });
+  });
+}
+
+describe('useAutoInsertToCanvas', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clearInsertedTaskIds();
+    mocks.board = null;
+    mocks.taskListeners.length = 0;
+    mocks.completionListeners.length = 0;
+    mocks.taskState.tasks = [];
+    mocks.quickInsert.mockReset();
+    mocks.quickInsert.mockResolvedValue({
+      success: true,
+      data: {
+        insertedCount: 1,
+        items: [
+          {
+            type: 'image',
+            point: [100, 100],
+            elementId: 'image-1',
+            size: { width: 512, height: 512 },
+          },
+        ],
+        firstElementId: 'image-1',
+        firstElementPosition: [100, 100],
+        firstElementSize: { width: 512, height: 512 },
+      },
+    });
+    mocks.markAsInserted.mockReset();
+    mocks.registerTask.mockReset();
+    mocks.startPostProcessing.mockReset();
+    mocks.completePostProcessing.mockReset();
+    mocks.failPostProcessing.mockReset();
+    mocks.clearTask.mockReset();
+    mocks.getPostProcessingStatus.mockReset();
+    mocks.getPostProcessingStatus.mockReturnValue(undefined);
+    mocks.retryTask.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries pending completed inserts when the canvas board is not ready yet', async () => {
+    const task = createCompletedImageTask();
+    mocks.taskState.tasks = [task];
+    renderHook(() =>
+      useAutoInsertToCanvas({
+        enabled: true,
+        groupSimilarTasks: true,
+        groupTimeWindow: 10,
+      })
+    );
+
+    act(() => {
+      emitTaskEvent(task);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(mocks.quickInsert).not.toHaveBeenCalled();
+
+    mocks.board = { children: [] };
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(mocks.quickInsert).toHaveBeenCalledTimes(1);
+    expect(mocks.markAsInserted).toHaveBeenCalledWith(task.id, 'auto_insert');
+    expect(mocks.completePostProcessing).toHaveBeenCalledWith(
+      task.id,
+      1,
+      [100, 100],
+      'image-1',
+      { width: 512, height: 512 }
+    );
+  });
+
+  it('recovers completed uninserted tasks that already exist before subscribing', async () => {
+    const task = createCompletedImageTask({ id: 'task-restored' });
+    mocks.board = { children: [] };
+    mocks.taskState.tasks = [task];
+
+    renderHook(() =>
+      useAutoInsertToCanvas({
+        enabled: true,
+        groupSimilarTasks: true,
+        groupTimeWindow: 10,
+      })
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(mocks.quickInsert).toHaveBeenCalledTimes(1);
+    expect(mocks.markAsInserted).toHaveBeenCalledWith(task.id, 'auto_insert');
+  });
+
+  it('does not retry a completed task that is already marked inserted', async () => {
+    const task = createCompletedImageTask({ insertedToCanvas: true });
+    mocks.board = { children: [] };
+    mocks.taskState.tasks = [task];
+
+    renderHook(() =>
+      useAutoInsertToCanvas({
+        enabled: true,
+        groupSimilarTasks: true,
+        groupTimeWindow: 10,
+      })
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(IMAGE_GENERATION_ANCHOR_RETRY_EVENT, {
+          detail: { taskId: task.id },
+        })
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(mocks.quickInsert).not.toHaveBeenCalled();
+    expect(mocks.clearTask).not.toHaveBeenCalled();
+    expect(mocks.markAsInserted).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a completed task whose post-processing already completed', async () => {
+    const task = createCompletedImageTask();
+    mocks.board = { children: [] };
+    mocks.taskState.tasks = [task];
+    mocks.getPostProcessingStatus.mockReturnValue({
+      taskId: task.id,
+      status: 'completed',
+      type: 'direct_insert',
+      insertedCount: 1,
+    });
+
+    renderHook(() =>
+      useAutoInsertToCanvas({
+        enabled: true,
+        groupSimilarTasks: true,
+        groupTimeWindow: 10,
+      })
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(IMAGE_GENERATION_ANCHOR_RETRY_EVENT, {
+          detail: { taskId: task.id },
+        })
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(mocks.quickInsert).not.toHaveBeenCalled();
+    expect(mocks.clearTask).not.toHaveBeenCalled();
+    expect(mocks.markAsInserted).not.toHaveBeenCalled();
+  });
+});

--- a/packages/drawnix/src/hooks/__tests__/useImageGenerationAnchorSync.test.ts
+++ b/packages/drawnix/src/hooks/__tests__/useImageGenerationAnchorSync.test.ts
@@ -8,7 +8,10 @@ import {
   TaskType,
   type Task,
 } from '../../types/task.types';
-import type { PlaitImageGenerationAnchor } from '../../types/image-generation-anchor.types';
+import {
+  IMAGE_GENERATION_ANCHOR_RETRY_EVENT,
+  type PlaitImageGenerationAnchor,
+} from '../../types/image-generation-anchor.types';
 
 const taskListeners: Array<(event: { task: Task }) => void> = [];
 const completionListeners: Array<(event: { taskId: string }) => void> = [];
@@ -450,5 +453,68 @@ describe('useImageGenerationAnchorSync', () => {
       [200, 300],
       [690, 578],
     ]);
+  });
+
+  it('reconciles stale completed anchors before dispatching retry', () => {
+    vi.useFakeTimers();
+
+    const board = createBoard(
+      createAnchor({
+        taskIds: ['task-1'],
+        primaryTaskId: 'task-1',
+        phase: 'developing',
+      }),
+      [createImageElement()]
+    );
+    taskState.tasks = [
+      createTask({
+        status: TaskStatus.PROCESSING,
+      }),
+    ];
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+    renderHook(() => useImageGenerationAnchorSync({ board, enabled: true }));
+
+    const boardState = board as unknown as {
+      children: PlaitImageGenerationAnchor[];
+    };
+    boardState.children[0] = {
+      ...boardState.children[0],
+      phase: 'developing',
+    };
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    taskState.tasks = [
+      createTask({
+        status: TaskStatus.COMPLETED,
+        insertedToCanvas: true,
+        result: {
+          url: 'https://example.com/generated.png',
+        },
+      }),
+    ];
+    completionState.byTaskId.set('task-1', {
+      taskId: 'task-1',
+      status: 'completed',
+      type: 'direct_insert',
+      firstElementPosition: [200, 300],
+      firstElementId: 'image-1',
+      firstElementSize: { width: 480, height: 278 },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(50_000);
+    });
+
+    const retryEvents = dispatchSpy.mock.calls.filter(
+      ([event]) => event.type === IMAGE_GENERATION_ANCHOR_RETRY_EVENT
+    );
+    expect(retryEvents).toHaveLength(0);
+    expect(boardState.children[0]?.phase).toBe('completed');
+
+    dispatchSpy.mockRestore();
   });
 });

--- a/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
+++ b/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
@@ -83,6 +83,8 @@ const DEFAULT_CONFIG: AutoInsertConfig = {
   groupTimeWindow: 5000, // 5秒内完成的同 Prompt 任务会分组
 };
 
+const BOARD_RETRY_DELAY = 500;
+
 /**
  * 已插入任务的记录，防止重复插入
  */
@@ -432,19 +434,37 @@ export function useAutoInsertToCanvas(
     let isActive = true;
 
     /**
+     * 调度 flush 操作
+     */
+    function scheduleFlush(delay = mergedConfig.groupTimeWindow) {
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+      }
+      flushTimerRef.current = setTimeout(() => {
+        flushTimerRef.current = null;
+        flushPendingInserts().catch((error) => {
+          console.error('[AutoInsert] Failed to flush pending inserts:', error);
+        });
+      }, delay);
+    }
+
+    /**
      * 执行批量插入
      */
-    const flushPendingInserts = async () => {
+    async function flushPendingInserts() {
       // console.log('[AutoInsert] flushPendingInserts called');
-      const board = getCanvasBoard();
-      if (!board || !isActive) {
-        // console.log(`[AutoInsert] flushPendingInserts aborted: board=${!!board}, isActive=${isActive}`);
-        return;
-      }
-
       const pendingMap = pendingInsertsRef.current;
       if (pendingMap.size === 0) {
         // console.log('[AutoInsert] flushPendingInserts: no pending tasks');
+        return;
+      }
+
+      const board = getCanvasBoard();
+      if (!board || !isActive) {
+        // console.log(`[AutoInsert] flushPendingInserts aborted: board=${!!board}, isActive=${isActive}`);
+        if (!board && isActive) {
+          scheduleFlush(BOARD_RETRY_DELAY);
+        }
         return;
       }
 
@@ -455,7 +475,12 @@ export function useAutoInsertToCanvas(
       pendingMap.clear();
 
       for (const [promptKey, inserts] of toInsert) {
-        if (!isActive) break;
+        if (!isActive) {
+          for (const { task } of inserts) {
+            releaseTaskInsertion(task.id);
+          }
+          continue;
+        }
 
         // console.log(`[AutoInsert] Processing prompt group "${promptKey.substring(0, 30)}..." with ${inserts.length} tasks`);
 
@@ -1052,19 +1077,7 @@ export function useAutoInsertToCanvas(
           }
         }
       }
-    };
-
-    /**
-     * 调度 flush 操作
-     */
-    const scheduleFlush = () => {
-      if (flushTimerRef.current) {
-        clearTimeout(flushTimerRef.current);
-      }
-      flushTimerRef.current = setTimeout(() => {
-        flushPendingInserts();
-      }, mergedConfig.groupTimeWindow);
-    };
+    }
 
     /**
      * 处理宫格图/灵感图任务：使用统一的媒体结果处理服务
@@ -1141,6 +1154,17 @@ export function useAutoInsertToCanvas(
       if (task.insertedToCanvas) {
         // console.log(`[AutoInsert] Task ${task.id} skipped: insertedToCanvas flag is true (persisted)`);
         insertedTaskIds.add(task.id);
+        return;
+      }
+
+      const postProcessingStatus =
+        workflowCompletionService.getPostProcessingStatus(task.id)?.status;
+      if (postProcessingStatus === 'completed') {
+        insertedTaskIds.add(task.id);
+        return;
+      }
+
+      if (postProcessingStatus === 'processing') {
         return;
       }
 
@@ -1234,8 +1258,18 @@ export function useAutoInsertToCanvas(
         scheduleFlush();
       } else {
         // console.log(`[AutoInsert] Flushing immediately`);
-        flushPendingInserts();
+        flushPendingInserts().catch((error) => {
+          console.error('[AutoInsert] Failed to flush pending inserts:', error);
+        });
       }
+    };
+
+    const recoverCompletedAutoInsertTasks = () => {
+      getTaskQueueService().getAllTasks().forEach((task) => {
+        if (task.status === TaskStatus.COMPLETED) {
+          handleTaskCompleted(task);
+        }
+      });
     };
 
     /**
@@ -1272,8 +1306,12 @@ export function useAutoInsertToCanvas(
           if (event.task.status === TaskStatus.COMPLETED) {
             handleTaskCompleted(event.task);
           }
+        } else if (event.type === 'taskCreated') {
+          recoverCompletedAutoInsertTasks();
         }
       });
+
+    recoverCompletedAutoInsertTasks();
 
     // 订阅后处理完成事件，以便在所有任务插入完成后删除 WorkZone
     const completionSub = workflowCompletionService
@@ -1328,13 +1366,33 @@ export function useAutoInsertToCanvas(
         return;
       }
 
-      releaseTaskInsertion(taskId);
-      workflowCompletionService.clearTask(taskId);
-
       const retryTask = getTaskQueueService().getTask(taskId);
       if (!retryTask) {
         return;
       }
+
+      const postProcessingStatus =
+        workflowCompletionService.getPostProcessingStatus(taskId)?.status;
+
+      if (retryTask.status === TaskStatus.COMPLETED) {
+        if (
+          retryTask.insertedToCanvas ||
+          postProcessingStatus === 'completed'
+        ) {
+          insertedTaskIds.add(taskId);
+          return;
+        }
+
+        if (
+          insertedTaskIds.has(taskId) ||
+          postProcessingStatus === 'processing'
+        ) {
+          return;
+        }
+      }
+
+      releaseTaskInsertion(taskId);
+      workflowCompletionService.clearTask(taskId);
 
       if (
         retryTask.status === TaskStatus.FAILED ||
@@ -1345,10 +1403,7 @@ export function useAutoInsertToCanvas(
       }
 
       if (retryTask.status === TaskStatus.COMPLETED) {
-        handleTaskCompleted({
-          ...retryTask,
-          insertedToCanvas: false,
-        });
+        handleTaskCompleted(retryTask);
       }
     };
 
@@ -1368,7 +1423,16 @@ export function useAutoInsertToCanvas(
       );
       if (flushTimerRef.current) {
         clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
       }
+      // 释放所有未处理的待插入任务，防止它们永久卡在 insertedTaskIds 中
+      const pendingMap = pendingInsertsRef.current;
+      for (const [, inserts] of pendingMap) {
+        for (const { task } of inserts) {
+          releaseTaskInsertion(task.id);
+        }
+      }
+      pendingMap.clear();
     };
   }, [
     mergedConfig.enabled,

--- a/packages/drawnix/src/hooks/useImageGenerationAnchorSync.ts
+++ b/packages/drawnix/src/hooks/useImageGenerationAnchorSync.ts
@@ -7,7 +7,10 @@ import {
   type WorkflowPostProcessingResult,
 } from '../services/workflow-completion-service';
 import { ImageGenerationAnchorTransforms } from '../plugins/with-image-generation-anchor';
-import type { PlaitImageGenerationAnchor } from '../types/image-generation-anchor.types';
+import {
+  IMAGE_GENERATION_ANCHOR_RETRY_EVENT,
+  type PlaitImageGenerationAnchor,
+} from '../types/image-generation-anchor.types';
 import { TaskStatus, TaskType, type Task } from '../types/task.types';
 import { getImageGenerationAnchorControllerResult } from '../utils/image-generation-anchor-controller';
 import {
@@ -27,6 +30,8 @@ export interface UseImageGenerationAnchorSyncOptions {
 }
 
 const COMPLETED_REMOVAL_DELAY = 1600;
+const STALE_ANCHOR_CHECK_INTERVAL = 10_000;
+const STALE_ANCHOR_THRESHOLD_MS = 45_000;
 
 function isImageTask(task: Task): boolean {
   return task.type === TaskType.IMAGE;
@@ -121,6 +126,39 @@ function deriveAnchorPreviewImageUrl(
     result?.urls?.find((url) => typeof url === 'string' && url.length > 0) ||
     anchor.previewImageUrl
   );
+}
+
+function getStaleAnchorRetryTaskId(
+  anchor: PlaitImageGenerationAnchor,
+  tasks: Task[]
+): string | undefined {
+  const relatedTasks = getTasksForImageGenerationAnchor(anchor, tasks);
+  const primaryTask = selectPrimaryImageGenerationAnchorTask(
+    anchor,
+    relatedTasks
+  );
+  const primaryTaskId =
+    anchor.primaryTaskId || primaryTask?.id || anchor.taskIds[0];
+
+  if (!primaryTaskId) {
+    return undefined;
+  }
+
+  const hasInserted =
+    relatedTasks.length > 0 &&
+    hasResolvedImageGenerationBatchCount(anchor, relatedTasks) &&
+    relatedTasks.every(
+      (task) =>
+        Boolean(task.insertedToCanvas) ||
+        workflowCompletionService.getPostProcessingStatus(task.id)?.status ===
+          'completed'
+    );
+
+  if (hasInserted) {
+    return undefined;
+  }
+
+  return primaryTaskId;
 }
 
 function isSamePoint(left?: Point, right?: Point): boolean {
@@ -507,9 +545,53 @@ export function useImageGenerationAnchorSync({
         reconcileAllAnchors();
       });
 
+    const stalePhaseTimestamps = new Map<string, number>();
+    const staleCheckTimer = setInterval(() => {
+      const anchors = ImageGenerationAnchorTransforms.getAllAnchors(board);
+      const now = Date.now();
+      for (const anchor of anchors) {
+        if (anchor.phase === 'developing' || anchor.phase === 'inserting') {
+          const entered = stalePhaseTimestamps.get(anchor.id);
+          if (!entered) {
+            stalePhaseTimestamps.set(anchor.id, now);
+          } else if (now - entered > STALE_ANCHOR_THRESHOLD_MS) {
+            stalePhaseTimestamps.delete(anchor.id);
+            reconcileAnchor(anchor.id);
+
+            const latestAnchor = ImageGenerationAnchorTransforms.getAnchorById(
+              board,
+              anchor.id
+            );
+            if (
+              !latestAnchor ||
+              (latestAnchor.phase !== 'developing' &&
+                latestAnchor.phase !== 'inserting')
+            ) {
+              continue;
+            }
+
+            const primaryTaskId = getStaleAnchorRetryTaskId(
+              latestAnchor,
+              taskQueueService.getAllTasks()
+            );
+            if (primaryTaskId) {
+              window.dispatchEvent(
+                new CustomEvent(IMAGE_GENERATION_ANCHOR_RETRY_EVENT, {
+                  detail: { taskId: primaryTaskId },
+                })
+              );
+            }
+          }
+        } else {
+          stalePhaseTimestamps.delete(anchor.id);
+        }
+      }
+    }, STALE_ANCHOR_CHECK_INTERVAL);
+
     return () => {
       taskSubscription.unsubscribe();
       completionSubscription.unsubscribe();
+      clearInterval(staleCheckTimer);
       removalTimers.forEach((timer) => clearTimeout(timer));
       removalTimers.clear();
     };


### PR DESCRIPTION
生图任务已经完成、图片结果已经拿到，但自动插入画布链路因为时机或状态不同步，导致锚点一直卡在“正在显影 / 正在插入”，以及后续 retry 可能造成重复插入的问题