### PR TITLE
feat: add image generate-again prefill

### DIFF
--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -26,6 +26,7 @@ import React, {
 } from 'react';
 import { Send } from 'lucide-react';
 import { MessagePlugin } from 'tdesign-react';
+import { useConfirmDialog } from '../dialog/ConfirmDialog';
 import { ImageUploadIcon, MediaLibraryIcon } from '../icons';
 import { useBoard } from '@plait-board/react-board';
 import { SelectedContentPreview } from '../shared/SelectedContentPreview';
@@ -166,7 +167,9 @@ import {
 } from '../../utils/ai-model-selection-storage';
 import {
   AI_INPUT_FOCUS_EVENT,
+  AI_INPUT_PREFILL_EVENT,
   type AIInputFocusEventDetail,
+  type AIInputPrefillEventDetail,
 } from '../../services/ai-input-ui-events';
 import { normalizeKnowledgeContextRefs } from '../../services/generation-context-service';
 
@@ -244,6 +247,42 @@ function getPromptHistoryCategoryForStep(
       workflow.generationType === 'text'
     ? workflow.generationType
     : 'agent';
+}
+
+function normalizeAIInputImageDataUrl(value: string): string {
+  const trimmed = value.trim();
+
+  if (
+    !trimmed ||
+    trimmed.startsWith('data:') ||
+    trimmed.startsWith('blob:') ||
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../')
+  ) {
+    return trimmed || value;
+  }
+
+  const normalized = trimmed.replace(/\s+/g, '');
+  if (!/^[A-Za-z0-9+/=]+$/.test(normalized) || normalized.length < 32) {
+    return trimmed;
+  }
+
+  return `data:image/png;base64,${normalized}`;
+}
+
+function normalizeAIInputImageUrl(url: string): string {
+  const normalized = normalizeAIInputImageDataUrl(url);
+  try {
+    const parsed = new URL(normalized, window.location.origin);
+    parsed.searchParams.delete('_retry');
+    parsed.searchParams.delete('bypass_sw');
+    return parsed.toString();
+  } catch {
+    return normalized;
+  }
 }
 
 function buildPromptLineageMeta(
@@ -702,6 +741,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       removeHistory: deletePromptHistory,
     } = usePromptHistory();
     const { addAsset } = useAssets();
+    const { confirm, confirmDialog } = useConfirmDialog();
     // 使用 ref 存储，避免依赖变化
     const sendWorkflowMessageRef = useRef(
       chatDrawerControl.sendWorkflowMessage
@@ -1181,9 +1221,22 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         ? 'agent'
         : `${initialGenerationType}:${initialSelectedModelKey}`
     );
+    const promptRef = useRef(prompt);
+    const selectedContentRef = useRef<SelectedContent[]>(selectedContent);
+    const uploadedContentRef = useRef<SelectedContent[]>(uploadedContent);
+    const suppressSelectionContentUrlsRef = useRef<Set<string>>(new Set());
     useEffect(() => {
       selectedParamsRef.current = selectedParams;
     }, [selectedParams]);
+    useEffect(() => {
+      promptRef.current = prompt;
+    }, [prompt]);
+    useEffect(() => {
+      selectedContentRef.current = selectedContent;
+    }, [selectedContent]);
+    useEffect(() => {
+      uploadedContentRef.current = uploadedContent;
+    }, [uploadedContent]);
     // 当前选中的生成数量
     const [selectedCount, setSelectedCount] = useState(
       initialPreferences.selectedCount
@@ -1217,7 +1270,6 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     const allContent = useMemo(() => {
       return [...uploadedContent, ...selectedContent];
     }, [uploadedContent, selectedContent]);
-
     const localImageMessages = useMemo(
       () => ({
         invalidFile:
@@ -1805,6 +1857,45 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       stopPropagation: true,
     });
 
+    const focusInput = useCallback(() => {
+      setIsFocused(true);
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }, []);
+
+    const confirmOverwriteInputIfNeeded = useCallback(
+      async (source?: AIInputPrefillEventDetail['source']) => {
+        const hasPrompt = promptRef.current.trim().length > 0;
+        const hasUploadedContent = uploadedContentRef.current.length > 0;
+        const hasSelectedContent = selectedContentRef.current.length > 0;
+        const hasKnowledgeContext = knowledgeContextRefs.length > 0;
+        const shouldConfirm =
+          source === 'canvas-toolbar'
+            ? hasPrompt || hasUploadedContent || hasKnowledgeContext
+            : hasPrompt ||
+              hasUploadedContent ||
+              hasSelectedContent ||
+              hasKnowledgeContext;
+
+        if (!shouldConfirm) {
+          return true;
+        }
+
+        return confirm({
+          title: language === 'zh' ? '覆盖当前输入？' : 'Overwrite current input?',
+          description:
+            language === 'zh'
+              ? '底部输入框已有提示词或参考图，继续会覆盖当前输入。'
+              : 'The bottom input already has a prompt or reference images. Continuing will overwrite it.',
+          confirmText: language === 'zh' ? '覆盖当前输入' : 'Overwrite input',
+          cancelText: language === 'zh' ? '取消' : 'Cancel',
+          confirmTheme: 'warning',
+        });
+      },
+      [confirm, knowledgeContextRefs.length, language]
+    );
+
     useEffect(() => {
       const handleAIInputFocus = (
         event: Event | CustomEvent<AIInputFocusEventDetail>
@@ -1822,17 +1913,126 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           }
         }
 
-        setIsFocused(true);
-        requestAnimationFrame(() => {
-          inputRef.current?.focus();
-        });
+        focusInput();
       };
 
       window.addEventListener(AI_INPUT_FOCUS_EVENT, handleAIInputFocus);
       return () => {
         window.removeEventListener(AI_INPUT_FOCUS_EVENT, handleAIInputFocus);
       };
-    }, []);
+    }, [focusInput]);
+
+    useEffect(() => {
+      const handleAIInputPrefill = async (
+        event: Event | CustomEvent<AIInputPrefillEventDetail>
+      ) => {
+        const detail = (event as CustomEvent<AIInputPrefillEventDetail>).detail;
+        if (!detail || !(await confirmOverwriteInputIfNeeded(detail.source))) {
+          return;
+        }
+
+        const nextGenerationType = detail.generationType;
+        const modelsForType =
+          nextGenerationType === 'video'
+            ? videoModels
+            : nextGenerationType === 'audio'
+            ? audioModels
+            : nextGenerationType === 'text' || nextGenerationType === 'agent'
+            ? textModels
+            : imageModels;
+        const nextModel =
+          findMatchingSelectableModel(
+            modelsForType,
+            detail.model,
+            detail.modelRef || null
+          ) ||
+          findMatchingSelectableModel(modelsForType, detail.model, null) ||
+          resolvePreferredModelSelection(nextGenerationType, modelsForType);
+        const nextModelRef = getModelRefFromConfig(nextModel);
+        const nextModelId = nextModel?.id || detail.model || selectedModel;
+        const nextScopeKey = getSelectionKey(nextModelId, nextModelRef);
+        const nextParams =
+          nextGenerationType === 'agent'
+            ? {}
+            : {
+                ...loadScopedAIInputModelParams(
+                  nextGenerationType,
+                  nextModelId,
+                  nextScopeKey
+                ),
+                ...(detail.params || {}),
+              };
+
+        if (detail.source === 'canvas-toolbar') {
+          const suppressedUrls = selectedContentRef.current
+            .filter(
+              (content): content is SelectedContent & { url: string } =>
+                content.type === 'image' && typeof content.url === 'string'
+            )
+            .map((content) => normalizeAIInputImageUrl(content.url));
+          suppressSelectionContentUrlsRef.current = new Set(suppressedUrls);
+          setSelectedContent((prev) =>
+            prev.filter((item) => {
+              if (item.type !== 'image' || typeof item.url !== 'string') {
+                return true;
+              }
+              return !suppressSelectionContentUrlsRef.current.has(
+                normalizeAIInputImageUrl(item.url)
+              );
+            })
+          );
+        } else {
+          suppressSelectionContentUrlsRef.current = new Set();
+        }
+
+        setGenerationType(nextGenerationType);
+        setPrompt(detail.prompt || '');
+        setUploadedContent(
+          (detail.images || []).map((image, index) => ({
+            type: 'image',
+            url: image.url,
+            name: image.name || `参考图 ${index + 1}`,
+            width: image.width,
+            height: image.height,
+          }))
+        );
+        setSelectedModel(nextModelId);
+        setSelectedModelRef(nextModelRef);
+        setKnowledgeContextRefs(
+          normalizeKnowledgeContextRefs(detail.knowledgeContextRefs)
+        );
+        setSelectedParams(nextParams);
+        selectedParamsRef.current = nextParams;
+        selectedParamScopeRef.current =
+          nextGenerationType === 'agent'
+            ? 'agent'
+            : `${nextGenerationType}:${nextScopeKey}`;
+        if (typeof detail.count === 'number' && detail.count > 0) {
+          setSelectedCount(detail.count);
+        }
+        MessagePlugin.success(
+          language === 'zh'
+            ? '已回填到底部输入框，请手动发送'
+            : 'Loaded into the bottom input. Send manually when ready.'
+        );
+        focusInput();
+      };
+
+      window.addEventListener(AI_INPUT_PREFILL_EVENT, handleAIInputPrefill);
+      return () => {
+        window.removeEventListener(AI_INPUT_PREFILL_EVENT, handleAIInputPrefill);
+      };
+    }, [
+      audioModels,
+      confirmOverwriteInputIfNeeded,
+      focusInput,
+      imageModels,
+      language,
+      resolvePreferredModelSelection,
+      selectedModel,
+      textModels,
+      videoModels,
+    ]);
 
     // 处理灵感模版选择：将提示词替换到输入框并切换到 Agent 模式
     const handleSelectInspirationPrompt = useCallback(
@@ -2154,7 +2354,33 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
 
     // 处理选择变化的回调（由 SelectionWatcher 调用）
     const handleSelectionChange = useCallback((content: SelectedContent[]) => {
-      setSelectedContent(content);
+      const suppressedUrls = suppressSelectionContentUrlsRef.current;
+      if (suppressedUrls.size === 0) {
+        setSelectedContent(content);
+        return;
+      }
+
+      const containsSuppressedSelection = content.some((item) => {
+        if (item.type !== 'image' || typeof item.url !== 'string') {
+          return false;
+        }
+        return suppressedUrls.has(normalizeAIInputImageUrl(item.url));
+      });
+
+      if (!containsSuppressedSelection) {
+        suppressSelectionContentUrlsRef.current = new Set();
+        setSelectedContent(content);
+        return;
+      }
+
+      setSelectedContent(
+        content.filter((item) => {
+          if (item.type !== 'image' || typeof item.url !== 'string') {
+            return true;
+          }
+          return !suppressedUrls.has(normalizeAIInputImageUrl(item.url));
+        })
+      );
     }, []);
 
     // 当选中单个 Frame 时，自动切换 size 参数为最接近 Frame 比例的选项
@@ -4205,18 +4431,20 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     }, [shouldKeepExpanded, prompt]);
 
     return (
-      <div
-        ref={containerRef}
-        className={classNames(
-          'ai-input-bar',
-          ATTACHED_ELEMENT_CLASS_NAME,
-          className,
-          {
-            'ai-input-bar--with-inspiration': showInspirationBoard,
-          }
-        )}
-        data-testid="ai-input-bar"
-      >
+      <>
+        {confirmDialog}
+        <div
+          ref={containerRef}
+          className={classNames(
+            'ai-input-bar',
+            ATTACHED_ELEMENT_CLASS_NAME,
+            className,
+            {
+              'ai-input-bar--with-inspiration': showInspirationBoard,
+            }
+          )}
+          data-testid="ai-input-bar"
+        >
         <SelectionWatcher
           language={language}
           onSelectionChange={handleSelectionChange}
@@ -4552,16 +4780,17 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           </div>
         </div>
 
-        {showMediaLibrary && (
-          <MediaLibraryModal
-            isOpen={showMediaLibrary}
-            onClose={() => setShowMediaLibrary(false)}
-            mode={SelectionMode.SELECT}
-            filterType={AssetType.IMAGE}
-            onSelect={handleMediaLibrarySelect}
-          />
-        )}
-      </div>
+          {showMediaLibrary && (
+            <MediaLibraryModal
+              isOpen={showMediaLibrary}
+              onClose={() => setShowMediaLibrary(false)}
+              mode={SelectionMode.SELECT}
+              filterType={AssetType.IMAGE}
+              onSelect={handleMediaLibrarySelect}
+            />
+          )}
+        </div>
+      </>
     );
   }
 );

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -1983,6 +1983,8 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           );
         } else {
           suppressSelectionContentUrlsRef.current = new Set();
+          setSelectedContent([]);
+          selectedFrameRef.current = null;
         }
 
         setGenerationType(nextGenerationType);

--- a/packages/drawnix/src/components/task-queue/DialogTaskList.tsx
+++ b/packages/drawnix/src/components/task-queue/DialogTaskList.tsx
@@ -16,12 +16,16 @@ import { insertVideoFromUrl } from '../../data/video';
 import { MessagePlugin, Input, Button } from 'tdesign-react';
 import { SearchIcon, DeleteIcon } from 'tdesign-icons-react';
 import { normalizeImageDataUrl } from '@aitu/utils';
+import { taskQueueService } from '../../services/task-queue';
+import { taskStorageReader } from '../../services/task-storage-reader';
+import { hasAIImageDraftContent } from '../../utils/ai-image-draft-state';
+import { buildImageTaskPrefillInitialData } from '../../utils/image-task-prefill';
 import {
   buildTaskDownloadItems,
   smartDownload,
 } from '../../utils/download-utils';
 import { CharacterCreateDialog } from '../character/CharacterCreateDialog';
-import { ConfirmDialog } from '../dialog/ConfirmDialog';
+import { ConfirmDialog, useConfirmDialog } from '../dialog/ConfirmDialog';
 import {
   UnifiedMediaViewer,
   type MediaItem as UnifiedMediaItem,
@@ -61,6 +65,7 @@ export const DialogTaskList: React.FC<DialogTaskListProps> = ({
   } = useFilteredTaskQueue({ taskType });
 
   const { board, openDialog } = useDrawnix();
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [taskToDelete, setTaskToDelete] = useState<string | null>(null);
   const [previewVisible, setPreviewVisible] = useState(false);
@@ -238,8 +243,50 @@ export const DialogTaskList: React.FC<DialogTaskListProps> = ({
     }
   };
 
-  const handleEdit = (taskId: string) => {
-    const task = tasks.find((t) => t.id === taskId);
+  const confirmOverwriteDraftIfNeeded = useCallback(async () => {
+    if (!hasAIImageDraftContent()) {
+      return true;
+    }
+
+    return confirm({
+      title: '覆盖当前输入？',
+      description: '当前 AI 图片生成窗口已有提示词或参考图，继续会覆盖当前输入。',
+      confirmText: '覆盖当前输入',
+      cancelText: '取消',
+      confirmTheme: 'warning',
+    });
+  }, [confirm]);
+
+  const handleRegenerate = async (taskId: string) => {
+    const task =
+      (await taskStorageReader.getTask(taskId)) ||
+      taskQueueService.getTask(taskId) ||
+      tasks.find((item) => item.id === taskId);
+    if (!task || task.type !== TaskType.IMAGE) {
+      MessagePlugin.warning('未找到可回填的图片任务');
+      return;
+    }
+
+    if (!(await confirmOverwriteDraftIfNeeded())) {
+      return;
+    }
+
+    if (onEditTask) {
+      onEditTask(task);
+    } else {
+      openDialog(
+        DialogType.aiImageGeneration,
+        buildImageTaskPrefillInitialData(task)
+      );
+    }
+    MessagePlugin.success('已回填历史提示词和参考图，请手动发送');
+  };
+
+  const handleEdit = async (taskId: string) => {
+    const task =
+      (await taskStorageReader.getTask(taskId)) ||
+      taskQueueService.getTask(taskId) ||
+      tasks.find((item) => item.id === taskId);
     if (!task) {
       console.warn('Cannot edit: task not found');
       return;
@@ -254,15 +301,10 @@ export const DialogTaskList: React.FC<DialogTaskListProps> = ({
     // 否则打开新的对话框（从任务队列面板调用）
     if (task.type === TaskType.IMAGE) {
       // 准备图片生成初始数据
-      const initialData = {
-        initialPrompt: task.params.prompt,
-        initialWidth: task.params.width,
-        initialHeight: task.params.height,
-        initialImages: task.params.uploadedImages, // 传递上传的参考图片(数组)
-        initialResultUrl: task.result?.url, // 传递结果URL用于预览
-        initialResultUrls: task.result?.urls, // 多图结果
-      };
-      openDialog(DialogType.aiImageGeneration, initialData);
+      openDialog(
+        DialogType.aiImageGeneration,
+        buildImageTaskPrefillInitialData(task)
+      );
     } else if (task.type === TaskType.VIDEO) {
       // 准备视频生成初始数据
       const initialData = {
@@ -451,6 +493,8 @@ export const DialogTaskList: React.FC<DialogTaskListProps> = ({
 
   return (
     <>
+      {confirmDialog}
+
       <div className="dialog-task-list">
         <div className="dialog-task-list__header">
           <div className="dialog-task-list__header-main">
@@ -489,6 +533,7 @@ export const DialogTaskList: React.FC<DialogTaskListProps> = ({
           onDownload={handleDownload}
           onInsert={handleInsert}
           onEdit={handleEdit}
+          onRegenerate={handleRegenerate}
           onPreviewOpen={handlePreviewOpen}
           onExtractCharacter={handleExtractCharacter}
           hasMore={hasMore && !searchText.trim()}

--- a/packages/drawnix/src/components/task-queue/TaskItem.tsx
+++ b/packages/drawnix/src/components/task-queue/TaskItem.tsx
@@ -17,6 +17,7 @@ import {
   PlayCircleIcon,
   CloseCircleIcon,
   CopyIcon,
+  RefreshIcon,
 } from 'tdesign-icons-react';
 import { normalizeImageDataUrl } from '@aitu/utils';
 import { Task, TaskStatus, TaskType } from '../../types/task.types';
@@ -167,6 +168,8 @@ export interface TaskItemProps {
   onPreviewOpen?: () => void;
   /** Callback when edit button is clicked */
   onEdit?: (taskId: string) => void;
+  /** Callback when reusing image task input */
+  onRegenerate?: (taskId: string) => void;
   /** Callback when extract character button is clicked */
   onExtractCharacter?: (taskId: string) => void;
 }
@@ -230,6 +233,7 @@ export const TaskItem: React.FC<TaskItemProps> = React.memo(
     onCopy,
     onPreviewOpen,
     onEdit,
+    onRegenerate,
     onExtractCharacter,
   }) => {
     const [imageDimensions, setImageDimensions] = useState<{
@@ -280,6 +284,7 @@ export const TaskItem: React.FC<TaskItemProps> = React.memo(
     const isAudioTask = task.type === TaskType.AUDIO;
     const isChatTask = task.type === TaskType.CHAT;
     const isLyricsTask = isAudioTask && isLyricsResult(task.result);
+    const canRegenerateTask = task.type === TaskType.IMAGE;
     const isPreviewableTask =
       task.type === TaskType.IMAGE ||
       task.type === TaskType.VIDEO ||
@@ -884,6 +889,23 @@ export const TaskItem: React.FC<TaskItemProps> = React.memo(
                     </HoverTip>
                   )}
 
+                  {canRegenerateTask && (
+                    <HoverTip content="以当前提示词再次生成">
+                      <Button
+                        size="small"
+                        variant="text"
+                        icon={<RefreshIcon />}
+                        aria-label="再次生成"
+                        data-track="task_click_regenerate_prefill"
+                        data-track-params={actionTrackParams}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onRegenerate?.(task.id);
+                        }}
+                      />
+                    </HoverTip>
+                  )}
+
                   {canExtractCharacter && (
                     <HoverTip content="角色">
                       <Button
@@ -996,7 +1018,8 @@ export const TaskItem: React.FC<TaskItemProps> = React.memo(
       prev.task.result === next.task.result &&
       prev.isSelected === next.isSelected &&
       prev.selectionMode === next.selectionMode &&
-      prev.isCompact === next.isCompact
+      prev.isCompact === next.isCompact &&
+      prev.onRegenerate === next.onRegenerate
     );
   }
 );

--- a/packages/drawnix/src/components/task-queue/TaskQueuePanel.tsx
+++ b/packages/drawnix/src/components/task-queue/TaskQueuePanel.tsx
@@ -63,6 +63,11 @@ import { resolveAudioResultUrls } from '../../services/audio-task-result-utils';
 import { ConfirmDialog } from '../dialog/ConfirmDialog';
 import { analytics } from '../../utils/posthog-analytics';
 import { DRAWER_PIN_KEYS } from '../../utils/drawer-pin';
+import {
+  buildImageTaskAIInputPrefillData,
+  buildImageTaskPrefillInitialData,
+} from '../../utils/image-task-prefill';
+import { requestAIInputPrefill } from '../../services/ai-input-ui-events';
 import './task-queue.scss';
 import { HoverTip } from '../shared';
 
@@ -725,6 +730,23 @@ export const TaskQueuePanel: React.FC<TaskQueuePanelProps> = ({
     }
   };
 
+  const handleRegenerate = async (taskId: string) => {
+    const task =
+      (await taskStorageReader.getTask(taskId)) ||
+      taskQueueService.getTask(taskId) ||
+      tasks.find((item) => item.id === taskId);
+    if (!task || task.type !== TaskType.IMAGE) {
+      MessagePlugin.warning('未找到可回填的图片任务');
+      return;
+    }
+
+    requestAIInputPrefill({
+      ...buildImageTaskAIInputPrefillData(task),
+      source: 'task-queue',
+    });
+    onTaskAction?.('regenerate', taskId);
+  };
+
   const handleEdit = (taskId: string) => {
     const task = tasks.find((t) => t.id === taskId);
     if (!task) {
@@ -735,15 +757,10 @@ export const TaskQueuePanel: React.FC<TaskQueuePanelProps> = ({
     // 根据任务类型打开对应的对话框
     if (task.type === TaskType.IMAGE) {
       // 准备图片生成初始数据
-      const initialData = {
-        initialPrompt: task.params.prompt,
-        initialWidth: task.params.width,
-        initialHeight: task.params.height,
-        initialImages: task.params.uploadedImages, // 传递上传的参考图片(数组)
-        initialResultUrl: task.result?.url, // 传递结果URL用于预览
-        initialResultUrls: task.result?.urls, // 多图结果
-      };
-      openDialog(DialogType.aiImageGeneration, initialData);
+      openDialog(
+        DialogType.aiImageGeneration,
+        buildImageTaskPrefillInitialData(task)
+      );
     } else if (task.type === TaskType.VIDEO) {
       // 准备视频生成初始数据
       const initialData = {
@@ -1272,6 +1289,7 @@ export const TaskQueuePanel: React.FC<TaskQueuePanelProps> = ({
             onInsert={handleInsert}
             onCopy={handleCopy}
             onEdit={handleEdit}
+            onRegenerate={handleRegenerate}
             onPreviewOpen={handlePreviewOpen}
             onExtractCharacter={handleExtractCharacter}
             hasMore={hasMore}

--- a/packages/drawnix/src/components/task-queue/VirtualTaskList.tsx
+++ b/packages/drawnix/src/components/task-queue/VirtualTaskList.tsx
@@ -33,6 +33,7 @@ export interface VirtualTaskListProps {
   onInsert?: (taskId: string) => void;
   onCopy?: (taskId: string) => void;
   onEdit?: (taskId: string) => void;
+  onRegenerate?: (taskId: string) => void;
   onPreviewOpen?: (taskId: string) => void;
   onExtractCharacter?: (taskId: string) => void;
   className?: string;
@@ -73,6 +74,7 @@ export const VirtualTaskList: React.FC<VirtualTaskListProps> = ({
   onInsert,
   onCopy,
   onEdit,
+  onRegenerate,
   onPreviewOpen,
   onExtractCharacter,
   className = '',
@@ -358,6 +360,7 @@ export const VirtualTaskList: React.FC<VirtualTaskListProps> = ({
               onDownload={onDownload}
               onInsert={onInsert}
               onEdit={onEdit}
+              onRegenerate={onRegenerate}
               onPreviewOpen={() => onPreviewOpen?.(task.id)}
               onExtractCharacter={onExtractCharacter}
             />
@@ -444,6 +447,7 @@ export const VirtualTaskList: React.FC<VirtualTaskListProps> = ({
                   onInsert={onInsert}
                   onCopy={onCopy}
                   onEdit={onEdit}
+                  onRegenerate={onRegenerate}
                   onPreviewOpen={() => onPreviewOpen?.(task.id)}
                   onExtractCharacter={onExtractCharacter}
                 />

--- a/packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.tsx
@@ -93,6 +93,7 @@ import {
   Volume2,
   VolumeX,
   Scaling,
+  RefreshCw,
 } from 'lucide-react';
 import { useDrawnix, DialogType } from '../../../hooks/use-drawnix';
 import { useI18n } from '../../../i18n';
@@ -117,6 +118,7 @@ import {
   buildDownloadFilename,
 } from '../../../utils/download-utils';
 import { MessagePlugin } from 'tdesign-react';
+import { taskQueueService } from '../../../services/task-queue';
 import { mergeVideos } from '../../../services/video-merge-webcodecs';
 import { insertImageFromUrl } from '../../../data/image';
 import { calculateEditedImagePoints } from '../../../utils/image';
@@ -149,6 +151,8 @@ import { isAudioNodeElement } from '../../../types/audio-node.types';
 import { getCanvasAudioPlaybackQueue } from '../../../data/audio';
 import { openMusicPlayerToolAndPlay } from '../../../services/tool-launch-service';
 import { useCanvasAudioPlayback } from '../../../hooks/useCanvasAudioPlayback';
+import { buildImageTaskAIInputPrefillData } from '../../../utils/image-task-prefill';
+import { requestAIInputPrefill } from '../../../services/ai-input-ui-events';
 import {
   AUDIO_PLAYLIST_CANVAS_AUDIO_ID,
   AUDIO_PLAYLIST_CANVAS_AUDIO_LABEL,
@@ -340,6 +344,7 @@ export const PopupToolbar = () => {
     hasMergeable?: boolean; // 是否显示合并按钮
     hasVideoMergeable?: boolean; // 是否显示视频合成按钮
     hasImageEdit?: boolean; // 是否显示图片编辑按钮
+    hasRegenerateImage?: boolean; // 是否显示再次生成回填按钮
     hasCornerRadius?: boolean; // 是否显示圆角设置按钮
     cornerRadius?: number; // 当前圆角值
     hasSizeInput?: boolean; // 是否显示宽高输入
@@ -638,6 +643,7 @@ export const PopupToolbar = () => {
       hasVideoFrame,
       hasSplitImage,
       hasImageEdit,
+      hasRegenerateImage: isImageSelected,
       hasDownloadable,
       hasMergeable,
       hasVideoMergeable,
@@ -793,6 +799,44 @@ export const PopupToolbar = () => {
       );
     }
   };
+
+  const prefillSelectedImageTaskToAIInput = useCallback(async () => {
+    const imageElement = selectedElements[0];
+    if (
+      selectedElements.length !== 1 ||
+      !PlaitDrawElement.isDrawElement(imageElement) ||
+      !PlaitDrawElement.isImage(imageElement) ||
+      !imageElement.url
+    ) {
+      return;
+    }
+
+    try {
+      const task = await taskQueueService.findImageTaskByResultUrl(
+        imageElement.url
+      );
+      if (!task) {
+        MessagePlugin.warning(
+          language === 'zh'
+            ? '未找到该图片的历史生成任务'
+            : 'No historical generation task found for this image'
+        );
+        return;
+      }
+
+      requestAIInputPrefill({
+        ...buildImageTaskAIInputPrefillData(task),
+        source: 'canvas-toolbar',
+      });
+    } catch (error) {
+      console.error('[PopupToolbar] Failed to prefill image generation:', error);
+      MessagePlugin.error(
+        language === 'zh'
+          ? '回填失败，请稍后重试'
+          : 'Failed to load generation inputs, please try again'
+      );
+    }
+  }, [language, selectedElements]);
 
   const openAIImageGenerationDialog = useCallback(() => {
     const selectedFrame =
@@ -2239,6 +2283,25 @@ export const PopupToolbar = () => {
                 }
               }}
             />
+            {state.hasRegenerateImage && (
+              <ToolButton
+                className="regenerate-image"
+                key="regenerate-image"
+                type="icon"
+                icon={<RefreshCw size={15} />}
+                visible={true}
+                tooltip={
+                  language === 'zh'
+                    ? '以当前提示词再次生成'
+                    : 'Generate again with the current prompt'
+                }
+                aria-label={language === 'zh' ? '再次生成' : 'Generate again'}
+                data-track="toolbar_click_regenerate_image_prefill"
+                onPointerUp={() => {
+                  void prefillSelectedImageTaskToAIInput();
+                }}
+              />
+            )}
             <ToolButton
               className="trash"
               key={9}

--- a/packages/drawnix/src/components/ttd-dialog/ai-image-generation.tsx
+++ b/packages/drawnix/src/components/ttd-dialog/ai-image-generation.tsx
@@ -49,6 +49,14 @@ import {
 } from '../../services/ai-generation-preferences-service';
 import { promptStorageService } from '../../services/prompt-storage-service';
 import {
+  clearAIImageDraftState,
+  setAIImageDraftState,
+} from '../../utils/ai-image-draft-state';
+import {
+  getImageTaskKnowledgeContextRefs,
+  getImageTaskReferenceImages,
+} from '../../utils/image-task-prefill';
+import {
   geminiSettings,
   hasInvocationRouteCredentials,
   resolveInvocationRoute,
@@ -396,6 +404,16 @@ const AIImageGeneration = ({
 
   const lastDraftRef = useRef('');
   useEffect(() => {
+    setAIImageDraftState({
+      prompt,
+      imageCount: uploadedImages.length,
+      knowledgeContextCount: knowledgeContextRefs.length,
+    });
+
+    return clearAIImageDraftState;
+  }, [knowledgeContextRefs.length, prompt, uploadedImages.length]);
+
+  useEffect(() => {
     if (!onDraftChange) {
       return;
     }
@@ -542,6 +560,7 @@ const AIImageGeneration = ({
     setPrompt('');
     setMjSelectedParams(resetParams);
     setUploadedImages([]);
+    setKnowledgeContextRefs([]);
     setError(null);
     setAspectRatio(getAspectRatioFromParams(resetParams));
     setMobilePanel('config');
@@ -604,13 +623,8 @@ const AIImageGeneration = ({
     setWidth(task.params.width || 1024);
     setHeight(task.params.height || 1024);
 
-    // 更新上传的图片 - 确保格式正确
-    if (task.params.uploadedImages && task.params.uploadedImages.length > 0) {
-      // console.log('Setting uploadedImages:', task.params.uploadedImages);
-      setUploadedImages(task.params.uploadedImages);
-    } else {
-      setUploadedImages([]);
-    }
+    setUploadedImages(getImageTaskReferenceImages(task));
+    setKnowledgeContextRefs(getImageTaskKnowledgeContextRefs(task));
 
     // 更新模型选择（通过全局设置）
     if (task.params.model) {

--- a/packages/drawnix/src/components/ttd-dialog/ttd-dialog.tsx
+++ b/packages/drawnix/src/components/ttd-dialog/ttd-dialog.tsx
@@ -4,6 +4,7 @@ import AIImageGeneration from './ai-image-generation';
 import AIVideoGeneration from './ai-video-generation';
 import type { ReferenceImage } from './shared/ReferenceImageUpload';
 import { useI18n } from '../../i18n';
+import type { KnowledgeContextRef } from '../../types/task.types';
 import { useBoard } from '@plait-board/react-board';
 import React, {
   useState,
@@ -198,6 +199,7 @@ const TTDDialogComponent = ({
     initialPrompt: string;
     initialImages: ReferenceImage[];
     selectedElementIds: string[]; // 保存选中元素的IDs
+    initialKnowledgeContextRefs?: KnowledgeContextRef[];
     initialResultUrl?: string; // 初始结果URL,用于显示预览
     initialAspectRatio?: string; // 选中 Frame 时自动匹配的宽高比
     targetFrameId?: string; // 目标 Frame ID（用于将生成结果插入到 Frame 内部）
@@ -344,6 +346,10 @@ const TTDDialogComponent = ({
               imageDialogInitialData.initialImages ||
               imageDialogInitialData.uploadedImages ||
               [],
+            initialKnowledgeContextRefs:
+              imageDialogInitialData.initialKnowledgeContextRefs ||
+              imageDialogInitialData.knowledgeContextRefs ||
+              [],
             selectedElementIds: [],
             initialResultUrl:
               imageDialogInitialData.initialResultUrl ||
@@ -409,6 +415,7 @@ const TTDDialogComponent = ({
         setAiImageData({
           initialPrompt: processedContent.remainingText || '',
           initialImages: imageItems,
+          initialKnowledgeContextRefs: [],
           selectedElementIds,
           initialAspectRatio: frameAspectRatio,
           targetFrameId: detectedFrameId,
@@ -426,6 +433,7 @@ const TTDDialogComponent = ({
         setAiImageData({
           initialPrompt: selectedContent.text || '',
           initialImages: imageItems,
+          initialKnowledgeContextRefs: [],
           selectedElementIds: [],
         });
       } finally {
@@ -673,6 +681,7 @@ const TTDDialogComponent = ({
       </Dialog>
       {/* AI 图片生成窗口 - 使用 WinBox */}
       <WinBoxWindow
+        key={imageDialogInitialData?.prefillId || 'ai-image-window'}
         id="ai-image-dialog"
         visible={appState.openDialogTypes.has(DialogType.aiImageGeneration)}
         title={
@@ -753,10 +762,15 @@ const TTDDialogComponent = ({
             </Suspense>
           ) : (
             <AIImageGeneration
-              key={imageDialogInitialData?.batchId || 'ai-image-dialog'}
+              key={
+                imageDialogInitialData?.prefillId ||
+                imageDialogInitialData?.batchId ||
+                'ai-image-dialog'
+              }
               initialPrompt={aiImageData.initialPrompt}
               initialImages={aiImageData.initialImages}
               initialKnowledgeContextRefs={
+                aiImageData.initialKnowledgeContextRefs ||
                 imageDialogInitialData?.initialKnowledgeContextRefs ||
                 imageDialogInitialData?.knowledgeContextRefs ||
                 []

--- a/packages/drawnix/src/services/ai-input-ui-events.ts
+++ b/packages/drawnix/src/services/ai-input-ui-events.ts
@@ -1,11 +1,35 @@
 import type { GenerationType } from '../utils/ai-input-parser';
+import type { ModelRef } from '../utils/settings-manager';
+import type { KnowledgeContextRef } from '../types/task.types';
 
 export interface AIInputFocusEventDetail {
   generationType?: GenerationType;
   skillId?: string;
 }
 
+export interface AIInputPrefillImage {
+  url: string;
+  name: string;
+  width?: number;
+  height?: number;
+}
+
+export type AIInputPrefillSource = 'canvas-toolbar' | 'task-queue' | 'dialog';
+
+export interface AIInputPrefillEventDetail {
+  generationType: GenerationType;
+  prompt: string;
+  images?: AIInputPrefillImage[];
+  model?: string;
+  modelRef?: ModelRef | null;
+  params?: Record<string, string>;
+  count?: number;
+  knowledgeContextRefs?: KnowledgeContextRef[];
+  source?: AIInputPrefillSource;
+}
+
 export const AI_INPUT_FOCUS_EVENT = 'aitu:ai-input-focus';
+export const AI_INPUT_PREFILL_EVENT = 'aitu:ai-input-prefill';
 
 export function requestAIInputFocus(
   detail: AIInputFocusEventDetail = {}
@@ -15,4 +39,14 @@ export function requestAIInputFocus(
   }
 
   window.dispatchEvent(new CustomEvent(AI_INPUT_FOCUS_EVENT, { detail }));
+}
+
+export function requestAIInputPrefill(
+  detail: AIInputPrefillEventDetail
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent(AI_INPUT_PREFILL_EVENT, { detail }));
 }

--- a/packages/drawnix/src/services/task-queue-service.ts
+++ b/packages/drawnix/src/services/task-queue-service.ts
@@ -315,6 +315,51 @@ function normalizeImageDataUrl(
   return `data:${fallbackMimeType};base64,${normalized}`;
 }
 
+function normalizeComparableMediaUrl(value: string): string {
+  const normalized = normalizeImageDataUrl(value);
+
+  if (typeof window === 'undefined') {
+    return normalized;
+  }
+
+  try {
+    const parsed = new URL(normalized, window.location.origin);
+    if (parsed.origin !== window.location.origin) {
+      return parsed.toString();
+    }
+
+    parsed.searchParams.delete('_retry');
+    parsed.searchParams.delete('bypass_sw');
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return normalized.trim();
+  }
+}
+
+function getTaskResultUrls(task: Task): string[] {
+  const urls = new Set<string>();
+  if (task.result?.url) {
+    urls.add(task.result.url);
+  }
+  task.result?.urls?.forEach((url) => {
+    if (url) {
+      urls.add(url);
+    }
+  });
+  return Array.from(urls);
+}
+
+function imageTaskMatchesUrl(task: Task, imageUrl: string): boolean {
+  if (task.type !== TaskType.IMAGE) {
+    return false;
+  }
+
+  const targetUrl = normalizeComparableMediaUrl(imageUrl);
+  return getTaskResultUrls(task).some(
+    (url) => normalizeComparableMediaUrl(url) === targetUrl
+  );
+}
+
 function hasAnyPersistedLargeTaskParams(
   params?: Record<string, unknown> | null
 ): boolean {
@@ -2024,6 +2069,32 @@ class TaskQueueService {
    */
   getTask(taskId: string): Task | undefined {
     return this.tasks.get(taskId);
+  }
+
+  async getCompleteTask(taskId: string): Promise<Task | undefined> {
+    const storedTask = await taskStorageReader.getTask(taskId);
+    if (storedTask) {
+      return storedTask;
+    }
+
+    const memoryTask = this.tasks.get(taskId);
+    return memoryTask ? this.restoreStrippedTaskParams(memoryTask) : undefined;
+  }
+
+  async findImageTaskByResultUrl(imageUrl: string): Promise<Task | undefined> {
+    const memoryMatch = this
+      .getAllTasks()
+      .find((task) => imageTaskMatchesUrl(task, imageUrl));
+    if (memoryMatch) {
+      return this.getCompleteTask(memoryMatch.id);
+    }
+
+    const storedTasks = await taskStorageReader.getAllTasks({
+      type: TaskType.IMAGE,
+      includeArchived: true,
+      limit: STORAGE_LIMITS.MAX_RETAINED_TASKS * 10,
+    });
+    return storedTasks.find((task) => imageTaskMatchesUrl(task, imageUrl));
   }
 
   /**

--- a/packages/drawnix/src/services/task-queue-service.ts
+++ b/packages/drawnix/src/services/task-queue-service.ts
@@ -2089,12 +2089,14 @@ class TaskQueueService {
       return this.getCompleteTask(memoryMatch.id);
     }
 
-    const storedTasks = await taskStorageReader.getAllTasks({
-      type: TaskType.IMAGE,
-      includeArchived: true,
-      limit: STORAGE_LIMITS.MAX_RETAINED_TASKS * 10,
-    });
-    return storedTasks.find((task) => imageTaskMatchesUrl(task, imageUrl));
+    const storedTaskId = await taskStorageReader.findImageTaskIdByResultUrl(
+      imageUrl,
+      {
+        includeArchived: true,
+        limit: STORAGE_LIMITS.MAX_RETAINED_TASKS * 10,
+      }
+    );
+    return storedTaskId ? this.getCompleteTask(storedTaskId) : undefined;
   }
 
   /**

--- a/packages/drawnix/src/services/task-storage-reader.ts
+++ b/packages/drawnix/src/services/task-storage-reader.ts
@@ -222,6 +222,50 @@ function convertSWTaskToTask(swTask: SWTask): Task {
   };
 }
 
+function normalizeComparableImageTaskUrl(value: string): string {
+  const normalized = normalizeImageDataUrl(value);
+
+  if (typeof window === 'undefined') {
+    return normalized;
+  }
+
+  try {
+    const parsed = new URL(normalized, window.location.origin);
+    if (parsed.origin !== window.location.origin) {
+      return parsed.toString();
+    }
+
+    parsed.searchParams.delete('_retry');
+    parsed.searchParams.delete('bypass_sw');
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return normalized.trim();
+  }
+}
+
+function getSWTaskResultUrls(swTask: SWTask): string[] {
+  const urls = new Set<string>();
+  if (swTask.result?.url) {
+    urls.add(swTask.result.url);
+  }
+  swTask.result?.urls?.forEach((url) => {
+    if (url) {
+      urls.add(url);
+    }
+  });
+  return Array.from(urls);
+}
+
+function swImageTaskMatchesUrl(swTask: SWTask, targetUrl: string): boolean {
+  if (swTask.type !== TaskType.IMAGE) {
+    return false;
+  }
+
+  return getSWTaskResultUrls(swTask).some(
+    (url) => normalizeComparableImageTaskUrl(url) === targetUrl
+  );
+}
+
 function convertSWTaskToAssetTask(swTask: SWTask): AssetTaskRecord | null {
   if (
     (swTask.type !== TaskType.IMAGE &&
@@ -752,6 +796,67 @@ class TaskStorageReader extends BaseStorageReader<TaskCache> {
       const swTask = await this.getById<SWTask>(TASKS_STORE, taskId);
       return swTask ? convertSWTaskToTask(swTask) : null;
     } catch {
+      return null;
+    }
+  }
+
+  async findImageTaskIdByResultUrl(
+    imageUrl: string,
+    options?: { includeArchived?: boolean; limit?: number }
+  ): Promise<string | null> {
+    const includeArchived = options?.includeArchived ?? true;
+    const limit = options?.limit ?? STORAGE_LIMITS.MAX_RETAINED_TASKS * 10;
+    const targetUrl = normalizeComparableImageTaskUrl(imageUrl);
+
+    try {
+      const db = await this.getDB();
+      if (!db.objectStoreNames.contains(TASKS_STORE)) {
+        return null;
+      }
+
+      return await new Promise<string | null>((resolve, reject) => {
+        const tx = db.transaction(TASKS_STORE, 'readonly');
+        const store = tx.objectStore(TASKS_STORE);
+        const index = store.index('createdAt');
+        let scannedImageTasks = 0;
+        const cursorReq = index.openCursor(null, 'prev');
+
+        cursorReq.onsuccess = () => {
+          const cursor = cursorReq.result;
+          if (!cursor || scannedImageTasks >= limit) {
+            resolve(null);
+            return;
+          }
+
+          const task = cursor.value as SWTask;
+          if (!includeArchived && task.archived) {
+            cursor.continue();
+            return;
+          }
+          if (task.type !== TaskType.IMAGE) {
+            cursor.continue();
+            return;
+          }
+
+          scannedImageTasks++;
+          if (swImageTaskMatchesUrl(task, targetUrl)) {
+            resolve(task.id);
+            return;
+          }
+
+          cursor.continue();
+        };
+
+        cursorReq.onerror = () => {
+          reject(
+            new Error(
+              `Failed to find image task by result URL: ${cursorReq.error?.message}`
+            )
+          );
+        };
+      });
+    } catch (error) {
+      console.error('[TaskStorageReader] Error finding image task:', error);
       return null;
     }
   }

--- a/packages/drawnix/src/utils/ai-image-draft-state.ts
+++ b/packages/drawnix/src/utils/ai-image-draft-state.ts
@@ -1,0 +1,35 @@
+export interface AIImageDraftState {
+  prompt: string;
+  imageCount: number;
+  knowledgeContextCount: number;
+}
+
+let currentDraft: AIImageDraftState = {
+  prompt: '',
+  imageCount: 0,
+  knowledgeContextCount: 0,
+};
+
+export function setAIImageDraftState(draft: AIImageDraftState): void {
+  currentDraft = {
+    prompt: draft.prompt,
+    imageCount: draft.imageCount,
+    knowledgeContextCount: draft.knowledgeContextCount,
+  };
+}
+
+export function clearAIImageDraftState(): void {
+  currentDraft = {
+    prompt: '',
+    imageCount: 0,
+    knowledgeContextCount: 0,
+  };
+}
+
+export function hasAIImageDraftContent(): boolean {
+  return (
+    currentDraft.prompt.trim().length > 0 ||
+    currentDraft.imageCount > 0 ||
+    currentDraft.knowledgeContextCount > 0
+  );
+}

--- a/packages/drawnix/src/utils/image-task-prefill.ts
+++ b/packages/drawnix/src/utils/image-task-prefill.ts
@@ -1,0 +1,260 @@
+import type { KnowledgeContextRef, Task } from '../types/task.types';
+import type { ModelRef } from './settings-manager';
+import type { AIInputPrefillEventDetail } from '../services/ai-input-ui-events';
+
+export interface ImageGenerationReferenceImage {
+  url: string;
+  name: string;
+}
+
+export interface ImageGenerationInitialData {
+  prefillId: string;
+  initialPrompt: string;
+  initialWidth?: number;
+  initialHeight?: number;
+  initialResultUrl?: string;
+  initialAspectRatio?: string;
+  initialImages: ImageGenerationReferenceImage[];
+  initialKnowledgeContextRefs?: KnowledgeContextRef[];
+}
+
+function normalizeImageTaskDataUrl(value: string): string {
+  const trimmed = value.trim();
+
+  if (
+    !trimmed ||
+    trimmed.startsWith('data:') ||
+    trimmed.startsWith('blob:') ||
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../')
+  ) {
+    return trimmed || value;
+  }
+
+  const normalized = trimmed.replace(/\s+/g, '');
+  if (!/^[A-Za-z0-9+/=]+$/.test(normalized) || normalized.length < 32) {
+    return trimmed;
+  }
+
+  return `data:image/png;base64,${normalized}`;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function readModelRef(value: unknown): ModelRef | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const profileId = record.profileId;
+  const modelId = record.modelId;
+  return {
+    profileId: typeof profileId === 'string' ? profileId : null,
+    modelId: typeof modelId === 'string' ? modelId : null,
+  };
+}
+
+function readStringParams(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return Object.entries(value as Record<string, unknown>).reduce<
+    Record<string, string>
+  >((acc, [key, item]) => {
+    if (typeof item === 'string' && item.trim()) {
+      acc[key] = item;
+    }
+    return acc;
+  }, {});
+}
+
+function readKnowledgeContextRefs(value: unknown): KnowledgeContextRef[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const refs: KnowledgeContextRef[] = [];
+  const seen = new Set<string>();
+  value.forEach((item) => {
+    if (!item || typeof item !== 'object') {
+      return;
+    }
+
+    const record = item as Record<string, unknown>;
+    const noteId = readString(record.noteId);
+    if (!noteId || seen.has(noteId)) {
+      return;
+    }
+
+    seen.add(noteId);
+    refs.push({
+      noteId,
+      title: readString(record.title) || '未命名笔记',
+      directoryId: readString(record.directoryId),
+      updatedAt: readFiniteNumber(record.updatedAt),
+    });
+  });
+  return refs;
+}
+
+function normalizeReferenceImage(
+  value: unknown,
+  index: number,
+  labelPrefix: string
+): ImageGenerationReferenceImage | null {
+  if (typeof value === 'string') {
+    const url = readString(value);
+    return url
+      ? { url: normalizeImageTaskDataUrl(url), name: `${labelPrefix} ${index + 1}` }
+      : null;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const url = readString(record.url) || readString(record.base64);
+  if (!url) {
+    return null;
+  }
+
+  return {
+    url: normalizeImageTaskDataUrl(url),
+    name: readString(record.name) || `${labelPrefix} ${index + 1}`,
+  };
+}
+
+function appendReferenceImages(
+  target: ImageGenerationReferenceImage[],
+  seenUrls: Set<string>,
+  values: unknown,
+  labelPrefix: string
+): void {
+  if (!Array.isArray(values)) {
+    return;
+  }
+
+  values.forEach((value, index) => {
+    const image = normalizeReferenceImage(value, index, labelPrefix);
+    if (!image || seenUrls.has(image.url)) {
+      return;
+    }
+
+    seenUrls.add(image.url);
+    target.push(image);
+  });
+}
+
+export function getImageTaskKnowledgeContextRefs(
+  task: Pick<Task, 'params'>
+): KnowledgeContextRef[] {
+  const params = task.params as Record<string, unknown>;
+  const refs = readKnowledgeContextRefs(params.knowledgeContextRefs);
+  if (refs.length > 0) {
+    return refs;
+  }
+
+  const promptMeta = params.promptMeta;
+  if (!promptMeta || typeof promptMeta !== 'object') {
+    return [];
+  }
+  return readKnowledgeContextRefs(
+    (promptMeta as Record<string, unknown>).knowledgeContextRefs
+  );
+}
+
+export function getImageTaskReferenceImages(
+  task: Pick<Task, 'params'>
+): ImageGenerationReferenceImage[] {
+  const params = task.params as Record<string, unknown>;
+  const images: ImageGenerationReferenceImage[] = [];
+  const seenUrls = new Set<string>();
+
+  appendReferenceImages(images, seenUrls, params.uploadedImages, '参考图');
+
+  const uploadedImage = normalizeReferenceImage(
+    params.uploadedImage,
+    images.length,
+    '参考图'
+  );
+  if (uploadedImage && !seenUrls.has(uploadedImage.url)) {
+    seenUrls.add(uploadedImage.url);
+    images.push(uploadedImage);
+  }
+
+  appendReferenceImages(images, seenUrls, params.referenceImages, '参考图');
+
+  const inputReference = normalizeReferenceImage(
+    params.inputReference,
+    images.length,
+    '参考图'
+  );
+  if (inputReference && !seenUrls.has(inputReference.url)) {
+    images.push(inputReference);
+  }
+
+  return images;
+}
+
+export function buildImageTaskPrefillInitialData(
+  task: Task
+): ImageGenerationInitialData {
+  const params = task.params as Record<string, unknown>;
+  const knowledgeContextRefs = getImageTaskKnowledgeContextRefs(task);
+
+  return {
+    prefillId: `${task.id}-${Date.now()}`,
+    initialPrompt: readString(params.prompt) || '',
+    initialWidth: readFiniteNumber(params.width),
+    initialHeight: readFiniteNumber(params.height),
+    initialResultUrl: readString(task.result?.url),
+    initialAspectRatio: readString(params.aspectRatio),
+    initialImages: getImageTaskReferenceImages(task),
+    ...(knowledgeContextRefs.length > 0
+      ? { initialKnowledgeContextRefs: knowledgeContextRefs }
+      : {}),
+  };
+}
+
+export function buildImageTaskAIInputPrefillData(
+  task: Task
+): AIInputPrefillEventDetail {
+  const params = task.params as Record<string, unknown>;
+  const nestedParams = readStringParams(params.params);
+  const size = readString(params.size) || readString(params.aspectRatio);
+  const model = readString(params.model);
+  const count = readPositiveInteger(params.batchTotal);
+  const knowledgeContextRefs = getImageTaskKnowledgeContextRefs(task);
+
+  return {
+    generationType: 'image',
+    prompt: readString(params.prompt) || '',
+    images: getImageTaskReferenceImages(task),
+    ...(model ? { model } : {}),
+    modelRef: readModelRef(params.modelRef),
+    ...(knowledgeContextRefs.length > 0 ? { knowledgeContextRefs } : {}),
+    params: {
+      ...nestedParams,
+      ...(size ? { size: size.replace(':', 'x').toLowerCase() } : {}),
+    },
+    ...(count ? { count } : {}),
+  };
+}


### PR DESCRIPTION
增加了一个“再次生成”的功能。

某次生成结果不满意，可以点击“再次生成”，会将对应的提示词、参考图重新添加到输入框，可以直接发送，或者微调之后发送。