### PR TITLE
Improve chat drawer workflow generation

### DIFF
--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -49,7 +49,10 @@ import {
   scrollToPointIfNeeded,
 } from '../../utils/selection-utils';
 import { useTextSelection } from '../../hooks/useTextSelection';
-import { useChatDrawerControl } from '../../contexts/ChatDrawerContext';
+import {
+  useChatDrawerControl,
+  type DrawerGenerationSubmitParams,
+} from '../../contexts/ChatDrawerContext';
 import { useAssets } from '../../contexts/AssetContext';
 import { useModelHealthContext } from '../../contexts/ModelHealthContext';
 import {
@@ -172,6 +175,12 @@ import {
   type AIInputPrefillEventDetail,
 } from '../../services/ai-input-ui-events';
 import { normalizeKnowledgeContextRefs } from '../../services/generation-context-service';
+import {
+  ensureTaskIdInStepResult,
+  extractTaskIdFromStepResult,
+  findWorkflowStepByTaskId,
+  findWorkflowStepForTask,
+} from '../../utils/workflow-task-linking';
 
 /**
  * 将 WorkflowDefinition 转换为 WorkflowMessageData
@@ -213,6 +222,13 @@ function toWorkflowMessageData(
     postProcessingStatus,
     insertedCount,
   };
+}
+
+function areAllWorkflowStepsCompleted(workflow: WorkflowDefinition): boolean {
+  return (
+    workflow.steps.length > 0 &&
+    workflow.steps.every((step) => step.status === 'completed')
+  );
 }
 
 function toPromptAnalyticsType(
@@ -384,6 +400,17 @@ interface SelectedContent {
   name: string; // 显示名称
   width?: number; // 图片/视频宽度
   height?: number; // 图片/视频高度
+}
+
+interface GenerationRequestOverride {
+  prompt: string;
+  content: SelectedContent[];
+  generationType: GenerationType;
+  selectedModel: string;
+  selectedModelRef?: ModelRef | null;
+  selectedParams: Record<string, string>;
+  selectedCount: number;
+  appendToCurrentChatSession?: boolean;
 }
 
 function getSelectionKeyForModel(
@@ -800,6 +827,11 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       chatDrawerControl.updateWorkflowMessage
     );
     updateWorkflowMessageRef.current = chatDrawerControl.updateWorkflowMessage;
+    const syncWorkflowTaskUpdateRef = useRef(
+      chatDrawerControl.syncWorkflowTaskUpdate
+    );
+    syncWorkflowTaskUpdateRef.current =
+      chatDrawerControl.syncWorkflowTaskUpdate;
     const appendAgentLogRef = useRef(chatDrawerControl.appendAgentLog);
     appendAgentLogRef.current = chatDrawerControl.appendAgentLog;
     const updateThinkingContentRef = useRef(
@@ -812,6 +844,11 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       chatDrawerControl.registerRetryHandler
     );
     registerRetryHandlerRef.current = chatDrawerControl.registerRetryHandler;
+    const registerGenerationSubmitterRef = useRef(
+      chatDrawerControl.registerGenerationSubmitter
+    );
+    registerGenerationSubmitterRef.current =
+      chatDrawerControl.registerGenerationSubmitter;
 
     // 当前工作流的重试上下文（用于在更新时保持 retryContext）
     const currentRetryContextRef = useRef<WorkflowRetryContext | null>(null);
@@ -1633,15 +1670,15 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         .observeTaskUpdates()
         .subscribe((event) => {
           const task = event.task;
+          syncWorkflowTaskUpdateRef.current(task);
+
           const workflow = workflowControl.getWorkflow();
 
           if (!workflow) return;
 
-          // 查找与此任务关联的步骤
-          const step = workflow.steps.find((s) => {
-            const result = s.result as { taskId?: string } | undefined;
-            return result?.taskId === task.id;
-          });
+          // 查找与此任务关联的步骤。图片锚点链路里，任务完成事件可能先于
+          // taskId 写入步骤抵达，所以除 result.taskId 外还按 workflowId/batchIndex 兜底。
+          const step = findWorkflowStepForTask(workflow, task);
 
           if (!step) return;
 
@@ -1658,19 +1695,26 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           switch (task.status) {
             case TaskStatus.PENDING:
             case TaskStatus.PROCESSING:
+              workflowControl.resumeWorkflow();
               newStatus = 'running';
+              stepResult = ensureTaskIdInStepResult(stepResult, task.id);
+              stepError = undefined;
               break;
             case TaskStatus.COMPLETED:
               newStatus = 'completed';
               // 添加任务结果信息
               stepResult = {
-                ...(typeof stepResult === 'object' ? stepResult : {}),
+                ...(stepResult && typeof stepResult === 'object'
+                  ? stepResult
+                  : {}),
                 taskId: task.id,
                 result: task.result,
               };
+              stepError = undefined;
               break;
             case TaskStatus.FAILED:
               newStatus = 'failed';
+              stepResult = ensureTaskIdInStepResult(stepResult, task.id);
               stepError = task.error?.message || '任务执行失败';
               break;
             case TaskStatus.CANCELLED:
@@ -1679,7 +1723,17 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           }
 
           // 只有状态变化时才更新
-          if (newStatus !== step.status) {
+          const nextTaskId = extractTaskIdFromStepResult(stepResult);
+          const previousTaskId = extractTaskIdFromStepResult(step.result);
+          const shouldForceImageCompletionSync =
+            workflow.generationType === 'image' &&
+            task.status === TaskStatus.COMPLETED;
+          if (
+            newStatus !== step.status ||
+            nextTaskId !== previousTaskId ||
+            stepError !== step.error ||
+            shouldForceImageCompletionSync
+          ) {
             workflowControl.updateStep(
               step.id,
               newStatus,
@@ -1711,9 +1765,19 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
             // 同步更新 ChatDrawer 中的工作流消息
             const updatedWorkflow = workflowControl.getWorkflow();
             if (updatedWorkflow) {
+              const shouldMarkImageWorkflowCompleted =
+                updatedWorkflow.generationType === 'image' &&
+                areAllWorkflowStepsCompleted(updatedWorkflow);
+              if (shouldMarkImageWorkflowCompleted) {
+                postProcessingStatusRef.current = 'completed';
+              }
               const workflowData = toWorkflowMessageData(
                 updatedWorkflow,
-                currentRetryContextRef.current || undefined
+                currentRetryContextRef.current || undefined,
+                shouldMarkImageWorkflowCompleted
+                  ? 'completed'
+                  : postProcessingStatusRef.current,
+                insertedCountRef.current
               );
               updateWorkflowMessageRef.current(workflowData);
 
@@ -1748,10 +1812,10 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           const workflow = workflowControl.getWorkflow();
 
           // 查找与此任务关联的步骤（即使 workflow 为 null 也继续处理 postProcessingCompleted）
-          const step = workflow?.steps.find((s) => {
-            const result = s.result as { taskId?: string } | undefined;
-            return result?.taskId === event.taskId;
-          });
+          const eventTask = taskQueueService.getTask(event.taskId);
+          const step = eventTask
+            ? findWorkflowStepForTask(workflow, eventTask)
+            : findWorkflowStepByTaskId(workflow, event.taskId);
 
           // 更新后处理状态
           let newPostProcessingStatus: PostProcessingStatus | undefined;
@@ -1779,12 +1843,50 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
 
           // 同步更新 ChatDrawer 中的工作流消息（仅当 workflow 和 step 都存在时）
           if (workflow && step) {
+            const stepTaskId = extractTaskIdFromStepResult(step.result);
+            if (!stepTaskId && eventTask) {
+              workflowControl.updateStep(
+                step.id,
+                step.status,
+                ensureTaskIdInStepResult(step.result, event.taskId),
+                step.error,
+                step.duration
+              );
+            }
+
+            if (
+              event.type === 'postProcessingCompleted' &&
+              step.status !== 'completed' &&
+              eventTask?.status === TaskStatus.COMPLETED
+            ) {
+              workflowControl.updateStep(
+                step.id,
+                'completed',
+                {
+                  ...ensureTaskIdInStepResult(step.result, event.taskId),
+                  result: eventTask.result,
+                },
+                undefined,
+                step.duration
+              );
+            }
+
             const updatedWorkflow = workflowControl.getWorkflow();
             if (updatedWorkflow) {
+              const shouldKeepImageWorkflowCompleted =
+                updatedWorkflow.generationType === 'image' &&
+                areAllWorkflowStepsCompleted(updatedWorkflow);
+              const workflowPostProcessingStatus =
+                shouldKeepImageWorkflowCompleted
+                  ? 'completed'
+                  : newPostProcessingStatus;
+              if (workflowPostProcessingStatus === 'completed') {
+                postProcessingStatusRef.current = 'completed';
+              }
               const workflowData = toWorkflowMessageData(
                 updatedWorkflow,
                 currentRetryContextRef.current || undefined,
-                newPostProcessingStatus,
+                workflowPostProcessingStatus,
                 insertedCountRef.current
               );
               updateWorkflowMessageRef.current(workflowData);
@@ -2482,6 +2584,8 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           url: c.url,
           text: c.text,
           name: c.name,
+          width: c.width,
+          height: c.height,
         }))
       );
     }, [allContent]);
@@ -2884,722 +2988,837 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     );
 
     // Handle generation
-    const handleGenerate = useCallback(async (trigger: AIInputSubmitTrigger) => {
-      const trimmedPrompt = prompt.trim();
-      if (!trimmedPrompt && allContent.length === 0) {
-        return;
-      }
-      if (submitLockRef.current || isSubmitting) {
-        return; // 仅防止快速重复点击
-      }
-      submitLockRef.current = true;
-      setIsInspirationSendGuideActive(false);
-      onEnableRuntime?.();
-
-      const submitStartTime = Date.now();
-      const promptLength = trimmedPrompt.length;
-      const submitAnalyticsBase = {
-        trigger,
-        source: 'ai_input_bar',
-        generationType,
-        generation_type: generationType,
-        model: selectedModel,
-        profileId: selectedModelRef?.profileId || null,
-        profile_id: selectedModelRef?.profileId || null,
-        hasAttachedContent: allContent.length > 0,
-        has_attached_content: allContent.length > 0,
-        attachedCount: allContent.length,
-        attached_count: allContent.length,
-        knowledgeContextCount: knowledgeContextRefs.length,
-        knowledge_context_count: knowledgeContextRefs.length,
-        promptLength,
-        prompt_length: promptLength,
-        promptLengthBucket: getPromptLengthBucket(promptLength),
-        prompt_length_bucket: getPromptLengthBucket(promptLength),
-      };
-      const trackSubmitStatus = (
-        status: 'start' | 'success' | 'failed' | 'cancelled',
-        extras: Record<string, unknown> = {}
+    const handleGenerate = useCallback(
+      async (
+        triggerOrOverride:
+          | AIInputSubmitTrigger
+          | GenerationRequestOverride = 'button'
       ) => {
-        const durationMs = Date.now() - submitStartTime;
-        analytics.track('ai_input_submit', {
-          ...submitAnalyticsBase,
-          status,
-          durationMs,
-          duration_ms: durationMs,
-          ...extras,
-        });
-      };
+        const override =
+          typeof triggerOrOverride === 'string' ? undefined : triggerOrOverride;
+        const trigger =
+          typeof triggerOrOverride === 'string' ? triggerOrOverride : 'button';
+        const effectivePrompt = override?.prompt ?? prompt;
+        const effectiveContent = override?.content ?? allContent;
+        const effectiveGenerationType =
+          override?.generationType ?? generationType;
+        const effectiveSelectedModel = override?.selectedModel ?? selectedModel;
+        const effectiveSelectedModelRef =
+          override?.selectedModelRef ?? selectedModelRef;
+        const effectiveSelectedParams =
+          override?.selectedParams ?? selectedParams;
+        const effectiveSelectedCount = override?.selectedCount ?? selectedCount;
+        const appendToCurrentChatSession =
+          override?.appendToCurrentChatSession ?? false;
+        const shouldClearLocalInput = !override;
+        const effectiveKnowledgeContextRefs = override
+          ? []
+          : knowledgeContextRefs;
+        const trimmedPrompt = effectivePrompt.trim();
 
-      trackSubmitStatus('start');
-      setIsSubmitting(true);
-
-      try {
-        // 检查 API key，如果没有配置则弹窗获取
-        const currentRouteType =
-          generationType === 'video'
-            ? 'video'
-            : generationType === 'audio'
-            ? 'audio'
-            : generationType === 'text' || generationType === 'agent'
-            ? 'text'
-            : 'image';
-        const hasRouteCredentials = hasInvocationRouteCredentials(
-          currentRouteType,
-          selectedModelRef || selectedModel
-        );
-        if (!hasRouteCredentials) {
-          const newApiKey = await promptForApiKey();
-          if (!newApiKey) {
-            trackSubmitStatus('cancelled', {
-              reason: 'missing_api_key',
-              submitMode: 'preflight',
-              submit_mode: 'preflight',
-            });
-            submitLockRef.current = false;
-            setIsSubmitting(false);
-            return;
-          }
+        if (!trimmedPrompt && effectiveContent.length === 0) {
+          return;
         }
+        if (submitLockRef.current || isSubmitting) {
+          return; // 仅防止快速重复点击
+        }
+        submitLockRef.current = true;
+        setIsInspirationSendGuideActive(false);
+        onEnableRuntime?.();
 
-        // 构建选中元素的分类信息（使用合并后的 allContent）
-        // 收集图片和图形的尺寸信息（按顺序：先 images，后 graphics）
-        const imageItems = allContent.filter(
-          (item) => item.type === 'image' && item.url
-        );
-        const graphicsItems = allContent.filter(
-          (item) => item.type === 'graphics' && item.url
-        );
-        const imageDimensions = [...imageItems, ...graphicsItems]
-          .map((item) => {
-            if (item.width && item.height) {
-              return { width: item.width, height: item.height };
-            }
-            return undefined;
-          })
-          .filter(
-            (dim): dim is { width: number; height: number } => dim !== undefined
-          );
-
-        const selection = {
-          texts: allContent
-            .filter((item) => item.type === 'text' && item.text)
-            .map((item) => item.text!),
-          images: imageItems.map((item) => item.url!),
-          videos: allContent
-            .filter((item) => item.type === 'video' && item.url)
-            .map((item) => item.url!),
-          graphics: graphicsItems.map((item) => item.url!),
-          // 添加图片尺寸信息（始终传递数组，避免下游处理 undefined）
-          imageDimensions: imageDimensions,
-          maskImage:
-            imageItems.length === 1 && graphicsItems.length === 0
-              ? imageItems[0].maskImage
-              : undefined,
+        const submitStartTime = Date.now();
+        const promptLength = trimmedPrompt.length;
+        const submitAnalyticsBase = {
+          trigger,
+          source: override ? 'chat_drawer' : 'ai_input_bar',
+          generationType: effectiveGenerationType,
+          generation_type: effectiveGenerationType,
+          model: effectiveSelectedModel,
+          profileId: effectiveSelectedModelRef?.profileId || null,
+          profile_id: effectiveSelectedModelRef?.profileId || null,
+          hasAttachedContent: effectiveContent.length > 0,
+          has_attached_content: effectiveContent.length > 0,
+          attachedCount: effectiveContent.length,
+          attached_count: effectiveContent.length,
+          knowledgeContextCount: effectiveKnowledgeContextRefs.length,
+          knowledge_context_count: effectiveKnowledgeContextRefs.length,
+          promptLength,
+          prompt_length: promptLength,
+          promptLengthBucket: getPromptLengthBucket(promptLength),
+          prompt_length_bucket: getPromptLengthBucket(promptLength),
+        };
+        const trackSubmitStatus = (
+          status: 'start' | 'success' | 'failed' | 'cancelled',
+          extras: Record<string, unknown> = {}
+        ) => {
+          const durationMs = Date.now() - submitStartTime;
+          analytics.track('ai_input_submit', {
+            ...submitAnalyticsBase,
+            status,
+            durationMs,
+            duration_ms: durationMs,
+            ...extras,
+          });
         };
 
-        // 解析输入内容，使用选中的模型和尺寸
-        const parsedParams = parseAIInput(prompt, selection, {
-          modelId: selectedModel,
-          modelRef: selectedModelRef,
-          params: selectedParams,
-          generationType: generationType,
-          count: selectedCount,
-          knowledgeContextRefs,
-          defaultModels:
-            generationType === 'agent' ? agentMediaDefaultModels : undefined,
-          defaultModelRefs:
-            generationType === 'agent' ? agentMediaDefaultModelRefs : undefined,
-        });
+        setIsSubmitting(true);
+        trackSubmitStatus('start');
 
-        // 收集所有参考媒体（图片 + 图形 + 视频）
-        const referenceImages = [...selection.images, ...selection.graphics];
-
-        // 创建工作流定义（仅用于 WorkZone 显示，实际工作流由 submitWorkflowToSW 创建）
-        let workflow: WorkflowDefinition;
-        if (generationType === 'agent' && selectedSkillId !== SKILL_AUTO_ID) {
-          // Skill 模式：根据 skillId 决定使用系统内置 Skill 还是用户自定义 Skill
-          const systemSkill = findSystemSkillById(selectedSkillId);
-          if (systemSkill) {
-            // 系统内置 Skill：直接转换，失败时降级到通用工作流
-            try {
-              workflow = await convertSkillFlowToWorkflow(
-                parsedParams,
-                systemSkill,
-                referenceImages
-              );
-            } catch (e) {
-              console.warn(
-                '[AIInputBar] 系统 Skill 工作流转换失败，降级到通用工作流:',
-                e
-              );
-              workflow = convertToWorkflow(parsedParams, referenceImages);
+        try {
+          // 检查 API key，如果没有配置则弹窗获取
+          const currentRouteType =
+            effectiveGenerationType === 'video'
+              ? 'video'
+              : effectiveGenerationType === 'audio'
+              ? 'audio'
+              : effectiveGenerationType === 'text' ||
+                effectiveGenerationType === 'agent'
+              ? 'text'
+              : 'image';
+          const hasRouteCredentials = hasInvocationRouteCredentials(
+            currentRouteType,
+            effectiveSelectedModelRef || effectiveSelectedModel
+          );
+          if (!hasRouteCredentials) {
+            const newApiKey = await promptForApiKey();
+            if (!newApiKey) {
+              trackSubmitStatus('cancelled', {
+                reason: 'missing_api_key',
+                submitMode: 'preflight',
+                submit_mode: 'preflight',
+              });
+              submitLockRef.current = false;
+              setIsSubmitting(false);
+              return;
             }
-          } else {
-            // 尝试外部 Skill
-            const externalSkill = findExternalSkillById(selectedSkillId);
-            if (externalSkill) {
-              // 外部 Skill：使用 content（SKILL.md 文档体）走三条路径
+          }
+
+          // 构建选中元素的分类信息（使用合并后的 allContent）
+          // 收集图片和图形的尺寸信息（按顺序：先 images，后 graphics）
+          const imageItems = effectiveContent.filter(
+            (item) => item.type === 'image' && item.url
+          );
+          const graphicsItems = effectiveContent.filter(
+            (item) => item.type === 'graphics' && item.url
+          );
+          const imageDimensions = [...imageItems, ...graphicsItems]
+            .map((item) => {
+              if (item.width && item.height) {
+                return { width: item.width, height: item.height };
+              }
+              return undefined;
+            })
+            .filter(
+              (dim): dim is { width: number; height: number } =>
+                dim !== undefined
+            );
+
+          const selection = {
+            texts: effectiveContent
+              .filter((item) => item.type === 'text' && item.text)
+              .map((item) => item.text!),
+            images: imageItems.map((item) => item.url!),
+            videos: effectiveContent
+              .filter((item) => item.type === 'video' && item.url)
+              .map((item) => item.url!),
+            graphics: graphicsItems.map((item) => item.url!),
+            // 添加图片尺寸信息（始终传递数组，避免下游处理 undefined）
+            imageDimensions: imageDimensions,
+            maskImage:
+              imageItems.length === 1 && graphicsItems.length === 0
+                ? imageItems[0].maskImage
+                : undefined,
+          };
+
+          // 解析输入内容，使用选中的模型和尺寸
+          const parsedParams = parseAIInput(effectivePrompt, selection, {
+            modelId: effectiveSelectedModel,
+            modelRef: effectiveSelectedModelRef,
+            params: effectiveSelectedParams,
+            generationType: effectiveGenerationType,
+            count: effectiveSelectedCount,
+            knowledgeContextRefs: effectiveKnowledgeContextRefs,
+            defaultModels:
+              effectiveGenerationType === 'agent'
+                ? agentMediaDefaultModels
+                : undefined,
+            defaultModelRefs:
+              effectiveGenerationType === 'agent'
+                ? agentMediaDefaultModelRefs
+                : undefined,
+          });
+
+          // 收集所有参考媒体（图片 + 图形 + 视频）
+          const referenceImages = [...selection.images, ...selection.graphics];
+
+          // 创建工作流定义（仅用于 WorkZone 显示，实际工作流由 submitWorkflowToSW 创建）
+          let workflow: WorkflowDefinition;
+          if (
+            effectiveGenerationType === 'agent' &&
+            selectedSkillId !== SKILL_AUTO_ID
+          ) {
+            // Skill 模式：根据 skillId 决定使用系统内置 Skill 还是用户自定义 Skill
+            const systemSkill = findSystemSkillById(selectedSkillId);
+            if (systemSkill) {
+              // 系统内置 Skill：直接转换，失败时降级到通用工作流
               try {
                 workflow = await convertSkillFlowToWorkflow(
                   parsedParams,
-                  {
-                    id: externalSkill.id,
-                    name: externalSkill.name,
-                    type: 'external' as const,
-                    content: externalSkill.content,
-                    outputType: externalSkill.outputType,
-                  },
+                  systemSkill,
                   referenceImages
                 );
               } catch (e) {
                 console.warn(
-                  '[AIInputBar] 外部 Skill 工作流转换失败，降级到角色扮演:',
+                  '[AIInputBar] 系统 Skill 工作流转换失败，降级到通用工作流:',
                   e
                 );
-                // 外部 Skill 降级时，使用 content 作为 systemPrompt
-                workflow = await convertSkillFlowToWorkflow(
-                  parsedParams,
-                  {
-                    id: externalSkill.id,
-                    name: externalSkill.name,
-                    type: 'external' as const,
-                    content: externalSkill.content,
-                    outputType: externalSkill.outputType,
-                  },
-                  referenceImages
-                ).catch(() => convertToWorkflow(parsedParams, referenceImages));
+                workflow = convertToWorkflow(parsedParams, referenceImages);
               }
             } else {
-              // 用户自定义 Skill：从知识库读取笔记内容
-              try {
-                const userNote = await knowledgeBaseService.getNoteById(
-                  selectedSkillId
-                );
-                if (userNote) {
-                  const userOutputType =
-                    (userNote.metadata?.outputType as
-                      | 'image'
-                      | 'text'
-                      | 'video'
-                      | 'audio'
-                      | 'ppt') || undefined;
+              // 尝试外部 Skill
+              const externalSkill = findExternalSkillById(selectedSkillId);
+              if (externalSkill) {
+                // 外部 Skill：使用 content（SKILL.md 文档体）走三条路径
+                try {
                   workflow = await convertSkillFlowToWorkflow(
                     parsedParams,
                     {
-                      id: userNote.id,
-                      name: userNote.title,
-                      type: 'user',
-                      content: userNote.content,
-                      outputType: userOutputType,
+                      id: externalSkill.id,
+                      name: externalSkill.name,
+                      type: 'external' as const,
+                      content: externalSkill.content,
+                      outputType: externalSkill.outputType,
                     },
                     referenceImages
                   );
-                } else {
+                } catch (e) {
+                  console.warn(
+                    '[AIInputBar] 外部 Skill 工作流转换失败，降级到角色扮演:',
+                    e
+                  );
+                  // 外部 Skill 降级时，使用 content 作为 systemPrompt
+                  workflow = await convertSkillFlowToWorkflow(
+                    parsedParams,
+                    {
+                      id: externalSkill.id,
+                      name: externalSkill.name,
+                      type: 'external' as const,
+                      content: externalSkill.content,
+                      outputType: externalSkill.outputType,
+                    },
+                    referenceImages
+                  ).catch(() =>
+                    convertToWorkflow(parsedParams, referenceImages)
+                  );
+                }
+              } else {
+                // 用户自定义 Skill：从知识库读取笔记内容
+                try {
+                  const userNote = await knowledgeBaseService.getNoteById(
+                    selectedSkillId
+                  );
+                  if (userNote) {
+                    const userOutputType =
+                      (userNote.metadata?.outputType as
+                        | 'image'
+                        | 'text'
+                        | 'video'
+                        | 'audio'
+                        | 'ppt') || undefined;
+                    workflow = await convertSkillFlowToWorkflow(
+                      parsedParams,
+                      {
+                        id: userNote.id,
+                        name: userNote.title,
+                        type: 'user',
+                        content: userNote.content,
+                        outputType: userOutputType,
+                      },
+                      referenceImages
+                    );
+                  } else {
+                    workflow = convertToWorkflow(parsedParams, referenceImages);
+                  }
+                } catch {
                   workflow = convertToWorkflow(parsedParams, referenceImages);
                 }
-              } catch {
-                workflow = convertToWorkflow(parsedParams, referenceImages);
               }
             }
-          }
-          // 兜底：若上述所有路径均未赋值（理论上不应发生），降级到通用工作流
-          if (!workflow) {
-            console.warn('[AIInputBar] Skill 工作流未能生成，降级到通用工作流');
+            // 兜底：若上述所有路径均未赋值（理论上不应发生），降级到通用工作流
+            if (!workflow) {
+              console.warn(
+                '[AIInputBar] Skill 工作流未能生成，降级到通用工作流'
+              );
+              workflow = convertToWorkflow(parsedParams, referenceImages);
+            }
+          } else {
             workflow = convertToWorkflow(parsedParams, referenceImages);
           }
-        } else {
-          workflow = convertToWorkflow(parsedParams, referenceImages);
-        }
-        const board = SelectionWatcherBoardRef.current;
-        if (board) {
-          // WorkZone 固定尺寸
-          const WORKZONE_WIDTH = 360;
-          const WORKZONE_HEIGHT = 240;
-          const GAP = 50;
+          const board = SelectionWatcherBoardRef.current;
+          if (board) {
+            // WorkZone 固定尺寸
+            const WORKZONE_WIDTH = 360;
+            const WORKZONE_HEIGHT = 240;
+            const GAP = 50;
 
-          const containerRect = board.host?.getBoundingClientRect();
-          const zoom = board.viewport?.zoom || 1;
-          const originX = board.viewport?.origination?.[0] || 0;
-          const originY = board.viewport?.origination?.[1] || 0;
+            const containerRect = board.host?.getBoundingClientRect();
+            const zoom = board.viewport?.zoom || 1;
+            const originX = board.viewport?.origination?.[0] || 0;
+            const originY = board.viewport?.origination?.[1] || 0;
 
-          const allElements = board.children.filter(
-            (el: { type?: string }) => el.type !== 'workzone'
-          );
+            const allElements = board.children.filter(
+              (el: { type?: string }) => el.type !== 'workzone'
+            );
 
-          const viewportCenterX =
-            originX + (containerRect?.width || 0) / 2 / zoom;
-          const viewportCenterY =
-            originY + (containerRect?.height || 0) / 2 / zoom;
+            const viewportCenterX =
+              originX + (containerRect?.width || 0) / 2 / zoom;
+            const viewportCenterY =
+              originY + (containerRect?.height || 0) / 2 / zoom;
 
-          let expectedInsertLeftX: number = viewportCenterX - 200;
-          let expectedInsertY: number = viewportCenterY;
-          let workzoneX: number = expectedInsertLeftX;
-          let workzoneY: number = viewportCenterY - WORKZONE_HEIGHT / 2;
+            let expectedInsertLeftX: number = viewportCenterX - 200;
+            let expectedInsertY: number = viewportCenterY;
+            let workzoneX: number = expectedInsertLeftX;
+            let workzoneY: number = viewportCenterY - WORKZONE_HEIGHT / 2;
 
-          if (allElements.length > 0) {
-            const selectedElements = getSelectedElements(board);
-            let positionCalculated = false;
+            if (allElements.length > 0) {
+              const selectedElements = getSelectedElements(board);
+              let positionCalculated = false;
 
-            if (selectedElements.length > 0) {
-              try {
-                const selectedRect = getRectangleByElements(
-                  board,
-                  selectedElements,
-                  false
-                );
-
-                // 检测选中元素是否全部为图片/视频
-                const allMediaElements = selectedElements.every(
-                  (el) =>
-                    (PlaitDrawElement.isDrawElement(el) &&
-                      PlaitDrawElement.isImage(el)) ||
-                    isPlaitVideo(el)
-                );
-
-                if (
-                  allMediaElements &&
-                  selectedRect.width > selectedRect.height
-                ) {
-                  // 横屏：插入到右侧，顶部对齐
-                  expectedInsertLeftX =
-                    selectedRect.x + selectedRect.width + GAP;
-                  expectedInsertY = selectedRect.y;
-                } else {
-                  // 竖屏或非媒体元素：插入到下方
-                  expectedInsertLeftX = selectedRect.x;
-                  expectedInsertY = selectedRect.y + selectedRect.height + GAP;
-                }
-
-                workzoneX = expectedInsertLeftX;
-                workzoneY = expectedInsertY;
-                positionCalculated = true;
-              } catch (error) {
-                console.warn(
-                  '[AIInputBar] Failed to calculate position for selected elements:',
-                  error
-                );
-              }
-            }
-
-            if (!positionCalculated) {
-              let bottommostElement: PlaitElement | null = null;
-              let maxBottomY = -Infinity;
-
-              for (const element of allElements) {
+              if (selectedElements.length > 0) {
                 try {
-                  const rect = getRectangleByElements(
+                  const selectedRect = getRectangleByElements(
                     board,
-                    [element as PlaitElement],
+                    selectedElements,
                     false
                   );
-                  const bottomY = rect.y + rect.height;
-                  if (bottomY > maxBottomY) {
-                    maxBottomY = bottomY;
-                    bottommostElement = element as PlaitElement;
+
+                  // 检测选中元素是否全部为图片/视频
+                  const allMediaElements = selectedElements.every(
+                    (el) =>
+                      (PlaitDrawElement.isDrawElement(el) &&
+                        PlaitDrawElement.isImage(el)) ||
+                      isPlaitVideo(el)
+                  );
+
+                  if (
+                    allMediaElements &&
+                    selectedRect.width > selectedRect.height
+                  ) {
+                    // 横屏：插入到右侧，顶部对齐
+                    expectedInsertLeftX =
+                      selectedRect.x + selectedRect.width + GAP;
+                    expectedInsertY = selectedRect.y;
+                  } else {
+                    // 竖屏或非媒体元素：插入到下方
+                    expectedInsertLeftX = selectedRect.x;
+                    expectedInsertY =
+                      selectedRect.y + selectedRect.height + GAP;
                   }
+
+                  workzoneX = expectedInsertLeftX;
+                  workzoneY = expectedInsertY;
+                  positionCalculated = true;
                 } catch (error) {
                   console.warn(
-                    '[AIInputBar] Failed to get rectangle for element:',
+                    '[AIInputBar] Failed to calculate position for selected elements:',
                     error
                   );
                 }
               }
 
-              if (bottommostElement) {
-                const bottommostRect = getRectangleByElements(
-                  board,
-                  [bottommostElement],
-                  false
-                );
-                expectedInsertLeftX = bottommostRect.x;
-                expectedInsertY =
-                  bottommostRect.y + bottommostRect.height + GAP;
-                workzoneX = expectedInsertLeftX;
-                workzoneY = expectedInsertY;
+              if (!positionCalculated) {
+                let bottommostElement: PlaitElement | null = null;
+                let maxBottomY = -Infinity;
+
+                for (const element of allElements) {
+                  try {
+                    const rect = getRectangleByElements(
+                      board,
+                      [element as PlaitElement],
+                      false
+                    );
+                    const bottomY = rect.y + rect.height;
+                    if (bottomY > maxBottomY) {
+                      maxBottomY = bottomY;
+                      bottommostElement = element as PlaitElement;
+                    }
+                  } catch (error) {
+                    console.warn(
+                      '[AIInputBar] Failed to get rectangle for element:',
+                      error
+                    );
+                  }
+                }
+
+                if (bottommostElement) {
+                  const bottommostRect = getRectangleByElements(
+                    board,
+                    [bottommostElement],
+                    false
+                  );
+                  expectedInsertLeftX = bottommostRect.x;
+                  expectedInsertY =
+                    bottommostRect.y + bottommostRect.height + GAP;
+                  workzoneX = expectedInsertLeftX;
+                  workzoneY = expectedInsertY;
+                }
               }
             }
-          }
 
-          const workflowMessageData = toWorkflowMessageData(workflow);
+            const workflowMessageData = toWorkflowMessageData(workflow);
 
-          // 如果选中了 Frame，将 Frame 信息传递给 WorkZone
-          // 生成完成后媒体将插入到 Frame 内部并缩放到 Frame 尺寸
-          const frameInfo = selectedFrameRef.current;
-          let targetFrameId: string | undefined;
-          let targetFrameDimensions:
-            | { width: number; height: number }
-            | undefined;
-          let targetFrameRect:
-            | { x: number; y: number; width: number; height: number }
-            | undefined;
+            // 如果选中了 Frame，将 Frame 信息传递给 WorkZone
+            // 生成完成后媒体将插入到 Frame 内部并缩放到 Frame 尺寸
+            const frameInfo = selectedFrameRef.current;
+            let targetFrameId: string | undefined;
+            let targetFrameDimensions:
+              | { width: number; height: number }
+              | undefined;
+            let targetFrameRect:
+              | { x: number; y: number; width: number; height: number }
+              | undefined;
 
-          if (frameInfo) {
-            // 验证 Frame 仍然存在
-            const frameElement = board.children.find(
-              (el: { id: string }) => el.id === frameInfo.id
-            );
-            if (frameElement && isFrameElement(frameElement)) {
-              targetFrameId = frameInfo.id;
-              targetFrameDimensions = {
-                width: frameInfo.width,
-                height: frameInfo.height,
-              };
-              // Frame 选中时，插入位置设为 Frame 左上角（后续由插入逻辑居中处理）
-              const frameRect = RectangleClient.getRectangleByPoints(
-                frameElement.points
+            if (frameInfo) {
+              // 验证 Frame 仍然存在
+              const frameElement = board.children.find(
+                (el: { id: string }) => el.id === frameInfo.id
               );
-              targetFrameRect = frameRect;
-              expectedInsertLeftX = frameRect.x;
-              expectedInsertY = frameRect.y;
+              if (frameElement && isFrameElement(frameElement)) {
+                targetFrameId = frameInfo.id;
+                targetFrameDimensions = {
+                  width: frameInfo.width,
+                  height: frameInfo.height,
+                };
+                // Frame 选中时，插入位置设为 Frame 左上角（后续由插入逻辑居中处理）
+                const frameRect = RectangleClient.getRectangleByPoints(
+                  frameElement.points
+                );
+                targetFrameRect = frameRect;
+                expectedInsertLeftX = frameRect.x;
+                expectedInsertY = frameRect.y;
+              }
             }
-          }
 
-          const isImageGeneration = parsedParams.generationType === 'image';
+            const isImageGeneration = parsedParams.generationType === 'image';
 
-          if (isImageGeneration) {
-            const requestedCount = Math.max(parsedParams.count ?? 1, 1);
-            const shouldCreateIndependentBatchAnchors = requestedCount > 1;
-            const anchorTargetFrameId = shouldCreateIndependentBatchAnchors
-              ? undefined
-              : targetFrameId;
-            const anchorTargetFrameDimensions =
-              shouldCreateIndependentBatchAnchors
+            if (isImageGeneration) {
+              const requestedCount = Math.max(parsedParams.count ?? 1, 1);
+              const shouldCreateIndependentBatchAnchors = requestedCount > 1;
+              const anchorTargetFrameId = shouldCreateIndependentBatchAnchors
                 ? undefined
-                : targetFrameDimensions;
-            const imageAnchorElements: Array<
-              ReturnType<typeof ImageGenerationAnchorTransforms.insertAnchor>
-            > = [];
-            const workflowBatchId = `wf_batch_${workflow.id}`;
-            const plannedAnchorPositions = !anchorTargetFrameId
-              ? resolveImageGenerationBatchAnchorPositions(
-                  board,
-                  [expectedInsertLeftX, expectedInsertY],
+                : targetFrameId;
+              const anchorTargetFrameDimensions =
+                shouldCreateIndependentBatchAnchors
+                  ? undefined
+                  : targetFrameDimensions;
+              const imageAnchorElements: Array<
+                ReturnType<typeof ImageGenerationAnchorTransforms.insertAnchor>
+              > = [];
+              const workflowBatchId = `wf_batch_${workflow.id}`;
+              const plannedAnchorPositions = !anchorTargetFrameId
+                ? resolveImageGenerationBatchAnchorPositions(
+                    board,
+                    [expectedInsertLeftX, expectedInsertY],
+                    buildImageGenerationAnchorCreateOptions({
+                      workflowId: workflow.id,
+                      expectedInsertPosition: [
+                        expectedInsertLeftX,
+                        expectedInsertY,
+                      ],
+                      requestedSize: parsedParams.size,
+                      requestedCount: 1,
+                      zoom,
+                      title: workflowMessageData.name || '图片生成',
+                      ...buildImageGenerationAnchorPresentationPatch(
+                        'submitted'
+                      ),
+                    }).size ?? {
+                      width: 320,
+                      height: 180,
+                    },
+                    requestedCount,
+                    {
+                      frameRect: shouldCreateIndependentBatchAnchors
+                        ? targetFrameRect
+                        : undefined,
+                    }
+                  )
+                : null;
+
+              for (let index = 0; index < requestedCount; index += 1) {
+                let anchorCreateOptions =
                   buildImageGenerationAnchorCreateOptions({
                     workflowId: workflow.id,
                     expectedInsertPosition: [
                       expectedInsertLeftX,
                       expectedInsertY,
                     ],
+                    targetFrameId: anchorTargetFrameId,
+                    targetFrameDimensions: anchorTargetFrameDimensions,
+                    frameAffinityId: shouldCreateIndependentBatchAnchors
+                      ? targetFrameId
+                      : undefined,
+                    frameAffinityDimensions: shouldCreateIndependentBatchAnchors
+                      ? targetFrameDimensions
+                      : undefined,
                     requestedSize: parsedParams.size,
-                    requestedCount: 1,
+                    requestedCount: shouldCreateIndependentBatchAnchors
+                      ? 1
+                      : requestedCount,
+                    batchId: shouldCreateIndependentBatchAnchors
+                      ? workflowBatchId
+                      : undefined,
+                    batchIndex: shouldCreateIndependentBatchAnchors
+                      ? index + 1
+                      : undefined,
+                    batchTotal: shouldCreateIndependentBatchAnchors
+                      ? requestedCount
+                      : undefined,
                     zoom,
                     title: workflowMessageData.name || '图片生成',
                     ...buildImageGenerationAnchorPresentationPatch('submitted'),
-                  }).size ?? {
-                    width: 320,
-                    height: 180,
-                  },
-                  requestedCount,
-                  {
-                    frameRect: shouldCreateIndependentBatchAnchors
-                      ? targetFrameRect
-                      : undefined,
-                  }
-                )
-              : null;
+                  });
 
-            for (let index = 0; index < requestedCount; index += 1) {
-              let anchorCreateOptions = buildImageGenerationAnchorCreateOptions(
-                {
-                  workflowId: workflow.id,
-                  expectedInsertPosition: [
-                    expectedInsertLeftX,
-                    expectedInsertY,
-                  ],
-                  targetFrameId: anchorTargetFrameId,
-                  targetFrameDimensions: anchorTargetFrameDimensions,
-                  frameAffinityId: shouldCreateIndependentBatchAnchors
-                    ? targetFrameId
-                    : undefined,
-                  frameAffinityDimensions: shouldCreateIndependentBatchAnchors
-                    ? targetFrameDimensions
-                    : undefined,
-                  requestedSize: parsedParams.size,
-                  requestedCount: shouldCreateIndependentBatchAnchors
-                    ? 1
-                    : requestedCount,
-                  batchId: shouldCreateIndependentBatchAnchors
-                    ? workflowBatchId
-                    : undefined,
-                  batchIndex: shouldCreateIndependentBatchAnchors
-                    ? index + 1
-                    : undefined,
-                  batchTotal: shouldCreateIndependentBatchAnchors
-                    ? requestedCount
-                    : undefined,
-                  zoom,
-                  title: workflowMessageData.name || '图片生成',
-                  ...buildImageGenerationAnchorPresentationPatch('submitted'),
+                if (!anchorTargetFrameId) {
+                  const resolvedAnchorPosition = plannedAnchorPositions
+                    ? plannedAnchorPositions[index] ??
+                      anchorCreateOptions.position
+                    : anchorCreateOptions.position;
+
+                  anchorCreateOptions = {
+                    ...anchorCreateOptions,
+                    position: resolvedAnchorPosition,
+                    expectedInsertPosition: resolvedAnchorPosition,
+                  };
                 }
-              );
 
-              if (!anchorTargetFrameId) {
-                const resolvedAnchorPosition = plannedAnchorPositions
-                  ? plannedAnchorPositions[index] ??
-                    anchorCreateOptions.position
-                  : anchorCreateOptions.position;
-
-                anchorCreateOptions = {
-                  ...anchorCreateOptions,
-                  position: resolvedAnchorPosition,
-                  expectedInsertPosition: resolvedAnchorPosition,
-                };
+                const anchorElement =
+                  ImageGenerationAnchorTransforms.insertAnchor(
+                    board,
+                    anchorCreateOptions
+                  );
+                imageAnchorElements.push(anchorElement);
               }
 
-              const anchorElement =
-                ImageGenerationAnchorTransforms.insertAnchor(
-                  board,
-                  anchorCreateOptions
-                );
-              imageAnchorElements.push(anchorElement);
-            }
+              currentImageAnchorIdsRef.current = imageAnchorElements.map(
+                (anchor) => anchor.id
+              );
+              currentWorkZoneIdRef.current = null;
+              const [firstAnchor] = imageAnchorElements;
+              if (firstAnchor) {
+                setTimeout(() => {
+                  const anchorRect = RectangleClient.getRectangleByPoints(
+                    firstAnchor.points
+                  );
+                  scrollToPointIfNeeded(
+                    board,
+                    [
+                      anchorRect.x + anchorRect.width / 2,
+                      anchorRect.y + anchorRect.height / 2,
+                    ],
+                    100
+                  );
+                }, 100);
+              }
+            } else {
+              const workzoneElement = WorkZoneTransforms.insertWorkZone(board, {
+                workflow: workflowMessageData,
+                position: [workzoneX, workzoneY],
+                size: { width: WORKZONE_WIDTH, height: WORKZONE_HEIGHT },
+                expectedInsertPosition: [expectedInsertLeftX, expectedInsertY],
+                targetFrameId,
+                targetFrameDimensions,
+                zoom,
+              });
 
-            currentImageAnchorIdsRef.current = imageAnchorElements.map(
-              (anchor) => anchor.id
-            );
-            currentWorkZoneIdRef.current = null;
-            const [firstAnchor] = imageAnchorElements;
-            if (firstAnchor) {
+              currentWorkZoneIdRef.current = workzoneElement.id;
+              currentImageAnchorIdsRef.current = [];
               setTimeout(() => {
-                const anchorRect = RectangleClient.getRectangleByPoints(
-                  firstAnchor.points
-                );
+                const workzoneCenterX = workzoneX + WORKZONE_WIDTH / 2;
+                const workzoneCenterY = workzoneY + WORKZONE_HEIGHT / 2;
                 scrollToPointIfNeeded(
                   board,
-                  [
-                    anchorRect.x + anchorRect.width / 2,
-                    anchorRect.y + anchorRect.height / 2,
-                  ],
+                  [workzoneCenterX, workzoneCenterY],
                   100
                 );
               }, 100);
             }
-          } else {
-            const workzoneElement = WorkZoneTransforms.insertWorkZone(board, {
-              workflow: workflowMessageData,
-              position: [workzoneX, workzoneY],
-              size: { width: WORKZONE_WIDTH, height: WORKZONE_HEIGHT },
-              expectedInsertPosition: [expectedInsertLeftX, expectedInsertY],
-              targetFrameId,
-              targetFrameDimensions,
-              zoom,
-            });
-
-            currentWorkZoneIdRef.current = workzoneElement.id;
-            currentImageAnchorIdsRef.current = [];
-            setTimeout(() => {
-              const workzoneCenterX = workzoneX + WORKZONE_WIDTH / 2;
-              const workzoneCenterY = workzoneY + WORKZONE_HEIGHT / 2;
-              scrollToPointIfNeeded(
-                board,
-                [workzoneCenterX, workzoneCenterY],
-                100
-              );
-            }, 100);
           }
-        }
 
-        const imageRoute = resolveInvocationRoute('image');
-        const videoRoute = resolveInvocationRoute('video');
-        const audioRoute = resolveInvocationRoute('audio');
-        const aiContext = {
-          rawInput: prompt,
-          userInstruction: parsedParams.userInstruction,
-          model: {
-            id: parsedParams.modelId,
-            type: parsedParams.generationType,
-            isExplicit: parsedParams.isModelExplicit,
-          },
-          modelRef: parsedParams.modelRef,
-          defaultModels: parsedParams.defaultModels || {
-            audio: audioRoute.modelId || getDefaultAudioModel(),
-            image: imageRoute.modelId || getDefaultImageModel(),
-            video: videoRoute.modelId || getDefaultVideoModel(),
-          },
-          defaultModelRefs: parsedParams.defaultModelRefs || {
-            audio: createModelRef(audioRoute.profileId, audioRoute.modelId),
-            image: createModelRef(imageRoute.profileId, imageRoute.modelId),
-            video: createModelRef(videoRoute.profileId, videoRoute.modelId),
-          },
-          params: {
-            count: parsedParams.count,
-            size: parsedParams.size,
-            duration: parsedParams.duration,
-          },
-          selection,
-          finalPrompt: parsedParams.prompt,
-          knowledgeContextRefs: parsedParams.knowledgeContextRefs,
-        };
+          const imageRoute = resolveInvocationRoute('image');
+          const videoRoute = resolveInvocationRoute('video');
+          const audioRoute = resolveInvocationRoute('audio');
+          const aiContext = {
+            rawInput: effectivePrompt,
+            userInstruction: parsedParams.userInstruction,
+            model: {
+              id: parsedParams.modelId,
+              type: parsedParams.generationType,
+              isExplicit: parsedParams.isModelExplicit,
+            },
+            modelRef: parsedParams.modelRef,
+            defaultModels: parsedParams.defaultModels || {
+              audio: audioRoute.modelId || getDefaultAudioModel(),
+              image: imageRoute.modelId || getDefaultImageModel(),
+              video: videoRoute.modelId || getDefaultVideoModel(),
+            },
+            defaultModelRefs: parsedParams.defaultModelRefs || {
+              audio: createModelRef(audioRoute.profileId, audioRoute.modelId),
+              image: createModelRef(imageRoute.profileId, imageRoute.modelId),
+              video: createModelRef(videoRoute.profileId, videoRoute.modelId),
+            },
+            params: {
+              count: parsedParams.count,
+              size: parsedParams.size,
+              duration: parsedParams.duration,
+            },
+            selection,
+            finalPrompt: parsedParams.prompt,
+            knowledgeContextRefs: parsedParams.knowledgeContextRefs,
+          };
 
-        const textModel = resolveInvocationRoute('text').modelId;
+          const textModel = resolveInvocationRoute('text').modelId;
 
-        const retryContext: WorkflowRetryContext = {
-          aiContext,
-          referenceImages,
-          textModel,
-        };
-        currentRetryContextRef.current = retryContext;
-
-        try {
-          const t0 = Date.now();
-          const { usedSW } = await submitWorkflowToSW(
-            parsedParams,
+          const retryContext: WorkflowRetryContext = {
+            aiContext,
             referenceImages,
-            retryContext,
-            workflow
-          );
-          if (usedSW) {
-            trackSubmitStatus('success', {
-              submitMode: 'service_worker',
-              submit_mode: 'service_worker',
-              workflowId: workflow.id,
-              workflow_id: workflow.id,
-              stepCount: workflow.steps.length,
-              step_count: workflow.steps.length,
-            });
-            if (generationType === 'image') {
-              applyCurrentImageAnchorPresentationState(board, 'accepted');
-            }
+            textModel,
+          };
+          currentRetryContextRef.current = retryContext;
 
-            if (prompt.trim()) {
-              const trimmedPrompt = prompt.trim();
-              const hasSelection = allContent.length > 0;
-              addPromptHistory(trimmedPrompt, hasSelection, generationType);
-              if (generationType === 'image') {
-                addImagePromptHistory(trimmedPrompt);
-              } else if (generationType === 'video') {
-                addVideoPromptHistory(trimmedPrompt);
+          try {
+            const { usedSW } = await submitWorkflowToSW(
+              parsedParams,
+              referenceImages,
+              retryContext,
+              workflow,
+              { appendToCurrentChatSession }
+            );
+            if (usedSW) {
+              trackSubmitStatus('success', {
+                submitMode: 'service_worker',
+                submit_mode: 'service_worker',
+                workflowId: workflow.id,
+                workflow_id: workflow.id,
+                stepCount: workflow.steps.length,
+                step_count: workflow.steps.length,
+              });
+              if (effectiveGenerationType === 'image') {
+                applyCurrentImageAnchorPresentationState(board, 'accepted');
               }
+
+              if (effectivePrompt.trim()) {
+                const trimmedPrompt = effectivePrompt.trim();
+                const hasSelection = effectiveContent.length > 0;
+                addPromptHistory(
+                  trimmedPrompt,
+                  hasSelection,
+                  effectiveGenerationType
+                );
+                if (effectiveGenerationType === 'image') {
+                  addImagePromptHistory(trimmedPrompt);
+                } else if (effectiveGenerationType === 'video') {
+                  addVideoPromptHistory(trimmedPrompt);
+                }
+              }
+              if (shouldClearLocalInput) {
+                setPrompt('');
+                setSelectedContent([]);
+                setUploadedContent([]);
+                setKnowledgeContextRefs([]);
+              }
+
+              if (submitCooldownRef.current) {
+                clearTimeout(submitCooldownRef.current);
+              }
+              submitCooldownRef.current = setTimeout(() => {
+                submitLockRef.current = false;
+                setIsSubmitting(false);
+                submitCooldownRef.current = null;
+              }, 1000);
+
+              return;
             }
+          } catch (swError) {
+            console.warn(
+              '[AIInputBar] SW execution failed, falling back to main thread:',
+              swError
+            );
+          }
+          if (effectiveGenerationType === 'image') {
+            applyCurrentImageAnchorPresentationState(board, 'handoff');
+          }
+
+          // 工作流已提交，立即保存历史、清空输入并解锁，步骤执行在后台继续
+          if (effectivePrompt.trim()) {
+            const trimmedPrompt = effectivePrompt.trim();
+            const hasSelection = effectiveContent.length > 0;
+            addPromptHistory(
+              trimmedPrompt,
+              hasSelection,
+              effectiveGenerationType
+            );
+            if (effectiveGenerationType === 'image') {
+              addImagePromptHistory(trimmedPrompt);
+            } else if (effectiveGenerationType === 'video') {
+              addVideoPromptHistory(trimmedPrompt);
+            }
+          }
+          if (shouldClearLocalInput) {
             setPrompt('');
             setSelectedContent([]);
             setUploadedContent([]);
             setKnowledgeContextRefs([]);
-
-            if (submitCooldownRef.current) {
-              clearTimeout(submitCooldownRef.current);
-            }
-            submitCooldownRef.current = setTimeout(() => {
-              submitLockRef.current = false;
-              setIsSubmitting(false);
-              submitCooldownRef.current = null;
-            }, 1000);
-
-            return;
           }
-        } catch (swError) {
-          console.warn(
-            '[AIInputBar] SW execution failed, falling back to main thread:',
-            swError
-          );
-        }
-        if (generationType === 'image') {
-          applyCurrentImageAnchorPresentationState(board, 'handoff');
-        }
-
-        // 工作流已提交，立即保存历史、清空输入并解锁，步骤执行在后台继续
-        if (prompt.trim()) {
-          const trimmedPrompt = prompt.trim();
-          const hasSelection = allContent.length > 0;
-          addPromptHistory(trimmedPrompt, hasSelection, generationType);
-          if (generationType === 'image') {
-            addImagePromptHistory(trimmedPrompt);
-          } else if (generationType === 'video') {
-            addVideoPromptHistory(trimmedPrompt);
+          if (submitCooldownRef.current) {
+            clearTimeout(submitCooldownRef.current);
           }
-        }
-        setPrompt('');
-        setSelectedContent([]);
-        setUploadedContent([]);
-        setKnowledgeContextRefs([]);
-        if (submitCooldownRef.current) {
-          clearTimeout(submitCooldownRef.current);
-        }
-        submitCooldownRef.current = setTimeout(() => {
-          submitLockRef.current = false;
-          setIsSubmitting(false);
-          submitCooldownRef.current = null;
-        }, 1000);
+          submitCooldownRef.current = setTimeout(() => {
+            submitLockRef.current = false;
+            setIsSubmitting(false);
+            submitCooldownRef.current = null;
+          }, 1000);
 
-        const createdTaskIds: string[] = [];
+          const createdTaskIds: string[] = [];
 
-        // 收集动态添加的步骤（用于后续执行）
-        const pendingNewSteps: Array<{
-          id: string;
-          mcp: string;
-          args: Record<string, unknown>;
-          description: string;
-          options?: WorkflowStepOptions;
-        }> = [];
+          // 收集动态添加的步骤（用于后续执行）
+          const pendingNewSteps: Array<{
+            id: string;
+            mcp: string;
+            args: Record<string, unknown>;
+            description: string;
+            options?: WorkflowStepOptions;
+          }> = [];
 
-        // 创建标准回调（所有工具都可使用，不需要的会忽略）
-        const createStepCallbacks = (
-          currentStep: (typeof workflow.steps)[0],
-          stepStartTime: number
-        ) => ({
-          // 流式输出回调
-          onChunk: (chunk: string) => {
-            updateThinkingContentRef.current(chunk);
-          },
-          // 动态添加步骤回调
-          onAddSteps: (
-            newSteps: Array<{
-              id: string;
-              mcp: string;
-              args: Record<string, unknown>;
-              description: string;
-              status: string;
-            }>
-          ) => {
-            // 当前步骤完成
-            workflowControl.updateStep(
-              currentStep.id,
-              'completed',
-              { analysis: 'completed' },
-              undefined,
-              Date.now() - stepStartTime
-            );
+          // 创建标准回调（所有工具都可使用，不需要的会忽略）
+          const createStepCallbacks = (
+            currentStep: (typeof workflow.steps)[0],
+            stepStartTime: number
+          ) => ({
+            // 流式输出回调
+            onChunk: (chunk: string) => {
+              updateThinkingContentRef.current(chunk);
+            },
+            // 动态添加步骤回调
+            onAddSteps: (
+              newSteps: Array<{
+                id: string;
+                mcp: string;
+                args: Record<string, unknown>;
+                description: string;
+                status: string;
+              }>
+            ) => {
+              // 当前步骤完成
+              workflowControl.updateStep(
+                currentStep.id,
+                'completed',
+                { analysis: 'completed' },
+                undefined,
+                Date.now() - stepStartTime
+              );
 
-            // 为新步骤添加 queue 模式选项（尊重传入的 status，若为 completed 则保留）
-            const stepsWithOptions = newSteps.map((s, index) =>
-              enrichStepArgsWithPromptMeta(workflow, {
-                ...s,
-                status: (s.status === 'completed' ? 'completed' : 'pending') as
-                  | 'pending'
-                  | 'completed',
-                options: {
-                  mode: 'queue' as const,
-                  batchId: `agent_${Date.now()}`,
-                  batchIndex: index + 1,
-                  batchTotal: newSteps.length,
-                  globalIndex: index + 1,
-                },
-              })
-            );
+              // 为新步骤添加 queue 模式选项（尊重传入的 status，若为 completed 则保留）
+              const stepsWithOptions = newSteps.map((s, index) =>
+                enrichStepArgsWithPromptMeta(workflow, {
+                  ...s,
+                  status: (s.status === 'completed'
+                    ? 'completed'
+                    : 'pending') as 'pending' | 'completed',
+                  options: {
+                    mode: 'queue' as const,
+                    batchId: `agent_${Date.now()}`,
+                    batchIndex: index + 1,
+                    batchTotal: newSteps.length,
+                    globalIndex: index + 1,
+                  },
+                })
+              );
 
-            // 添加新步骤到工作流
-            workflowControl.addSteps(stepsWithOptions);
+              // 添加新步骤到工作流
+              workflowControl.addSteps(stepsWithOptions);
 
-            // 收集待执行的步骤
-            pendingNewSteps.push(...stepsWithOptions);
+              // 收集待执行的步骤
+              pendingNewSteps.push(...stepsWithOptions);
 
-            // 追加工具调用日志
-            newSteps.forEach((s) => {
-              appendAgentLogRef.current({
-                type: 'tool_call',
-                timestamp: Date.now(),
-                toolName: s.mcp,
-                args: s.args,
+              // 追加工具调用日志
+              newSteps.forEach((s) => {
+                appendAgentLogRef.current({
+                  type: 'tool_call',
+                  timestamp: Date.now(),
+                  toolName: s.mcp,
+                  args: s.args,
+                });
               });
-            });
 
+              const workflowData = toWorkflowMessageData(
+                workflowControl.getWorkflow()!,
+                currentRetryContextRef.current || undefined
+              );
+              updateWorkflowMessageRef.current(workflowData);
+              // 同步更新 WorkZone
+              if (currentWorkZoneIdRef.current && board) {
+                WorkZoneTransforms.updateWorkflow(
+                  board,
+                  currentWorkZoneIdRef.current,
+                  workflowData
+                );
+              }
+            },
+            // 更新步骤状态回调
+            onUpdateStep: (
+              stepId: string,
+              status: string,
+              result?: unknown,
+              error?: string
+            ) => {
+              workflowControl.updateStep(
+                stepId,
+                status as
+                  | 'pending'
+                  | 'running'
+                  | 'completed'
+                  | 'failed'
+                  | 'skipped',
+                result,
+                error
+              );
+
+              // 追加工具结果日志
+              appendAgentLogRef.current({
+                type: 'tool_result',
+                timestamp: Date.now(),
+                toolName: stepId,
+                success: status === 'completed',
+                data: result,
+                error,
+              });
+
+              const workflowData = toWorkflowMessageData(
+                workflowControl.getWorkflow()!,
+                currentRetryContextRef.current || undefined
+              );
+              updateWorkflowMessageRef.current(workflowData);
+              // 同步更新 WorkZone
+              if (currentWorkZoneIdRef.current && board) {
+                WorkZoneTransforms.updateWorkflow(
+                  board,
+                  currentWorkZoneIdRef.current,
+                  workflowData
+                );
+              }
+            },
+          });
+
+          let workflowFailed = false;
+
+          // 辅助函数：同步更新 ChatDrawer 和 WorkZone
+          const syncWorkflowUpdates = () => {
             const workflowData = toWorkflowMessageData(
               workflowControl.getWorkflow()!,
               currentRetryContextRef.current || undefined
             );
             updateWorkflowMessageRef.current(workflowData);
-            // 同步更新 WorkZone
             if (currentWorkZoneIdRef.current && board) {
               WorkZoneTransforms.updateWorkflow(
                 board,
@@ -3607,352 +3826,326 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                 workflowData
               );
             }
-          },
-          // 更新步骤状态回调
-          onUpdateStep: (
-            stepId: string,
-            status: string,
-            result?: unknown,
-            error?: string
-          ) => {
-            workflowControl.updateStep(
-              stepId,
-              status as
-                | 'pending'
-                | 'running'
-                | 'completed'
-                | 'failed'
-                | 'skipped',
-              result,
-              error
-            );
+          };
 
-            // 追加工具结果日志
-            appendAgentLogRef.current({
-              type: 'tool_result',
-              timestamp: Date.now(),
-              toolName: stepId,
-              success: status === 'completed',
-              data: result,
-              error,
-            });
+          // 执行单个步骤的函数
+          const executeStep = async (step: (typeof workflow.steps)[0]) => {
+            const stepStartTime = Date.now();
+            // 记录执行前的动态步骤数量，用于判断 ai_analyze 是否触发了 onAddSteps
+            const pendingStepsBeforeExec = pendingNewSteps.length;
 
-            const workflowData = toWorkflowMessageData(
-              workflowControl.getWorkflow()!,
-              currentRetryContextRef.current || undefined
-            );
-            updateWorkflowMessageRef.current(workflowData);
-            // 同步更新 WorkZone
-            if (currentWorkZoneIdRef.current && board) {
-              WorkZoneTransforms.updateWorkflow(
-                board,
-                currentWorkZoneIdRef.current,
-                workflowData
+            // 更新步骤为运行中
+            workflowControl.updateStep(step.id, 'running');
+            syncWorkflowUpdates();
+
+            try {
+              // 合并步骤选项和标准回调（工具自行决定是否使用回调）
+              const executeOptions = {
+                ...step.options,
+                ...createStepCallbacks(step, stepStartTime),
+              }; // 通过 MCP Registry 执行工具
+              const executableStep = enrichStepArgsWithPromptMeta(
+                workflow,
+                step
               );
-            }
-          },
-        });
+              const result = (await mcpRegistry.executeTool(
+                { name: executableStep.mcp, arguments: executableStep.args },
+                executeOptions
+              )) as MCPTaskResult;
+              // 根据结果更新步骤状态
+              const currentStepStatus = workflowControl
+                .getWorkflow()
+                ?.steps.find((s) => s.id === step.id)?.status;
 
-        let workflowFailed = false;
+              if (!result.success) {
+                // 执行失败，标记工作流失败
+                workflowControl.updateStep(
+                  step.id,
+                  'failed',
+                  undefined,
+                  result.error || '执行失败',
+                  Date.now() - stepStartTime
+                );
+                return false; // 返回失败
+              } else if (result.taskId) {
+                // 队列模式：记录任务 ID（状态保持 running，等任务完成后更新）
+                createdTaskIds.push(result.taskId);
+                workflowControl.updateStep(step.id, 'running', {
+                  taskId: result.taskId,
+                });
 
-        // 辅助函数：同步更新 ChatDrawer 和 WorkZone
-        const syncWorkflowUpdates = () => {
-          const workflowData = toWorkflowMessageData(
-            workflowControl.getWorkflow()!,
-            currentRetryContextRef.current || undefined
-          );
-          updateWorkflowMessageRef.current(workflowData);
-          if (currentWorkZoneIdRef.current && board) {
-            WorkZoneTransforms.updateWorkflow(
-              board,
-              currentWorkZoneIdRef.current,
-              workflowData
-            );
-          }
-        };
+                bindCurrentImageAnchorTask(board, result.taskId, {
+                  workflowId: workflow.id,
+                  batchId: step.options?.batchId,
+                  batchIndex: step.options?.batchIndex,
+                });
+              } else if (currentStepStatus === 'running') {
+                const normalizedResultData =
+                  result.type === 'text' &&
+                  result.data &&
+                  typeof result.data === 'object' &&
+                  'content' in result.data
+                    ? { content: (result.data as { content?: string }).content }
+                    : result.data;
+                // 同步模式且未被回调更新：标记为完成
+                workflowControl.updateStep(
+                  step.id,
+                  'completed',
+                  normalizedResultData,
+                  undefined,
+                  Date.now() - stepStartTime
+                );
 
-        // 执行单个步骤的函数
-        const executeStep = async (step: (typeof workflow.steps)[0]) => {
-          const stepStartTime = Date.now();
-          // 记录执行前的动态步骤数量，用于判断 ai_analyze 是否触发了 onAddSteps
-          const pendingStepsBeforeExec = pendingNewSteps.length;
+                const responseText =
+                  step.mcp === 'generate_text'
+                    ? (result.data as { content?: string })?.content
+                    : step.mcp === 'ai_analyze'
+                    ? (result.data as { response?: string })?.response
+                    : undefined;
 
-          // 更新步骤为运行中
-          workflowControl.updateStep(step.id, 'running');
-          syncWorkflowUpdates();
+                const shouldInsertReturnedText =
+                  (step.mcp === 'generate_text' || step.mcp === 'ai_analyze') &&
+                  responseText &&
+                  responseText.trim() &&
+                  pendingNewSteps.length === pendingStepsBeforeExec;
 
-          try {
-            // 合并步骤选项和标准回调（工具自行决定是否使用回调）
-            const executeOptions = {
-              ...step.options,
-              ...createStepCallbacks(step, stepStartTime),
-            }; // 通过 MCP Registry 执行工具
-            const executableStep = enrichStepArgsWithPromptMeta(workflow, step);
-            const result = (await mcpRegistry.executeTool(
-              { name: executableStep.mcp, arguments: executableStep.args },
-              executeOptions
-            )) as MCPTaskResult;
-            // 根据结果更新步骤状态
-            const currentStepStatus = workflowControl
-              .getWorkflow()
-              ?.steps.find((s) => s.id === step.id)?.status;
+                if (shouldInsertReturnedText) {
+                  const insertStepId = `${step.id}-insert-text`;
+                  const insertStep = {
+                    id: insertStepId,
+                    mcp: 'insert_to_canvas',
+                    args: {
+                      items: [
+                        {
+                          type: 'text',
+                          content: responseText,
+                        },
+                      ],
+                    },
+                    description:
+                      step.mcp === 'generate_text'
+                        ? '将生成文本插入画布'
+                        : '将 AI 回复插入画布',
+                    status: 'pending' as const,
+                  };
+                  workflowControl.addSteps([insertStep]);
+                  pendingNewSteps.push(insertStep);
+                }
+              }
 
-            if (!result.success) {
-              // 执行失败，标记工作流失败
+              return true; // 返回成功
+            } catch (stepError) {
+              // 更新步骤为失败
               workflowControl.updateStep(
                 step.id,
                 'failed',
                 undefined,
-                result.error || '执行失败',
-                Date.now() - stepStartTime
+                String(stepError)
               );
               return false; // 返回失败
-            } else if (result.taskId) {
-              // 队列模式：记录任务 ID（状态保持 running，等任务完成后更新）
-              createdTaskIds.push(result.taskId);
-              workflowControl.updateStep(step.id, 'running', {
-                taskId: result.taskId,
-              });
-
-              bindCurrentImageAnchorTask(board, result.taskId, {
-                workflowId: workflow.id,
-                batchId: step.options?.batchId,
-                batchIndex: step.options?.batchIndex,
-              });
-            } else if (currentStepStatus === 'running') {
-              const normalizedResultData =
-                result.type === 'text' &&
-                result.data &&
-                typeof result.data === 'object' &&
-                'content' in result.data
-                  ? { content: (result.data as { content?: string }).content }
-                  : result.data;
-              // 同步模式且未被回调更新：标记为完成
-              workflowControl.updateStep(
-                step.id,
-                'completed',
-                normalizedResultData,
-                undefined,
-                Date.now() - stepStartTime
-              );
-
-              const responseText =
-                step.mcp === 'generate_text'
-                  ? (result.data as { content?: string })?.content
-                  : step.mcp === 'ai_analyze'
-                  ? (result.data as { response?: string })?.response
-                  : undefined;
-
-              const shouldInsertReturnedText =
-                (step.mcp === 'generate_text' || step.mcp === 'ai_analyze') &&
-                responseText &&
-                responseText.trim() &&
-                pendingNewSteps.length === pendingStepsBeforeExec;
-
-              if (shouldInsertReturnedText) {
-                const insertStepId = `${step.id}-insert-text`;
-                const insertStep = {
-                  id: insertStepId,
-                  mcp: 'insert_to_canvas',
-                  args: {
-                    items: [
-                      {
-                        type: 'text',
-                        content: responseText,
-                      },
-                    ],
-                  },
-                  description:
-                    step.mcp === 'generate_text'
-                      ? '将生成文本插入画布'
-                      : '将 AI 回复插入画布',
-                  status: 'pending' as const,
-                };
-                workflowControl.addSteps([insertStep]);
-                pendingNewSteps.push(insertStep);
-              }
+            } finally {
+              // 同步更新 ChatDrawer 和 WorkZone
+              syncWorkflowUpdates();
             }
+          };
 
-            return true; // 返回成功
-          } catch (stepError) {
-            // 更新步骤为失败
-            workflowControl.updateStep(
-              step.id,
-              'failed',
-              undefined,
-              String(stepError)
-            );
-            return false; // 返回失败
-          } finally {
-            // 同步更新 ChatDrawer 和 WorkZone
-            syncWorkflowUpdates();
-          }
-        };
-
-        // 执行初始步骤
-        for (const step of workflow.steps) {
-          // 如果工作流已失败，跳过剩余步骤
-          if (workflowFailed) {
-            workflowControl.updateStep(step.id, 'skipped');
-            syncWorkflowUpdates();
-            continue;
-          }
-
-          const success = await executeStep(step);
-          if (!success) {
-            workflowFailed = true;
-          }
-        }
-
-        // 执行动态添加的步骤（由 ai_analyze 通过 onAddSteps 添加）
-        if (!workflowFailed && pendingNewSteps.length > 0) {
-          // console.log(`[AIInputBar] Executing ${pendingNewSteps.length} dynamically added steps`);
-
-          // 获取当前工作流状态用于调试
-          const currentWorkflow = workflowControl.getWorkflow();
-          // console.log(`[AIInputBar] Current workflow steps:`, currentWorkflow?.steps.map(s => ({ id: s.id, mcp: s.mcp, status: s.status })));
-          // console.log(`[AIInputBar] Pending steps to execute:`, pendingNewSteps.map(s => ({ id: s.id, mcp: s.mcp })));
-
-          for (const newStep of pendingNewSteps) {
+          // 执行初始步骤
+          for (const step of workflow.steps) {
+            // 如果工作流已失败，跳过剩余步骤
             if (workflowFailed) {
-              workflowControl.updateStep(newStep.id, 'skipped');
+              workflowControl.updateStep(step.id, 'skipped');
               syncWorkflowUpdates();
               continue;
             }
 
-            // 从 workflowControl 获取完整的步骤信息
-            const fullStep = workflowControl
-              .getWorkflow()
-              ?.steps.find((s) => s.id === newStep.id);
-            // console.log(`[AIInputBar] Looking for step ${newStep.id}, found:`, fullStep ? 'yes' : 'no', 'status:', fullStep?.status);
-
-            if (!fullStep) {
-              console.warn(
-                `[AIInputBar] Step ${newStep.id} not found in workflow!`
-              );
-              continue;
-            }
-
-            // 如果步骤已标记为 completed（如 long-video-generation 预创建的任务），跳过执行
-            if (fullStep.status === 'completed') {
-              // console.log(`[AIInputBar] Skipping already completed step: ${fullStep.mcp}`);
-              continue;
-            }
-
-            // console.log(`[AIInputBar] Executing dynamic step: ${fullStep.mcp}`, fullStep.args);
-            const success = await executeStep(fullStep);
+            const success = await executeStep(step);
             if (!success) {
               workflowFailed = true;
             }
           }
-        }
 
-        // 检查工作流是否已完成（所有步骤都是 completed 或 failed/skipped）
-        // 如果没有创建任务（createdTaskIds 为空），则立即删除 WorkZone
-        const finalWorkflow = workflowControl.getWorkflow();
-        const allStepsFinished = finalWorkflow?.steps.every(
-          (s) =>
-            s.status === 'completed' ||
-            s.status === 'failed' ||
-            s.status === 'skipped'
-        );
-        const hasCreatedTasks = createdTaskIds.length > 0;
+          // 执行动态添加的步骤（由 ai_analyze 通过 onAddSteps 添加）
+          if (!workflowFailed && pendingNewSteps.length > 0) {
+            // console.log(`[AIInputBar] Executing ${pendingNewSteps.length} dynamically added steps`);
 
-        if (allStepsFinished && !hasCreatedTasks) {
-          // 所有步骤都已完成且没有创建任务，立即删除 WorkZone
-          const workZoneId = currentWorkZoneIdRef.current;
-          const imageAnchorIds = currentImageAnchorIdsRef.current;
-          const board = SelectionWatcherBoardRef.current;
-          if ((workZoneId || imageAnchorIds.length > 0) && board) {
-            // 检查是否所有后处理都已完成
-            const allPostProcessingFinished = finalWorkflow?.steps.every(
-              (step) => {
-                const stepResult = step.result as
-                  | { taskId?: string }
-                  | undefined;
-                if (stepResult?.taskId) {
-                  const isCompleted =
-                    workflowCompletionService.isPostProcessingCompleted(
-                      stepResult.taskId
-                    );
-                  // console.log(`[AIInputBar] Task ${stepResult.taskId} post-processing finished:`, isCompleted);
-                  return isCompleted;
-                }
-                return true;
+            // 获取当前工作流状态用于调试
+            const currentWorkflow = workflowControl.getWorkflow();
+            // console.log(`[AIInputBar] Current workflow steps:`, currentWorkflow?.steps.map(s => ({ id: s.id, mcp: s.mcp, status: s.status })));
+            // console.log(`[AIInputBar] Pending steps to execute:`, pendingNewSteps.map(s => ({ id: s.id, mcp: s.mcp })));
+
+            for (const newStep of pendingNewSteps) {
+              if (workflowFailed) {
+                workflowControl.updateStep(newStep.id, 'skipped');
+                syncWorkflowUpdates();
+                continue;
               }
-            );
 
-            // console.log(`[AIInputBar] WorkZone ${workZoneId} allStepsFinished: ${allStepsFinished}, hasCreatedTasks: ${hasCreatedTasks}, allPostProcessingFinished: ${allPostProcessingFinished}`);
+              // 从 workflowControl 获取完整的步骤信息
+              const fullStep = workflowControl
+                .getWorkflow()
+                ?.steps.find((s) => s.id === newStep.id);
+              // console.log(`[AIInputBar] Looking for step ${newStep.id}, found:`, fullStep ? 'yes' : 'no', 'status:', fullStep?.status);
 
-            if (allPostProcessingFinished) {
-              // 无队列任务的 image 仍走这里做一次兜底收口；
-              // 常规 image anchor 的删除由 useImageGenerationAnchorSync 统一处理。
-              setTimeout(() => {
-                if (workZoneId) {
-                  WorkZoneTransforms.removeWorkZone(board, workZoneId);
-                  currentWorkZoneIdRef.current = null;
-                }
-                if (imageAnchorIds.length > 0) {
-                  applyCurrentImageAnchorPresentationState(board, 'completed');
-                  removeCurrentImageAnchor(board);
-                }
-              }, 1500);
+              if (!fullStep) {
+                console.warn(
+                  `[AIInputBar] Step ${newStep.id} not found in workflow!`
+                );
+                continue;
+              }
+
+              // 如果步骤已标记为 completed（如 long-video-generation 预创建的任务），跳过执行
+              if (fullStep.status === 'completed') {
+                // console.log(`[AIInputBar] Skipping already completed step: ${fullStep.mcp}`);
+                continue;
+              }
+
+              // console.log(`[AIInputBar] Executing dynamic step: ${fullStep.mcp}`, fullStep.args);
+              const success = await executeStep(fullStep);
+              if (!success) {
+                workflowFailed = true;
+              }
             }
           }
-        }
-        trackSubmitStatus(workflowFailed ? 'failed' : 'success', {
-          submitMode: 'main_thread',
-          submit_mode: 'main_thread',
-          workflowId: workflow.id,
-          workflow_id: workflow.id,
-          stepCount: finalWorkflow?.steps.length || workflow.steps.length,
-          step_count: finalWorkflow?.steps.length || workflow.steps.length,
-          createdTaskCount: createdTaskIds.length,
-          created_task_count: createdTaskIds.length,
-          failureReason: workflowFailed ? 'workflow_step_failed' : undefined,
-          failure_reason: workflowFailed ? 'workflow_step_failed' : undefined,
-        });
-      } catch (error) {
-        console.error('Failed to create generation task:', error);
-        trackSubmitStatus('failed', {
-          submitMode: 'setup',
-          submit_mode: 'setup',
-          error: error instanceof Error ? error.message : String(error),
-        });
-        if (generationType === 'image') {
-          applyCurrentImageAnchorPresentationState(
-            SelectionWatcherBoardRef.current,
-            'failed',
-            {
-              error:
-                error instanceof Error ? error.message : '创建图片任务失败',
-            }
+          // 检查工作流是否已完成（所有步骤都是 completed 或 failed/skipped）
+          // 如果没有创建任务（createdTaskIds 为空），则立即删除 WorkZone
+          const finalWorkflow = workflowControl.getWorkflow();
+          const allStepsFinished = finalWorkflow?.steps.every(
+            (s) =>
+              s.status === 'completed' ||
+              s.status === 'failed' ||
+              s.status === 'skipped'
           );
+          const hasCreatedTasks = createdTaskIds.length > 0;
+
+          if (allStepsFinished && !hasCreatedTasks) {
+            // 所有步骤都已完成且没有创建任务，立即删除 WorkZone
+            const workZoneId = currentWorkZoneIdRef.current;
+            const imageAnchorIds = currentImageAnchorIdsRef.current;
+            const board = SelectionWatcherBoardRef.current;
+            if ((workZoneId || imageAnchorIds.length > 0) && board) {
+              // 检查是否所有后处理都已完成
+              const allPostProcessingFinished = finalWorkflow?.steps.every(
+                (step) => {
+                  const stepResult = step.result as
+                    | { taskId?: string }
+                    | undefined;
+                  if (stepResult?.taskId) {
+                    const isCompleted =
+                      workflowCompletionService.isPostProcessingCompleted(
+                        stepResult.taskId
+                      );
+                    // console.log(`[AIInputBar] Task ${stepResult.taskId} post-processing finished:`, isCompleted);
+                    return isCompleted;
+                  }
+                  return true;
+                }
+              );
+
+              // console.log(`[AIInputBar] WorkZone ${workZoneId} allStepsFinished: ${allStepsFinished}, hasCreatedTasks: ${hasCreatedTasks}, allPostProcessingFinished: ${allPostProcessingFinished}`);
+
+              if (allPostProcessingFinished) {
+                // 无队列任务的 image 仍走这里做一次兜底收口；
+                // 常规 image anchor 的删除由 useImageGenerationAnchorSync 统一处理。
+                setTimeout(() => {
+                  if (workZoneId) {
+                    WorkZoneTransforms.removeWorkZone(board, workZoneId);
+                    currentWorkZoneIdRef.current = null;
+                  }
+                  if (imageAnchorIds.length > 0) {
+                    applyCurrentImageAnchorPresentationState(
+                      board,
+                      'completed'
+                    );
+                    removeCurrentImageAnchor(board);
+                  }
+                }, 1500);
+              }
+            }
+          }
+          trackSubmitStatus(workflowFailed ? 'failed' : 'success', {
+            submitMode: 'main_thread',
+            submit_mode: 'main_thread',
+            workflowId: workflow.id,
+            workflow_id: workflow.id,
+            stepCount: finalWorkflow?.steps.length || workflow.steps.length,
+            step_count: finalWorkflow?.steps.length || workflow.steps.length,
+            createdTaskCount: createdTaskIds.length,
+            created_task_count: createdTaskIds.length,
+            failureReason: workflowFailed ? 'workflow_step_failed' : undefined,
+            failure_reason: workflowFailed ? 'workflow_step_failed' : undefined,
+          });
+        } catch (error) {
+          console.error('Failed to create generation task:', error);
+          trackSubmitStatus('failed', {
+            submitMode: 'setup',
+            submit_mode: 'setup',
+            error: error instanceof Error ? error.message : String(error),
+          });
+          if (effectiveGenerationType === 'image') {
+            applyCurrentImageAnchorPresentationState(
+              SelectionWatcherBoardRef.current,
+              'failed',
+              {
+                error:
+                  error instanceof Error ? error.message : '创建图片任务失败',
+              }
+            );
+          }
+          workflowControl.abortWorkflow();
+          submitLockRef.current = false;
+          setIsSubmitting(false);
         }
-        workflowControl.abortWorkflow();
-        submitLockRef.current = false;
-        setIsSubmitting(false);
-      }
-    }, [
-      prompt,
-      allContent,
-      isSubmitting,
-      selectedModel,
-      selectedModelRef,
-      workflowControl,
-      submitWorkflowToSW,
-      addPromptHistory,
-      selectedParams,
-      knowledgeContextRefs,
-      agentMediaDefaultModels,
-      agentMediaDefaultModelRefs,
-      generationType,
-      selectedCount,
-      bindCurrentImageAnchorTask,
-      applyCurrentImageAnchorPresentationState,
-      removeCurrentImageAnchor,
-      onEnableRuntime,
-    ]);
+      },
+      [
+        prompt,
+        allContent,
+        isSubmitting,
+        selectedModel,
+        selectedModelRef,
+        workflowControl,
+        submitWorkflowToSW,
+        addPromptHistory,
+        selectedParams,
+        knowledgeContextRefs,
+        agentMediaDefaultModels,
+        agentMediaDefaultModelRefs,
+        generationType,
+        selectedCount,
+        selectedSkillId,
+        bindCurrentImageAnchorTask,
+        applyCurrentImageAnchorPresentationState,
+        removeCurrentImageAnchor,
+        onEnableRuntime,
+      ]
+    );
+
+    useEffect(() => {
+      const submitFromDrawer = async (params: DrawerGenerationSubmitParams) => {
+        await handleGenerate({
+          prompt: params.prompt,
+          content: params.selectedContent.map((item) => ({
+            type: item.type,
+            url: item.url,
+            maskImage: item.maskImage,
+            text: item.text,
+            name: item.name,
+            width: item.width,
+            height: item.height,
+          })),
+          generationType: params.generationType,
+          selectedModel: params.selectedModel,
+          selectedModelRef: params.selectedModelRef,
+          selectedParams: params.selectedParams,
+          selectedCount: params.selectedCount,
+          appendToCurrentChatSession: true,
+        });
+      };
+
+      registerGenerationSubmitterRef.current(submitFromDrawer);
+      return () => {
+        registerGenerationSubmitterRef.current(null);
+      };
+    }, [handleGenerate]);
 
     // 处理工作流重试（从指定步骤开始）
     // workZoneId: 从 WorkZone 按钮发起重试时传入的 WorkZone 元素 ID

--- a/packages/drawnix/src/components/chat-drawer/ChatDrawer.tsx
+++ b/packages/drawnix/src/components/chat-drawer/ChatDrawer.tsx
@@ -40,8 +40,11 @@ import type {
   ChatMessage as ChatMessageType,
 } from '../../types/chat.types';
 import { MessageRole, MessageStatus } from '../../types/chat.types';
+import type { Task } from '../../types/task.types';
 import type { Message } from '../../types/chat-ui.types';
 import { useTextSelection } from '../../hooks/useTextSelection';
+import { applyTaskUpdateToWorkflowMessage } from '../../utils/workflow-task-sync';
+import { resolveWorkflowSessionTarget } from '../../utils/chat-drawer-session-target';
 
 import { analytics } from '../../utils/posthog-analytics';
 import { HoverTip } from '../shared';
@@ -103,6 +106,20 @@ const DEFAULT_DRAWER_WIDTH = Math.max(375, window.innerWidth * 0.5);
 // 最小宽度
 const MIN_DRAWER_WIDTH = 375;
 
+function getMessageStatusForWorkflow(
+  workflow: WorkflowMessageData
+): MessageStatus {
+  switch (workflow.status) {
+    case 'completed':
+      return MessageStatus.SUCCESS;
+    case 'failed':
+    case 'cancelled':
+      return MessageStatus.FAILED;
+    default:
+      return MessageStatus.STREAMING;
+  }
+}
+
 export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
   ({ defaultOpen = false, onOpenChange }, ref) => {
     // Initialize state from cache synchronously to prevent flash
@@ -146,6 +163,7 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
     const [workflowMessages, setWorkflowMessages] = useState<
       Map<string, WorkflowMessageData>
     >(new Map());
+    const workflowMessagesRef = useRef(workflowMessages);
     // 当前正在更新的工作流消息 ID
     const currentWorkflowMsgIdRef = useRef<string | null>(null);
     // 正在重试的工作流 ID
@@ -365,6 +383,10 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
       temporaryModel: sessionModelRef || sessionModel, // 传递临时模型来源
       onToolCalls: handleToolCalls, // 传递工具调用回调
     });
+
+    useEffect(() => {
+      workflowMessagesRef.current = workflowMessages;
+    }, [workflowMessages]);
 
     // 使用 ref 存储 sendMessage 函数，避免 useEffect 依赖 chatHandler 导致重复执行
     const sendMessageRef = useRef(chatHandler.sendMessage);
@@ -821,10 +843,16 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
       [activeSessionId, chatHandler, appState, setAppState]
     );
 
-    // 发送工作流消息（创建新对话）
+    // 发送工作流消息
     const handleSendWorkflowMessage = useCallback(
       async (params: WorkflowMessageParams) => {
-        const { context, workflow, textModel, autoOpen = true } = params;
+        const {
+          context,
+          workflow,
+          textModel,
+          autoOpen = true,
+          appendToCurrentSession,
+        } = params;
         // 根据 autoOpen 参数决定是否打开抽屉
         if (autoOpen) {
           setIsOpen(true);
@@ -836,8 +864,10 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
           setSessionModel(textModel);
         }
 
-        // 创建新对话
-        const newSession = await chatStorageService.createSession();
+        const sessionTarget = resolveWorkflowSessionTarget(
+          activeSessionId,
+          appendToCurrentSession
+        );
 
         // 构建显示用的消息内容
         // 区分：选中的文本元素（作为 prompt）vs 用户输入的指令（额外要求）
@@ -913,12 +943,21 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
         } else if (context.model.id) {
           titleText = `模型: ${context.model.id}`;
         }
-        const title = titleText; //.length > 30 ? titleText.slice(0, 30) + '...' : titleText;
-        await chatStorageService.updateSession(newSession.id, { title });
-        newSession.title = title;
+        let targetSessionId: string;
+        let shouldReplaceMessages = false;
+        if (sessionTarget.mode === 'append') {
+          targetSessionId = sessionTarget.sessionId;
+        } else {
+          const newSession = await chatStorageService.createSession();
+          const title = titleText;
+          await chatStorageService.updateSession(newSession.id, { title });
+          newSession.title = title;
 
-        setSessions((prev) => [newSession, ...prev]);
-        setActiveSessionId(newSession.id);
+          setSessions((prev) => [newSession, ...prev]);
+          setActiveSessionId(newSession.id);
+          targetSessionId = newSession.id;
+          shouldReplaceMessages = true;
+        }
 
         // 创建用户消息（包含图片和视频）
         const timestamp = Date.now();
@@ -974,18 +1013,18 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
           ],
         };
 
-        // 存储工作流数据到内存
-        setWorkflowMessages((prev) => {
-          const newMap = new Map(prev);
-          newMap.set(workflowMsgId, workflow);
-          return newMap;
-        });
+        // 存储工作流数据到内存。同步写 ref，避免任务事件比 React
+        // state effect 更快到达时找不到刚创建的 workflow 气泡。
+        const nextWorkflowMessages = new Map(workflowMessagesRef.current);
+        nextWorkflowMessages.set(workflowMsgId, workflow);
+        workflowMessagesRef.current = nextWorkflowMessages;
+        setWorkflowMessages(nextWorkflowMessages);
         currentWorkflowMsgIdRef.current = workflowMsgId;
 
         // 持久化用户消息到本地存储
         const userChatMsg: ChatMessageType = {
           id: userMsgId,
-          sessionId: newSession.id,
+          sessionId: targetSessionId,
           role: MessageRole.USER,
           content: userDisplayText,
           timestamp: Date.now(),
@@ -1018,7 +1057,7 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
         // 持久化工作流消息到本地存储
         const workflowChatMsg: ChatMessageType = {
           id: workflowMsgId,
-          sessionId: newSession.id,
+          sessionId: targetSessionId,
           role: MessageRole.ASSISTANT,
           content: `${WORKFLOW_MESSAGE_PREFIX}${workflowMsgId}`,
           timestamp: Date.now(),
@@ -1027,14 +1066,40 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
         };
         await chatStorageService.addMessage(workflowChatMsg);
 
-        // 直接设置消息（不通过 sendMessage，因为这不是普通对话）
-        // 同时设置原始消息以确保多轮对话时上下文正确
-        chatHandler.setMessagesWithRaw?.(
-          [userMsg, workflowMsg],
-          [userChatMsg, workflowChatMsg]
+        const session = await chatStorageService.getSession(targetSessionId);
+        const nextUpdatedAt = Date.now();
+        const nextMessageCount = (session?.messageCount || 0) + 2;
+        await chatStorageService.updateSession(targetSessionId, {
+          updatedAt: nextUpdatedAt,
+          messageCount: nextMessageCount,
+        });
+        setSessions((prev) =>
+          prev.map((item) =>
+            item.id === targetSessionId
+              ? {
+                  ...item,
+                  updatedAt: nextUpdatedAt,
+                  messageCount: nextMessageCount,
+                }
+              : item
+          )
         );
+
+        if (shouldReplaceMessages) {
+          // 新建会话时直接替换为新会话消息。
+          chatHandler.setMessagesWithRaw?.(
+            [userMsg, workflowMsg],
+            [userChatMsg, workflowChatMsg]
+          );
+        } else {
+          // 抽屉内生成应留在当前会话，只追加消息，不跳到新会话。
+          chatHandler.appendMessagesWithRaw?.(
+            [userMsg, workflowMsg],
+            [userChatMsg, workflowChatMsg]
+          );
+        }
       },
-      [chatHandler, onOpenChange]
+      [activeSessionId, chatHandler, onOpenChange]
     );
 
     // 更新当前工作流消息（同时持久化到本地存储）
@@ -1042,8 +1107,15 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
       async (workflow: WorkflowMessageData) => {
         let msgId = currentWorkflowMsgIdRef.current;
 
-        // If no current msgId, try to find existing message by workflow ID
-        // This handles page refresh recovery case
+        if (msgId) {
+          const currentWorkflow = workflowMessages.get(msgId);
+          if (currentWorkflow && currentWorkflow.id !== workflow.id) {
+            msgId = null;
+          }
+        }
+
+        // If no current msgId (or it points to another workflow), try to find
+        // the existing message by workflow ID. This also handles page recovery.
         if (!msgId) {
           for (const [id, wf] of workflowMessages.entries()) {
             if (wf.id === workflow.id) {
@@ -1073,6 +1145,42 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
         chatHandler.updateRawMessageWorkflow?.(msgId, workflow);
       },
       [activeSessionId, sessions, chatHandler, workflowMessages]
+    );
+
+    const handleSyncWorkflowTaskUpdate = useCallback(
+      (task: Task): boolean => {
+        const currentWorkflowMessages = workflowMessagesRef.current;
+        let targetMsgId: string | null = null;
+        let updatedWorkflow: WorkflowMessageData | null = null;
+
+        for (const [msgId, workflow] of currentWorkflowMessages.entries()) {
+          const candidate = applyTaskUpdateToWorkflowMessage(workflow, task);
+          if (candidate) {
+            targetMsgId = msgId;
+            updatedWorkflow = candidate;
+            break;
+          }
+        }
+
+        if (!targetMsgId || !updatedWorkflow) {
+          return false;
+        }
+
+        const nextWorkflowMessages = new Map(currentWorkflowMessages);
+        nextWorkflowMessages.set(targetMsgId, updatedWorkflow);
+        workflowMessagesRef.current = nextWorkflowMessages;
+        currentWorkflowMsgIdRef.current = targetMsgId;
+        setWorkflowMessages(nextWorkflowMessages);
+
+        chatStorageService.updateMessage(targetMsgId, {
+          workflow: updatedWorkflow,
+          status: getMessageStatusForWorkflow(updatedWorkflow),
+        });
+        chatHandler.updateRawMessageWorkflow?.(targetMsgId, updatedWorkflow);
+
+        return true;
+      },
+      [chatHandler]
     );
 
     // 追加 Agent 执行日志（同时持久化）
@@ -1222,6 +1330,7 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
         },
         sendWorkflowMessage: handleSendWorkflowMessage,
         updateWorkflowMessage: handleUpdateWorkflowMessage,
+        syncWorkflowTaskUpdate: handleSyncWorkflowTaskUpdate,
         appendAgentLog: handleAppendAgentLog,
         updateThinkingContent: handleUpdateThinkingContent,
         isOpen: () => isOpen,
@@ -1254,6 +1363,7 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
         handleSendWrapper,
         handleSendWorkflowMessage,
         handleUpdateWorkflowMessage,
+        handleSyncWorkflowTaskUpdate,
         handleAppendAgentLog,
         handleUpdateThinkingContent,
         onOpenChange,
@@ -1464,7 +1574,7 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
               <EnhancedChatInput
                 selectedContent={selectedContent}
                 onSend={handleSendWrapper}
-                placeholder="支持连续对话"
+                placeholder="继续描述要修改的内容..."
               />
             </div>
           </div>

--- a/packages/drawnix/src/components/chat-drawer/EnhancedChatInput.tsx
+++ b/packages/drawnix/src/components/chat-drawer/EnhancedChatInput.tsx
@@ -6,12 +6,39 @@
  * - 多行文本输入
  */
 
-import React, { useRef, useState, useCallback, useEffect, forwardRef, useImperativeHandle } from 'react';
-import { SendIcon } from 'tdesign-icons-react';
+import React, {
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
+import { Send } from 'lucide-react';
+import { MessagePlugin } from 'tdesign-react';
 import { SelectedContentPreview } from '../shared/SelectedContentPreview';
 import type { SelectedContentItem } from '../../contexts/ChatDrawerContext';
+import { useChatDrawerControl } from '../../contexts/ChatDrawerContext';
 import type { Message } from '../../types/chat-ui.types';
 import { usePromptHistory } from '../../hooks/usePromptHistory';
+import { useI18n } from '../../i18n';
+import { useAssets } from '../../contexts/AssetContext';
+import {
+  AssetSource,
+  AssetType,
+  SelectionMode,
+  type Asset,
+} from '../../types/asset.types';
+import { GenerationTypeDropdown } from '../ai-input-bar/GenerationTypeDropdown';
+import { ModelDropdown } from '../ai-input-bar/ModelDropdown';
+import { ParametersDropdown } from '../ai-input-bar/ParametersDropdown';
+import { CountDropdown } from '../ai-input-bar/CountDropdown';
+import { MediaLibraryModal } from '../media-library/MediaLibraryModal';
+import { ImageUploadIcon, MediaLibraryIcon } from '../icons';
+import { HoverTip } from '../shared';
+import { useChatDrawerGenerationControls } from './useChatDrawerGenerationControls';
+import '../ai-input-bar/ai-input-bar.scss';
 
 interface EnhancedChatInputProps {
   selectedContent: SelectedContentItem[];
@@ -32,150 +59,459 @@ export interface EnhancedChatInputRef {
   focus: () => void;
 }
 
-export const EnhancedChatInput = forwardRef<EnhancedChatInputRef, EnhancedChatInputProps>(({
-  selectedContent,
-  onSend,
-  disabled = false,
-  placeholder = '输入消息...',
-}, ref) => {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [input, setInput] = useState('');
-  const hasSelection = selectedContent.length > 0;
-  const { addHistory: addPromptHistory } = usePromptHistory();
-
-  // 暴露方法给父组件
-  useImperativeHandle(ref, () => ({
-    setContent: (content: string) => {
-      setInput(content);
-      // 聚焦输入框
-      textareaRef.current?.focus();
-    },
-    getContent: () => input,
-    focus: () => textareaRef.current?.focus(),
-  }), [input]);
-
-  // 发送消息
-  const handleSend = useCallback(() => {
-    const trimmedInput = input.trim();
-    if (!trimmedInput && selectedContent.length === 0) return;
-
-    // 构建消息
-    const parts: Message['parts'] = [];
-
-    // 添加文本
-    if (trimmedInput) {
-      parts.push({ type: 'text', text: trimmedInput });
-    }
-
-    // 添加选中的图片/视频
-    selectedContent.forEach((item, index) => {
-      if (item.type === 'image' || item.type === 'graphics') {
-        parts.push({
-          type: 'data-file',
-          data: {
-            filename: `${item.type}-${index + 1}.png`,
-            mediaType: 'image/png',
-            url: item.url || '',
-          },
-        } as any);
-      } else if (item.type === 'video') {
-        parts.push({
-          type: 'data-file',
-          data: {
-            filename: `video-${index + 1}.mp4`,
-            mediaType: 'video/mp4',
-            url: item.url || '',
-          },
-        } as any);
-      }
-    });
-
-    const message: Message = {
-      id: `msg_${Date.now()}`,
-      role: 'user',
-      parts,
-    };
-
-    // 保存提示词到历史记录（Chat Drawer 默认为 Agent 模式）
-    if (trimmedInput) {
-      addPromptHistory(trimmedInput, hasSelection, 'agent');
-    }
-
-    void Promise.resolve(onSend(message)).catch((error) => {
-      console.error('[EnhancedChatInput] send failed:', error);
-    });
-    setInput('');
-  }, [input, selectedContent, onSend, addPromptHistory, hasSelection]);
-
-  // 键盘事件处理
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // 检测 IME 组合输入状态（如中文拼音输入法）
-    if (e.nativeEvent.isComposing) {
-      return;
-    }
-
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-  }, [handleSend]);
-
-  // 自动调整高度
-  useEffect(() => {
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 120)}px`;
-    }
-  }, [input]);
-
-  // 渲染选中内容预览
-  const renderSelectedContent = () => {
-    if (selectedContent.length === 0) return null;
-
-    return (
-      <div className="enhanced-chat-input__selection">
-        <SelectedContentPreview
-          items={selectedContent}
-          language="zh"
-          enableHoverPreview={true}
-        />
-      </div>
+export const EnhancedChatInput = forwardRef<
+  EnhancedChatInputRef,
+  EnhancedChatInputProps
+>(
+  (
+    { selectedContent, onSend, disabled = false, placeholder = '输入消息...' },
+    ref
+  ) => {
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [input, setInput] = useState('');
+    const [uploadedContent, setUploadedContent] = useState<
+      SelectedContentItem[]
+    >([]);
+    const [showMediaLibrary, setShowMediaLibrary] = useState(false);
+    const allContent = useMemo(
+      () => [...uploadedContent, ...selectedContent],
+      [selectedContent, uploadedContent]
     );
-  };
+    const hasSelection = allContent.length > 0;
+    const { addHistory: addPromptHistory } = usePromptHistory();
+    const { language } = useI18n();
+    const { addAsset } = useAssets();
+    const chatDrawerControl = useChatDrawerControl();
+    const generationControls = useChatDrawerGenerationControls();
 
-  const isActive = (input.trim() || selectedContent.length > 0) && !disabled;
+    const appendUploadedContent = useCallback(
+      (items: SelectedContentItem[]) => {
+        if (items.length === 0) return;
+        setUploadedContent((prev) => [...prev, ...items]);
+      },
+      []
+    );
 
-  return (
-    <div className="enhanced-chat-input" ref={containerRef}>
-      {renderSelectedContent()}
+    const fileToBase64WithDimensions = useCallback(
+      (file: Blob): Promise<{ url: string; width: number; height: number }> => {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const base64Url = reader.result as string;
+            const img = new Image();
+            img.onload = () => {
+              resolve({
+                url: base64Url,
+                width: img.naturalWidth,
+                height: img.naturalHeight,
+              });
+            };
+            img.onerror = () =>
+              resolve({ url: base64Url, width: 0, height: 0 });
+            img.src = base64Url;
+          };
+          reader.onerror = reject;
+          reader.readAsDataURL(file);
+        });
+      },
+      []
+    );
 
-      <div className="enhanced-chat-input__form">
-        <div className="enhanced-chat-input__input-wrapper">
-          <textarea
-            ref={textareaRef}
-            className="enhanced-chat-input__textarea"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={hasSelection ? '描述你想要的效果...' : placeholder}
-            disabled={disabled}
-            rows={4}
+    const importLocalImages = useCallback(
+      async (files: File[] | FileList) => {
+        const fileList = Array.from(files);
+        if (fileList.length === 0) return;
+
+        const newContent: SelectedContentItem[] = [];
+
+        for (const [index, file] of fileList.entries()) {
+          if (!file.type.startsWith('image/')) {
+            MessagePlugin.error('请选择图片文件');
+            continue;
+          }
+
+          if (file.size > 25 * 1024 * 1024) {
+            MessagePlugin.error('图片不能超过 25MB');
+            continue;
+          }
+
+          try {
+            addAsset(file, AssetType.IMAGE, AssetSource.LOCAL, file.name).catch(
+              (error) => {
+                console.warn(
+                  '[EnhancedChatInput] Failed to add asset to library:',
+                  error
+                );
+              }
+            );
+
+            const { url, width, height } = await fileToBase64WithDimensions(
+              file
+            );
+            newContent.push({
+              type: 'image',
+              url,
+              name: file.name || `上传图片 ${index + 1}`,
+              width: width || undefined,
+              height: height || undefined,
+            });
+          } catch (error) {
+            console.error('[EnhancedChatInput] Failed to import image:', error);
+            MessagePlugin.error('图片读取失败');
+          }
+        }
+
+        appendUploadedContent(newContent);
+      },
+      [addAsset, appendUploadedContent, fileToBase64WithDimensions]
+    );
+
+    const handleFileChange = useCallback(
+      async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = e.target.files;
+        if (!files || files.length === 0) return;
+
+        await importLocalImages(files);
+        e.target.value = '';
+      },
+      [importLocalImages]
+    );
+
+    const handleUploadClick = useCallback(() => {
+      fileInputRef.current?.click();
+    }, []);
+
+    const handleMediaLibrarySelect = useCallback(
+      (asset: Asset) => {
+        const selectedAssetContent: SelectedContentItem = {
+          type: 'image',
+          url: asset.url,
+          name: asset.name || `素材-${Date.now()}`,
+        };
+
+        appendUploadedContent([selectedAssetContent]);
+        setShowMediaLibrary(false);
+      },
+      [appendUploadedContent]
+    );
+
+    const handleRemoveUploadedContent = useCallback((index: number) => {
+      setUploadedContent((prev) => prev.filter((_, i) => i !== index));
+    }, []);
+
+    // 暴露方法给父组件
+    useImperativeHandle(
+      ref,
+      () => ({
+        setContent: (content: string) => {
+          setInput(content);
+          // 聚焦输入框
+          textareaRef.current?.focus();
+        },
+        getContent: () => input,
+        focus: () => textareaRef.current?.focus(),
+      }),
+      [input]
+    );
+
+    // 发送消息
+    const submitGeneration = useCallback(
+      async (trimmedInput: string) => {
+        const submitted = await chatDrawerControl.submitGenerationFromDrawer({
+          prompt: trimmedInput,
+          selectedContent: allContent,
+          generationType: generationControls.generationType,
+          selectedModel: generationControls.selectedModel,
+          selectedModelRef: generationControls.selectedModelRef,
+          selectedParams: generationControls.selectedParams,
+          selectedCount: generationControls.selectedCount,
+        });
+
+        if (!submitted) {
+          MessagePlugin.error('生成入口未准备好，请稍后重试');
+          return;
+        }
+
+        setInput('');
+        setUploadedContent([]);
+      },
+      [
+        chatDrawerControl,
+        generationControls.generationType,
+        generationControls.selectedCount,
+        generationControls.selectedModel,
+        generationControls.selectedModelRef,
+        generationControls.selectedParams,
+        allContent,
+      ]
+    );
+
+    const handleSend = useCallback(() => {
+      const trimmedInput = input.trim();
+      if (!trimmedInput && allContent.length === 0) return;
+
+      if (generationControls.generationType !== 'agent') {
+        void submitGeneration(trimmedInput).catch((error) => {
+          console.error('[EnhancedChatInput] generation submit failed:', error);
+          MessagePlugin.error('生成提交失败');
+        });
+        return;
+      }
+
+      // 构建消息
+      const parts: Message['parts'] = [];
+
+      // 添加文本
+      if (trimmedInput) {
+        parts.push({ type: 'text', text: trimmedInput });
+      }
+
+      // 添加选中的图片/视频
+      allContent.forEach((item, index) => {
+        if (item.type === 'image' || item.type === 'graphics') {
+          parts.push({
+            type: 'data-file',
+            data: {
+              filename: `${item.type}-${index + 1}.png`,
+              mediaType: 'image/png',
+              url: item.url || '',
+            },
+          } as any);
+        } else if (item.type === 'video') {
+          parts.push({
+            type: 'data-file',
+            data: {
+              filename: `video-${index + 1}.mp4`,
+              mediaType: 'video/mp4',
+              url: item.url || '',
+            },
+          } as any);
+        }
+      });
+
+      const message: Message = {
+        id: `msg_${Date.now()}`,
+        role: 'user',
+        parts,
+      };
+
+      // 保存提示词到历史记录（Chat Drawer 默认为 Agent 模式）
+      if (trimmedInput) {
+        addPromptHistory(trimmedInput, hasSelection, 'agent');
+      }
+
+      void Promise.resolve(onSend(message)).catch((error) => {
+        console.error('[EnhancedChatInput] send failed:', error);
+      });
+      setInput('');
+      setUploadedContent([]);
+    }, [
+      input,
+      allContent,
+      generationControls.generationType,
+      submitGeneration,
+      onSend,
+      addPromptHistory,
+      hasSelection,
+    ]);
+
+    // 键盘事件处理
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        // 检测 IME 组合输入状态（如中文拼音输入法）
+        if (e.nativeEvent.isComposing) {
+          return;
+        }
+
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          handleSend();
+        }
+      },
+      [handleSend]
+    );
+
+    // 自动调整高度
+    useEffect(() => {
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+        textareaRef.current.style.height = `${Math.min(
+          textareaRef.current.scrollHeight,
+          120
+        )}px`;
+      }
+    }, [input]);
+
+    // 渲染选中内容预览
+    const renderSelectedContent = () => {
+      if (allContent.length === 0) return null;
+
+      return (
+        <div className="enhanced-chat-input__selection">
+          <SelectedContentPreview
+            items={allContent}
+            language="zh"
+            enableHoverPreview={true}
+            onRemove={handleRemoveUploadedContent}
+            removableStartIndex={uploadedContent.length}
           />
         </div>
+      );
+    };
 
-        <button
-          className={`enhanced-chat-input__send ${isActive ? 'enhanced-chat-input__send--active' : ''}`}
-          onClick={handleSend}
-          disabled={!isActive}
-          aria-label="发送"
-        >
-          <SendIcon size={20} />
-        </button>
+    const isActive = (input.trim() || allContent.length > 0) && !disabled;
+    const isGenerationMode = generationControls.generationType !== 'agent';
+
+    return (
+      <div className="enhanced-chat-input" ref={containerRef}>
+        <div className="enhanced-chat-input__form">
+          {renderSelectedContent()}
+
+          <div className="enhanced-chat-input__input-wrapper">
+            <textarea
+              ref={textareaRef}
+              className="enhanced-chat-input__textarea"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={hasSelection ? '描述你想要的效果...' : placeholder}
+              disabled={disabled}
+              rows={4}
+            />
+          </div>
+
+          <div className="enhanced-chat-input__footer ai-input-bar enhanced-chat-input__control-shell">
+            <div className="ai-input-bar__bottom-bar">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handleFileChange}
+                style={{ display: 'none' }}
+              />
+
+              <HoverTip
+                content={language === 'zh' ? '上传图片' : 'Upload images'}
+                placement="top"
+              >
+                <button
+                  className="ai-input-bar__upload-btn"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onClick={handleUploadClick}
+                  aria-label={language === 'zh' ? '上传图片' : 'Upload images'}
+                  type="button"
+                >
+                  <ImageUploadIcon size={18} />
+                </button>
+              </HoverTip>
+
+              <HoverTip
+                content={
+                  language === 'zh' ? '从素材库选择' : 'Select from library'
+                }
+                placement="top"
+              >
+                <button
+                  className="ai-input-bar__library-btn"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onClick={() => setShowMediaLibrary(true)}
+                  aria-label={
+                    language === 'zh' ? '从素材库选择' : 'Select from library'
+                  }
+                  type="button"
+                >
+                  <MediaLibraryIcon size={18} />
+                </button>
+              </HoverTip>
+
+              <GenerationTypeDropdown
+                value={generationControls.generationType}
+                onSelect={generationControls.setGenerationType}
+                disabled={disabled}
+              />
+              <ModelDropdown
+                selectedModel={generationControls.selectedModel}
+                selectedSelectionKey={generationControls.selectedSelectionKey}
+                onSelect={generationControls.handleModelSelect}
+                onSelectModel={generationControls.handleModelConfigSelect}
+                language={language}
+                models={generationControls.currentModels}
+                placement="up"
+                header={
+                  language === 'zh'
+                    ? isGenerationMode
+                      ? '选择模型 (↑↓ Tab)'
+                      : '选择文本模型 (↑↓ Tab)'
+                    : isGenerationMode
+                    ? 'Select model (↑↓ Tab)'
+                    : 'Select text model (↑↓ Tab)'
+                }
+                disabled={disabled}
+              />
+              {isGenerationMode &&
+                generationControls.compatibleParams.length > 0 && (
+                  <ParametersDropdown
+                    key={generationControls.selectedModel}
+                    selectedParams={generationControls.selectedParams}
+                    onParamChange={generationControls.handleParamSelect}
+                    compatibleParams={generationControls.compatibleParams}
+                    modelId={generationControls.selectedModel}
+                    language={language}
+                    disabled={disabled}
+                    placement="up"
+                  />
+                )}
+              {isGenerationMode &&
+                generationControls.generationType !== 'text' &&
+                generationControls.generationType !== 'audio' && (
+                  <CountDropdown
+                    value={generationControls.selectedCount}
+                    onSelect={generationControls.setSelectedCount}
+                    disabled={disabled}
+                  />
+                )}
+
+              <div className="ai-input-bar__bottom-spacer" />
+
+              <button
+                className={`ai-input-bar__send-btn ${isActive ? 'active' : ''}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onClick={handleSend}
+                disabled={!isActive}
+                aria-label="发送"
+                data-testid="drawer-ai-send-btn"
+              >
+                <Send size={18} />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {showMediaLibrary && (
+          <MediaLibraryModal
+            isOpen={showMediaLibrary}
+            onClose={() => setShowMediaLibrary(false)}
+            mode={SelectionMode.SELECT}
+            filterType={AssetType.IMAGE}
+            onSelect={handleMediaLibrarySelect}
+          />
+        )}
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 EnhancedChatInput.displayName = 'EnhancedChatInput';
 

--- a/packages/drawnix/src/components/chat-drawer/WorkflowMessageBubble.tsx
+++ b/packages/drawnix/src/components/chat-drawer/WorkflowMessageBubble.tsx
@@ -1,6 +1,6 @@
 /**
  * 工作流消息气泡组件
- * 
+ *
  * 在对话消息中展示工作流执行过程
  */
 
@@ -12,8 +12,15 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
-import type { WorkflowMessageData, AgentLogEntry } from '../../types/chat.types';
+import type {
+  WorkflowMessageData,
+  AgentLogEntry,
+} from '../../types/chat.types';
 import MarkdownReadonly from '../MarkdownReadonly';
+import {
+  getWorkflowBubbleStatus,
+  normalizeWorkflowStepsForDisplay,
+} from '../../utils/workflow-bubble-status';
 import './workflow-message-bubble.scss';
 
 const MermaidRenderer = lazy(() =>
@@ -53,10 +60,7 @@ function renderWorkflowCodeBlock(
 
   return (
     <Suspense key={key} fallback={null}>
-      <MermaidRenderer
-        code={code.trim()}
-        className="chat-markdown__mermaid"
-      />
+      <MermaidRenderer code={code.trim()} className="chat-markdown__mermaid" />
     </Suspense>
   );
 }
@@ -79,11 +83,7 @@ interface StepItemProps {
   isCurrentStep: boolean;
 }
 
-const StepItem: React.FC<StepItemProps> = ({
-  step,
-  index,
-  isCurrentStep,
-}) => {
+const StepItem: React.FC<StepItemProps> = ({ step, index, isCurrentStep }) => {
   const [expanded, setExpanded] = useState(false);
 
   const statusIcon = STATUS_ICONS[step.status];
@@ -91,7 +91,8 @@ const StepItem: React.FC<StepItemProps> = ({
   // 步骤有详情的条件：有参数、有结果、有错误、有耗时
   const hasArgs: boolean = Object.keys(step.args).length > 0;
   const hasResult = step.result !== undefined && step.result !== null;
-  const hasDetails = hasArgs || hasResult || Boolean(step.error) || step.duration !== undefined;
+  const hasDetails =
+    hasArgs || hasResult || Boolean(step.error) || step.duration !== undefined;
 
   // 格式化显示参数，排除 context 等大对象
   const formatArgs = (args: Record<string, unknown> | undefined) => {
@@ -117,7 +118,9 @@ const StepItem: React.FC<StepItemProps> = ({
 
   return (
     <div
-      className={`workflow-bubble-step workflow-bubble-step--${step.status} ${isCurrentStep ? 'workflow-bubble-step--current' : ''}`}
+      className={`workflow-bubble-step workflow-bubble-step--${step.status} ${
+        isCurrentStep ? 'workflow-bubble-step--current' : ''
+      }`}
     >
       <div
         className="workflow-bubble-step__main"
@@ -125,7 +128,9 @@ const StepItem: React.FC<StepItemProps> = ({
         style={{ cursor: hasDetails ? 'pointer' : 'default' }}
       >
         <div className="workflow-bubble-step__index">{index + 1}</div>
-        <div className={`workflow-bubble-step__status workflow-bubble-step__status--${step.status}`}>
+        <div
+          className={`workflow-bubble-step__status workflow-bubble-step__status--${step.status}`}
+        >
           {step.status === 'running' ? (
             <span className="workflow-bubble-step__spinner" />
           ) : (
@@ -137,7 +142,11 @@ const StepItem: React.FC<StepItemProps> = ({
           <div className="workflow-bubble-step__status-text">{statusLabel}</div>
         </div>
         {hasDetails && (
-          <div className={`workflow-bubble-step__expand ${expanded ? 'workflow-bubble-step__expand--open' : ''}`}>
+          <div
+            className={`workflow-bubble-step__expand ${
+              expanded ? 'workflow-bubble-step__expand--open' : ''
+            }`}
+          >
             ▼
           </div>
         )}
@@ -155,9 +164,7 @@ const StepItem: React.FC<StepItemProps> = ({
           {hasArgs ? (
             <div className="workflow-bubble-step__detail-row workflow-bubble-step__detail-row--block">
               <span className="workflow-bubble-step__label">输入参数:</span>
-              <pre className="workflow-bubble-step__args">
-                {argsText}
-              </pre>
+              <pre className="workflow-bubble-step__args">{argsText}</pre>
             </div>
           ) : null}
 
@@ -242,7 +249,11 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
         >
           <span className="agent-log__icon">🔧</span>
           <span className="agent-log__title">调用工具: {log.toolName}</span>
-          <span className={`agent-log__expand ${expanded ? 'agent-log__expand--open' : ''}`}>
+          <span
+            className={`agent-log__expand ${
+              expanded ? 'agent-log__expand--open' : ''
+            }`}
+          >
             ▼
           </span>
         </div>
@@ -263,7 +274,9 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
     const hasData = log.data !== undefined && log.data !== null;
 
     return (
-      <div className={`agent-log agent-log--tool-result agent-log--${statusClass}`}>
+      <div
+        className={`agent-log agent-log--tool-result agent-log--${statusClass}`}
+      >
         <div
           className="agent-log__header agent-log__header--clickable"
           onClick={() => setExpanded(!expanded)}
@@ -272,15 +285,17 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
           <span className="agent-log__title">
             {log.toolName} {log.success ? '执行成功' : '执行失败'}
           </span>
-          <span className={`agent-log__expand ${expanded ? 'agent-log__expand--open' : ''}`}>
+          <span
+            className={`agent-log__expand ${
+              expanded ? 'agent-log__expand--open' : ''
+            }`}
+          >
             ▼
           </span>
         </div>
         {expanded && (
           <div className="agent-log__content">
-            {log.error && (
-              <div className="agent-log__error">{log.error}</div>
-            )}
+            {log.error && <div className="agent-log__error">{log.error}</div>}
             {hasData && (
               <pre className="agent-log__data">
                 {typeof log.data === 'string'
@@ -328,72 +343,19 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
   isRetrying = false,
 }) => {
   const normalizedSteps = useMemo(() => {
-    return workflow.steps.map((step) => {
-      const stepResult = step.result as { taskId?: string } | undefined;
-      const hasPendingTask = Boolean(stepResult?.taskId);
-      const hasCompletedResult = step.result !== undefined && step.result !== null;
-      const hasDuration = step.duration !== undefined;
-
-      if ((step.status === 'running' || step.status === 'pending') && !hasPendingTask) {
-        if (step.error) {
-          return { ...step, status: 'failed' as const };
-        }
-        if (hasCompletedResult || hasDuration) {
-          return { ...step, status: 'completed' as const };
-        }
-      }
-      return step;
-    });
+    return normalizeWorkflowStepsForDisplay(workflow.steps);
   }, [workflow.steps]);
 
-  // 检查是否需要后处理（图片生成类任务需要拆分和插入画布）
-  const needsPostProcessing = useMemo(() => {
-    return workflow.generationType === 'image' && normalizedSteps.some(s =>
-      s.mcp === 'generate_image' ||
-      s.mcp === 'generate_grid_image' ||
-      s.mcp === 'generate_inspiration_board'
-    );
-  }, [workflow.generationType, normalizedSteps]);
-
-  // 计算工作流状态（考虑后处理）
+  // 计算工作流状态。图片生成以任务队列完成为准，画布插入不再阻塞抽屉收口。
   const workflowStatus = useMemo(() => {
-    const steps = normalizedSteps;
-    const totalSteps = steps.length;
-    const completedSteps = steps.filter(s => s.status === 'completed').length;
-    const failedSteps = steps.filter(s => s.status === 'failed').length;
-    const runningSteps = steps.filter(s => s.status === 'running').length;
-
-    let status: 'pending' | 'running' | 'completed' | 'failed' = 'pending';
-    if (failedSteps > 0) {
-      status = 'failed';
-    } else if (completedSteps === totalSteps && totalSteps > 0) {
-      // 所有步骤完成，但需要检查后处理状态
-      if (needsPostProcessing) {
-        const postStatus = workflow.postProcessingStatus;
-        if (postStatus === 'completed') {
-          status = 'completed';
-        } else if (postStatus === 'failed') {
-          status = 'failed';
-        } else if (postStatus === 'processing' || !postStatus) {
-          // 后处理进行中或尚未开始（等待后处理）
-          status = 'running';
-        } else {
-          status = 'running';
-        }
-      } else {
-        status = 'completed';
-      }
-    } else if (runningSteps > 0 || completedSteps > 0) {
-      status = 'running';
-    }
-
-    return { status, totalSteps, completedSteps };
-  }, [normalizedSteps, workflow.postProcessingStatus, needsPostProcessing]);
+    return getWorkflowBubbleStatus(normalizedSteps);
+  }, [normalizedSteps]);
 
   // 计算进度
-  const progress = workflowStatus.totalSteps > 0 
-    ? (workflowStatus.completedSteps / workflowStatus.totalSteps) * 100 
-    : 0;
+  const progress =
+    workflowStatus.totalSteps > 0
+      ? (workflowStatus.completedSteps / workflowStatus.totalSteps) * 100
+      : 0;
 
   // 状态标签（考虑后处理状态）
   const statusLabel = useMemo(() => {
@@ -404,17 +366,8 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
       failed: '执行失败',
     };
 
-    // 如果所有步骤完成但正在后处理，显示特定状态
-    const allStepsCompleted = normalizedSteps.every(s => s.status === 'completed');
-    if (allStepsCompleted && needsPostProcessing && workflow.postProcessingStatus === 'processing') {
-      return '正在插入画布';
-    }
-    if (allStepsCompleted && needsPostProcessing && !workflow.postProcessingStatus) {
-      return '正在处理';
-    }
-
     return baseLabels[workflowStatus.status];
-  }, [workflowStatus.status, normalizedSteps, workflow.postProcessingStatus, needsPostProcessing]);
+  }, [workflowStatus.status]);
 
   const isCompleted = workflowStatus.status === 'completed';
   const isFailed = workflowStatus.status === 'failed';
@@ -447,7 +400,10 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
           data?: { content?: unknown; response?: unknown };
         };
         // 优先取 data.content（ai_analyze 格式），再取顶层 content/response
-        const text = (res.data?.content || res.data?.response || res.content || res.response) as string;
+        const text = (res.data?.content ||
+          res.data?.response ||
+          res.content ||
+          res.response) as string;
         if (typeof text === 'string') {
           const trimmed = text.trim();
           if (trimmed) return trimmed;
@@ -464,11 +420,14 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
     const mediaGenerationMcps = [
       'generate_image',
       'generate_video',
+      'generate_audio',
       'generate_grid_image',
       'generate_inspiration_board',
       'generate_long_video',
     ];
-    return normalizedSteps.some(step => mediaGenerationMcps.includes(step.mcp || ''));
+    return normalizedSteps.some((step) =>
+      mediaGenerationMcps.includes(step.mcp || '')
+    );
   }, [normalizedSteps]);
 
   const summaryView = useMemo(() => {
@@ -481,12 +440,16 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
 
     // 直接展示最后一个 content
     if (lastContent) {
-      return { variant: 'markdown' as const, icon: '✨', markdown: lastContent };
+      return {
+        variant: 'markdown' as const,
+        icon: '✨',
+        markdown: lastContent,
+      };
     }
 
     // 媒体生成场景，成功但没有 content 返回
     if (hasMediaGeneration) {
-      return { variant: 'info' as const, icon: '✅', text: '已生成' };
+      return null;
     }
 
     // 没有任何内容
@@ -500,13 +463,36 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
 
   // 获取当前执行步骤的索引
   const currentStepIndex = useMemo(() => {
-    return normalizedSteps.findIndex(s => s.status === 'running');
+    return normalizedSteps.findIndex((s) => s.status === 'running');
   }, [normalizedSteps]);
 
   // 获取第一个失败步骤的索引
   const firstFailedStepIndex = useMemo(() => {
-    return normalizedSteps.findIndex(s => s.status === 'failed');
+    return normalizedSteps.findIndex((s) => s.status === 'failed');
   }, [normalizedSteps]);
+
+  const shouldCollapseCompletedDetails = isCompleted && hasMediaGeneration;
+  const hasDetailsContent =
+    normalizedSteps.length > 0 || Boolean(workflow.logs?.length);
+  const [showCompletedDetails, setShowCompletedDetails] = useState(false);
+  const previousWorkflowIdRef = useRef(workflow.id);
+
+  useEffect(() => {
+    if (previousWorkflowIdRef.current !== workflow.id) {
+      previousWorkflowIdRef.current = workflow.id;
+      setShowCompletedDetails(false);
+      return;
+    }
+
+    if (shouldCollapseCompletedDetails) {
+      setShowCompletedDetails(false);
+    }
+  }, [shouldCollapseCompletedDetails, workflow.id]);
+
+  const shouldShowDetails =
+    !shouldCollapseCompletedDetails || showCompletedDetails;
+  const shouldShowDetailsToggle =
+    shouldCollapseCompletedDetails && hasDetailsContent;
 
   // 当前执行步骤的 ref，用于自动滚动
   const currentStepRef = useRef<HTMLDivElement>(null);
@@ -530,7 +516,8 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
   }, [currentStepIndex, isRunning, normalizedSteps.length]);
 
   // 检查是否可以重试（有重试上下文且有失败步骤）
-  const canRetry = isFailed && workflow.retryContext && firstFailedStepIndex >= 0;
+  const canRetry =
+    isFailed && workflow.retryContext && firstFailedStepIndex >= 0;
 
   // 处理重试点击
   const handleRetry = () => {
@@ -540,7 +527,10 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
   };
 
   return (
-    <div ref={bubbleRef} className={`workflow-bubble chat-message chat-message--assistant ${className}`}>
+    <div
+      ref={bubbleRef}
+      className={`workflow-bubble chat-message chat-message--assistant ${className}`}
+    >
       <div className="chat-message-avatar">
         <span>
           {workflow.generationType === 'image'
@@ -557,7 +547,9 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
         <div className="workflow-bubble__header">
           <span className="workflow-bubble__title">{workflow.name}</span>
           <div className="workflow-bubble__status-info">
-            <span className={`workflow-bubble__status workflow-bubble__status--${workflowStatus.status}`}>
+            <span
+              className={`workflow-bubble__status workflow-bubble__status--${workflowStatus.status}`}
+            >
               {statusLabel}
             </span>
             <span className="workflow-bubble__progress-text">
@@ -586,20 +578,46 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
           </div>
         )}
 
+        {shouldShowDetailsToggle && (
+          <button
+            type="button"
+            className="workflow-bubble__details-toggle"
+            onClick={() => setShowCompletedDetails((value) => !value)}
+            aria-expanded={showCompletedDetails}
+            aria-label={
+              showCompletedDetails ? '收起执行详情' : '查看执行详情'
+            }
+          >
+            <span>{showCompletedDetails ? '收起详情' : '查看详情'}</span>
+            <span
+              className={`workflow-bubble__details-toggle-icon ${
+                showCompletedDetails
+                  ? 'workflow-bubble__details-toggle-icon--open'
+                  : ''
+              }`}
+              aria-hidden="true"
+            >
+              ▼
+            </span>
+          </button>
+        )}
+
         {/* 步骤列表 */}
-        <div className="workflow-bubble__steps">
-          {normalizedSteps.map((step, index) => (
-            <StepItem
-              key={step.id}
-              step={step}
-              index={index}
-              isCurrentStep={index === currentStepIndex && isRunning}
-            />
-          ))}
-        </div>
+        {shouldShowDetails && (
+          <div className="workflow-bubble__steps">
+            {normalizedSteps.map((step, index) => (
+              <StepItem
+                key={step.id}
+                step={step}
+                index={index}
+                isCurrentStep={index === currentStepIndex && isRunning}
+              />
+            ))}
+          </div>
+        )}
 
         {/* Agent 执行日志 */}
-        {workflow.logs && workflow.logs.length > 0 && (
+        {shouldShowDetails && workflow.logs && workflow.logs.length > 0 && (
           <div className="workflow-bubble__logs">
             <div className="workflow-bubble__logs-header">
               <span className="workflow-bubble__logs-title">执行详情</span>
@@ -614,24 +632,32 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
 
         {/* 完成摘要 */}
         {summaryView && summaryView.variant !== 'markdown' && (
-          <div className={`workflow-bubble__summary workflow-bubble__summary--${summaryView.variant}`}>
-            <span className="workflow-bubble__summary-icon">{summaryView.icon}</span>
+          <div
+            className={`workflow-bubble__summary workflow-bubble__summary--${summaryView.variant}`}
+          >
+            <span className="workflow-bubble__summary-icon">
+              {summaryView.icon}
+            </span>
             <span>{summaryView.text}</span>
           </div>
         )}
 
-        {summaryView && summaryView.variant === 'markdown' && markdownSummary && (
-          <div className="workflow-bubble__summary workflow-bubble__summary--success workflow-bubble__summary--markdown">
-            <span className="workflow-bubble__summary-icon">{summaryView.icon}</span>
-            <div className="workflow-bubble__summary-markdown">
-              <div className="workflow-bubble__markdown-message">
-                <div className="workflow-bubble__markdown-content">
-                  {renderMarkdownWithMermaid(markdownSummary)}
+        {summaryView &&
+          summaryView.variant === 'markdown' &&
+          markdownSummary && (
+            <div className="workflow-bubble__summary workflow-bubble__summary--success workflow-bubble__summary--markdown">
+              <span className="workflow-bubble__summary-icon">
+                {summaryView.icon}
+              </span>
+              <div className="workflow-bubble__summary-markdown">
+                <div className="workflow-bubble__markdown-message">
+                  <div className="workflow-bubble__markdown-content">
+                    {renderMarkdownWithMermaid(markdownSummary)}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
 
         {/* 失败提示 */}
         {isFailed && (

--- a/packages/drawnix/src/components/chat-drawer/__tests__/EnhancedChatInput.test.tsx
+++ b/packages/drawnix/src/components/chat-drawer/__tests__/EnhancedChatInput.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { EnhancedChatInput } from '../EnhancedChatInput';
+
+vi.mock('../../../contexts/ChatDrawerContext', () => ({
+  useChatDrawerControl: () => ({
+    submitGenerationFromDrawer: async () => true,
+  }),
+}));
+
+vi.mock('../../../hooks/usePromptHistory', () => ({
+  usePromptHistory: () => ({
+    addHistory: () => undefined,
+  }),
+}));
+
+vi.mock('../../../i18n', () => ({
+  useI18n: () => ({
+    language: 'zh',
+  }),
+}));
+
+vi.mock('../../../contexts/AssetContext', () => ({
+  useAssets: () => ({
+    addAsset: async () => undefined,
+  }),
+}));
+
+vi.mock('../useChatDrawerGenerationControls', () => ({
+  useChatDrawerGenerationControls: () => ({
+    generationType: 'agent',
+    setGenerationType: () => undefined,
+    selectedModel: 'gpt-5.4',
+    selectedModelRef: null,
+    selectedSelectionKey: 'gpt-5.4',
+    selectedParams: {},
+    compatibleParams: [],
+    selectedCount: 1,
+    setSelectedCount: () => undefined,
+    currentModels: [],
+    handleModelSelect: () => undefined,
+    handleModelConfigSelect: () => undefined,
+    handleParamSelect: () => undefined,
+  }),
+}));
+
+vi.mock('../../shared/SelectedContentPreview', () => ({
+  SelectedContentPreview: () => (
+    <div data-testid="selected-content-preview">selected</div>
+  ),
+}));
+
+vi.mock('../../ai-input-bar/GenerationTypeDropdown', () => ({
+  GenerationTypeDropdown: () => <button type="button">类型</button>,
+}));
+
+vi.mock('../../ai-input-bar/ModelDropdown', () => ({
+  ModelDropdown: () => <button type="button">模型</button>,
+}));
+
+vi.mock('../../ai-input-bar/ParametersDropdown', () => ({
+  ParametersDropdown: () => <button type="button">参数</button>,
+}));
+
+vi.mock('../../ai-input-bar/CountDropdown', () => ({
+  CountDropdown: () => <button type="button">数量</button>,
+}));
+
+vi.mock('../../media-library/MediaLibraryModal', () => ({
+  MediaLibraryModal: () => <div data-testid="media-library-modal" />,
+}));
+
+vi.mock('../../icons', () => ({
+  ImageUploadIcon: () => <span aria-hidden="true">upload</span>,
+  MediaLibraryIcon: () => <span aria-hidden="true">library</span>,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('EnhancedChatInput placeholder', () => {
+  it('uses continuation copy when there is no attached content', () => {
+    render(
+      <EnhancedChatInput
+        selectedContent={[]}
+        onSend={() => undefined}
+        placeholder="继续描述要修改的内容..."
+      />
+    );
+
+    expect(
+      screen.getByPlaceholderText('继续描述要修改的内容...')
+    ).toBeTruthy();
+  });
+
+  it('keeps effect-description copy when content is attached', () => {
+    render(
+      <EnhancedChatInput
+        selectedContent={[
+          {
+            type: 'image',
+            name: '参考图',
+            url: 'data:image/png;base64,abc',
+          },
+        ]}
+        onSend={() => undefined}
+        placeholder="继续描述要修改的内容..."
+      />
+    );
+
+    expect(screen.getByPlaceholderText('描述你想要的效果...')).toBeTruthy();
+  });
+});

--- a/packages/drawnix/src/components/chat-drawer/__tests__/WorkflowMessageBubble.test.tsx
+++ b/packages/drawnix/src/components/chat-drawer/__tests__/WorkflowMessageBubble.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { WorkflowMessageData } from '../../../types/chat.types';
+import { WorkflowMessageBubble } from '../WorkflowMessageBubble';
+import {
+  getWorkflowBubbleStatus,
+  normalizeWorkflowStepsForDisplay,
+} from '../../../utils/workflow-bubble-status';
+
+function createImageWorkflow(
+  overrides: Partial<WorkflowMessageData> = {}
+): WorkflowMessageData {
+  const baseSteps: WorkflowMessageData['steps'] = [1, 2, 3].map((index) => ({
+    id: `step-${index}`,
+    description: `生成图片 (${index}/3)`,
+    status: 'completed' as const,
+    mcp: 'generate_image',
+    args: {
+      prompt: '生成一个超级苹果。',
+    },
+    result: {
+      taskId: `task-${index}`,
+      result: {
+        url: `/__aitu_cache__/image/task-${index}.png`,
+        format: 'png',
+        size: 123,
+      },
+    },
+    options: {
+      batchId: 'wf_batch_wf-1',
+      batchIndex: index,
+      batchTotal: 3,
+    },
+  }));
+
+  return {
+    id: 'wf-1',
+    name: '图片生成',
+    generationType: 'image',
+    prompt: '生成一个超级苹果。',
+    count: 3,
+    status: 'completed',
+    steps: baseSteps,
+    ...overrides,
+  };
+}
+
+function createFailedWorkflow(): WorkflowMessageData {
+  return createImageWorkflow({
+    status: 'failed',
+    steps: createImageWorkflow().steps.map((step) => ({
+      ...step,
+      status: 'failed',
+      error: '图片生成失败',
+      result: { taskId: `task-${step.options?.batchIndex}` },
+    })),
+    retryContext: {
+      aiContext: {} as WorkflowMessageData['retryContext']['aiContext'],
+      referenceImages: [],
+    },
+  });
+}
+
+beforeEach(() => {
+  window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('WorkflowMessageBubble status helpers', () => {
+  it('shows image workflow as completed when all generation tasks are completed', () => {
+    const workflow = createImageWorkflow();
+    const steps = normalizeWorkflowStepsForDisplay(workflow.steps);
+
+    expect(getWorkflowBubbleStatus(steps)).toEqual({
+      status: 'completed',
+      totalSteps: 3,
+      completedSteps: 3,
+    });
+  });
+
+  it('does not keep a completed image workflow running because post-processing is missing', () => {
+    const workflow = createImageWorkflow({
+      postProcessingStatus: undefined,
+    });
+    const steps = normalizeWorkflowStepsForDisplay(workflow.steps);
+
+    expect(getWorkflowBubbleStatus(steps).status).toBe('completed');
+  });
+});
+
+describe('WorkflowMessageBubble rendering', () => {
+  it('hides completed media steps by default and omits redundant generated summary', () => {
+    render(<WorkflowMessageBubble workflow={createImageWorkflow()} />);
+
+    expect(screen.getByText('图片生成')).toBeTruthy();
+    expect(screen.getAllByText('已完成')).toHaveLength(1);
+    expect(screen.getByText('3/3')).toBeTruthy();
+    expect(screen.queryByText('生成图片 (1/3)')).toBeNull();
+    expect(screen.queryByText('已生成')).toBeNull();
+    expect(
+      screen
+        .getByRole('button', { name: '查看执行详情' })
+        .getAttribute('aria-expanded')
+    ).toBe('false');
+  });
+
+  it('reveals completed media steps from the details toggle', () => {
+    render(<WorkflowMessageBubble workflow={createImageWorkflow()} />);
+
+    const toggle = screen.getByRole('button', { name: '查看执行详情' });
+    fireEvent.click(toggle);
+
+    expect(screen.getByText('生成图片 (1/3)')).toBeTruthy();
+    expect(screen.getByText('生成图片 (2/3)')).toBeTruthy();
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('keeps running workflow steps visible immediately', () => {
+    render(
+      <WorkflowMessageBubble
+        workflow={createImageWorkflow({
+          status: 'running',
+          steps: createImageWorkflow().steps.map((step, index) => ({
+            ...step,
+            status: index === 0 ? 'running' : 'pending',
+            result: undefined,
+          })),
+        })}
+      />
+    );
+
+    expect(screen.getByText('生成图片 (1/3)')).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: '查看执行详情' })
+    ).toBeNull();
+  });
+
+  it('keeps failed workflow details and retry controls visible', () => {
+    render(
+      <WorkflowMessageBubble
+        workflow={createFailedWorkflow()}
+        onRetry={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('生成图片 (1/3)')).toBeTruthy();
+    expect(screen.getByText('执行失败，请重试')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /从失败步骤重试/ })
+    ).toBeTruthy();
+  });
+});

--- a/packages/drawnix/src/components/chat-drawer/chat-drawer.scss
+++ b/packages/drawnix/src/components/chat-drawer/chat-drawer.scss
@@ -11,7 +11,7 @@
 $drawer-min-width: 375px;
 $border-radius: 12px;
 $drawer-header-height: 108px; // 增加了高度以适应新设计
-$drawer-input-height: 160px;
+$drawer-input-max-height: 280px;
 
 // ============================================================================
 // Chat Drawer Container
@@ -191,7 +191,9 @@ $drawer-input-height: 160px;
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    height: calc(100vh - #{$drawer-header-height});
+    flex: 1;
+    min-height: 0;
+    height: auto;
   }
 
   &__close-btn {
@@ -781,9 +783,7 @@ $drawer-input-height: 160px;
     }
 
     &__content {
-      height: calc(
-        100vh - #{$drawer-header-height} - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)
-      );
+      min-height: 0;
     }
   }
 
@@ -805,6 +805,7 @@ $drawer-input-height: 160px;
   .enhanced-chat-input {
     padding: $spacing-sm $spacing-md;
     padding-bottom: calc(env(safe-area-inset-bottom, 0px) + #{$spacing-sm});
+    max-height: min(42vh, 260px);
 
     &__form {
       padding: 6px;
@@ -815,7 +816,7 @@ $drawer-input-height: 160px;
       font-size: 15px;
     }
 
-    &__send {
+    &__control-shell .ai-input-bar__send-btn {
       width: 36px;
       height: 36px;
       min-width: 36px;
@@ -892,7 +893,7 @@ $drawer-input-height: 160px;
   // 输入区域更紧凑
   .enhanced-chat-input {
     padding: $spacing-xs $spacing-sm;
-    max-height: 140px;
+    max-height: min(46vh, 220px);
 
     &__form {
       padding: 4px;
@@ -967,7 +968,7 @@ $drawer-input-height: 160px;
       height: 28px;
     }
 
-    &__send {
+    &__control-shell .ai-input-bar__send-btn {
       width: 32px;
       height: 32px;
       min-width: 32px;
@@ -995,7 +996,9 @@ $drawer-input-height: 160px;
 .chat-section {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - #{$drawer-header-height} - #{$drawer-input-height});
+  flex: 1;
+  min-height: 0;
+  height: auto;
   overflow: hidden;
   padding: 0 !important;
 }
@@ -1326,20 +1329,22 @@ $drawer-input-height: 160px;
 .enhanced-chat-input {
   position: relative;
   flex-shrink: 0;
-  max-height: $drawer-input-height;
+  max-height: $drawer-input-max-height;
+  max-height: min(36vh, #{$drawer-input-max-height});
   padding: $spacing-md $spacing-lg;
   border-top: 1px solid var(--td-component-border);
   background: #ffffff;
   overflow-y: auto;
+  overscroll-behavior: contain;
 
   // 选中内容预览（对齐 AIInputBar 样式）
   &__selection {
     display: flex;
     flex-wrap: wrap;
     gap: $spacing-sm;
-    padding-bottom: $spacing-sm;
-    margin-bottom: $spacing-sm;
-    border-bottom: 1px dashed var(--td-component-border);
+    padding: 0 12px 2px;
+    margin: 0;
+    border-bottom: none;
     align-items: center;
   }
 
@@ -1393,11 +1398,11 @@ $drawer-input-height: 160px;
 
   &__form {
     display: flex;
-    align-items: flex-start;
-    gap: $spacing-sm;
+    flex-direction: column;
+    gap: 6px;
     background: #ffffff;
-    border-radius: 16px;
-    padding: 8px;
+    border-radius: 24px;
+    padding: 12px 12px 10px;
     border: 1px solid var(--td-component-border);
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
     transition: all 0.3s ease;
@@ -1410,7 +1415,27 @@ $drawer-input-height: 160px;
 
   &__input-wrapper {
     position: relative;
-    flex: 1;
+    width: 100%;
+  }
+
+  &__footer {
+    width: 100%;
+  }
+
+  &__control-shell.ai-input-bar {
+    position: static;
+    inset: auto;
+    transform: none;
+    z-index: auto;
+    max-width: none;
+    padding: 0;
+    pointer-events: auto;
+    align-items: stretch;
+    gap: 0;
+
+    .ai-input-bar__bottom-bar {
+      min-height: 40px;
+    }
   }
 
   // 高亮背景层 - 显示模型/参数/个数标签的背景色块
@@ -1470,9 +1495,9 @@ $drawer-input-height: 160px;
     position: relative;
     z-index: 2;
     width: 100%;
-    min-height: 88px;
+    min-height: 52px;
     max-height: 120px;
-    padding: 10px 12px;
+    padding: 4px 12px 0;
     background: transparent;
     border: none;
     border-radius: 12px;
@@ -1486,45 +1511,6 @@ $drawer-input-height: 160px;
 
     &::placeholder {
       color: var(--td-text-color-placeholder);
-    }
-  }
-
-  &__send {
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: #f3f4f6;
-    border: none;
-    border-radius: 50%;
-    color: #9ca3af;
-    cursor: not-allowed;
-    transition: all 0.2s ease;
-    flex-shrink: 0;
-
-    &--active {
-      background: #f59e0b;
-      color: #fff;
-      cursor: pointer;
-      box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
-
-      &:hover {
-        background: #d97706;
-        transform: scale(1.05);
-      }
-    }
-
-    &:disabled {
-      background: #f3f4f6;
-      color: #9ca3af;
-      cursor: not-allowed;
-      box-shadow: none;
-    }
-
-    svg {
-      width: 20px;
-      height: 20px;
     }
   }
 }

--- a/packages/drawnix/src/components/chat-drawer/useChatDrawerGenerationControls.ts
+++ b/packages/drawnix/src/components/chat-drawer/useChatDrawerGenerationControls.ts
@@ -1,0 +1,389 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  getCompatibleParams,
+  getDefaultAudioModel,
+  getDefaultImageModel,
+  getDefaultSizeForModel,
+  getDefaultTextModel,
+  getDefaultVideoModel,
+  getModelConfig,
+  type ModelConfig,
+} from '../../constants/model-config';
+import { useSelectableModels } from '../../hooks/use-runtime-models';
+import {
+  loadAIInputPreferences,
+  loadScopedAIInputModelParams,
+  saveAIInputPreferences,
+  saveScopedAIInputModelParams,
+} from '../../services/ai-generation-preferences-service';
+import { getEffectiveVideoCompatibleParams } from '../../services/video-binding-utils';
+import type { GenerationType } from '../../utils/ai-input-parser';
+import { applyForcedSunoParams } from '../../utils/suno-model-aliases';
+import {
+  createModelRef,
+  resolveInvocationRoute,
+  type ModelRef,
+} from '../../utils/settings-manager';
+
+function getSelectionKey(modelId: string, modelRef?: ModelRef | null): string {
+  return modelRef?.profileId ? `${modelRef.profileId}::${modelId}` : modelId;
+}
+
+function getSelectionKeyForModel(
+  model: Pick<ModelConfig, 'id' | 'selectionKey' | 'sourceProfileId'>
+): string {
+  return (
+    model.selectionKey ||
+    (model.sourceProfileId ? `${model.sourceProfileId}::${model.id}` : model.id)
+  );
+}
+
+function getModelRefFromConfig(model?: ModelConfig | null): ModelRef | null {
+  if (!model) {
+    return null;
+  }
+
+  return createModelRef(model.sourceProfileId || null, model.id);
+}
+
+function findMatchingSelectableModel(
+  models: ModelConfig[],
+  modelId: string,
+  modelRef?: ModelRef | null
+): ModelConfig | undefined {
+  const expectedKey = getSelectionKey(modelId, modelRef);
+  const expectedProfileId = modelRef?.profileId ?? null;
+
+  return (
+    models.find((model) => getSelectionKeyForModel(model) === expectedKey) ||
+    (expectedProfileId === null
+      ? models.find((model) => model.id === modelId && !model.sourceProfileId)
+      : undefined) ||
+    models.find((model) => model.id === modelId)
+  );
+}
+
+function resolveGenerationTypeForModelSelection(
+  currentGenerationType: GenerationType,
+  modelType: ModelConfig['type']
+): GenerationType {
+  if (currentGenerationType === 'agent' && modelType === 'text') {
+    return 'agent';
+  }
+
+  return modelType as GenerationType;
+}
+
+function getFallbackModelId(generationType: GenerationType): string {
+  if (generationType === 'video') return getDefaultVideoModel();
+  if (generationType === 'audio') return getDefaultAudioModel();
+  if (generationType === 'text' || generationType === 'agent') {
+    return getDefaultTextModel();
+  }
+  return getDefaultImageModel();
+}
+
+function getRouteType(
+  generationType: GenerationType
+): 'image' | 'video' | 'audio' | 'text' {
+  if (generationType === 'video') return 'video';
+  if (generationType === 'audio') return 'audio';
+  if (generationType === 'text' || generationType === 'agent') return 'text';
+  return 'image';
+}
+
+function areParamsEqual(
+  a: Record<string, string>,
+  b: Record<string, string>
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  return (
+    aKeys.length === bKeys.length && aKeys.every((key) => a[key] === b[key])
+  );
+}
+
+export function useChatDrawerGenerationControls() {
+  const imageModels = useSelectableModels('image');
+  const videoModels = useSelectableModels('video');
+  const audioModels = useSelectableModels('audio');
+  const textModels = useSelectableModels('text');
+  const initialPreferences = useMemo(() => loadAIInputPreferences(), []);
+
+  const [generationType, setGenerationType] = useState<GenerationType>(
+    initialPreferences.generationType
+  );
+  const [selectedModel, setSelectedModel] = useState(
+    initialPreferences.selectedModel
+  );
+  const [selectedModelRef, setSelectedModelRef] = useState<ModelRef | null>(
+    null
+  );
+  const [selectedParams, setSelectedParams] = useState<Record<string, string>>(
+    initialPreferences.selectedParams
+  );
+  const [selectedCount, setSelectedCount] = useState(
+    initialPreferences.selectedCount
+  );
+
+  const selectedParamsRef = useRef(selectedParams);
+  const selectedParamScopeRef = useRef(
+    `${generationType}:${getSelectionKey(selectedModel, selectedModelRef)}`
+  );
+
+  useEffect(() => {
+    selectedParamsRef.current = selectedParams;
+  }, [selectedParams]);
+
+  const currentModels = useMemo(() => {
+    if (generationType === 'video') return videoModels;
+    if (generationType === 'audio') return audioModels;
+    if (generationType === 'text' || generationType === 'agent') {
+      return textModels;
+    }
+    return imageModels;
+  }, [audioModels, generationType, imageModels, textModels, videoModels]);
+
+  const resolvePreferredModelSelection = useCallback(
+    (type: GenerationType, models: ModelConfig[]) => {
+      const route = resolveInvocationRoute(getRouteType(type));
+      const routeModel =
+        findMatchingSelectableModel(
+          models,
+          route.modelId,
+          createModelRef(route.profileId, route.modelId)
+        ) || findMatchingSelectableModel(models, route.modelId, null);
+      if (routeModel) {
+        return routeModel;
+      }
+
+      const fallbackModelId = getFallbackModelId(type);
+      return (
+        findMatchingSelectableModel(models, fallbackModelId, null) ||
+        getModelConfig(fallbackModelId) ||
+        models[0]
+      );
+    },
+    []
+  );
+
+  useEffect(() => {
+    const currentModelConfig = findMatchingSelectableModel(
+      currentModels,
+      selectedModel,
+      selectedModelRef
+    );
+    const nextModelConfig =
+      currentModelConfig ||
+      resolvePreferredModelSelection(generationType, currentModels);
+
+    if (nextModelConfig) {
+      const currentSelectionKey = getSelectionKey(
+        selectedModel,
+        selectedModelRef
+      );
+      const nextSelectionKey = getSelectionKeyForModel(nextModelConfig);
+      if (currentSelectionKey !== nextSelectionKey) {
+        setSelectedModel(nextModelConfig.id);
+        setSelectedModelRef(getModelRefFromConfig(nextModelConfig));
+      }
+    }
+
+    if (
+      generationType === 'agent' ||
+      generationType === 'text' ||
+      generationType === 'audio'
+    ) {
+      setSelectedCount(1);
+    }
+  }, [
+    currentModels,
+    generationType,
+    resolvePreferredModelSelection,
+    selectedModel,
+    selectedModelRef,
+  ]);
+
+  const compatibleParams = useMemo(() => {
+    if (generationType === 'agent') return [];
+    if (generationType === 'video') {
+      return getEffectiveVideoCompatibleParams(
+        selectedModel,
+        selectedModelRef || selectedModel,
+        selectedParams
+      );
+    }
+
+    const params = getCompatibleParams(selectedModel);
+    if (generationType !== 'audio') {
+      return params;
+    }
+
+    const sunoAction =
+      selectedParams.sunoAction ||
+      params.find((param) => param.id === 'sunoAction')?.defaultValue ||
+      'music';
+    if (sunoAction === 'lyrics') {
+      return params.filter(
+        (param) =>
+          param.id === 'sunoAction' ||
+          param.id === 'mv' ||
+          param.id === 'title' ||
+          param.id === 'tags'
+      );
+    }
+
+    return params;
+  }, [generationType, selectedModel, selectedModelRef, selectedParams]);
+
+  useEffect(() => {
+    const currentScopeKey =
+      generationType === 'agent'
+        ? 'agent'
+        : `${generationType}:${getSelectionKey(
+            selectedModel,
+            selectedModelRef
+          )}`;
+    const baseParams =
+      generationType === 'agent'
+        ? {}
+        : selectedParamScopeRef.current === currentScopeKey
+        ? selectedParamsRef.current || {}
+        : loadScopedAIInputModelParams(
+            generationType,
+            selectedModel,
+            getSelectionKey(selectedModel, selectedModelRef),
+            selectedParamsRef.current
+          );
+    const nextParams: Record<string, string> = {};
+
+    const sizeParam = compatibleParams.find((param) => param.id === 'size');
+    const prevSize = baseParams.size;
+    const prevSizeIsValid =
+      !prevSize ||
+      !sizeParam?.options ||
+      sizeParam.options.some((option) => option.value === prevSize);
+    if (!selectedModel.startsWith('mj') && sizeParam) {
+      nextParams.size =
+        prevSize && prevSizeIsValid
+          ? prevSize
+          : sizeParam.defaultValue || getDefaultSizeForModel(selectedModel);
+    }
+
+    compatibleParams.forEach((param) => {
+      if (param.id === 'size') return;
+      const prevValue = baseParams[param.id];
+      const prevValueIsValid =
+        !prevValue ||
+        param.valueType !== 'enum' ||
+        !param.options ||
+        param.options.some((option) => option.value === prevValue);
+      if (prevValue && prevValueIsValid) {
+        nextParams[param.id] = prevValue;
+      } else if (param.defaultValue) {
+        nextParams[param.id] = param.defaultValue;
+      }
+    });
+
+    const normalizedParams = applyForcedSunoParams(selectedModel, nextParams);
+    if (!areParamsEqual(selectedParamsRef.current || {}, normalizedParams)) {
+      setSelectedParams(normalizedParams);
+      selectedParamsRef.current = normalizedParams;
+    }
+    selectedParamScopeRef.current = currentScopeKey;
+  }, [compatibleParams, generationType, selectedModel, selectedModelRef]);
+
+  useEffect(() => {
+    saveAIInputPreferences({
+      generationType,
+      selectedModel,
+      selectedParams,
+      selectedCount,
+      selectedSkillId: 'auto',
+    });
+    if (generationType !== 'agent') {
+      saveScopedAIInputModelParams(
+        generationType,
+        selectedModel,
+        selectedParams,
+        getSelectionKey(selectedModel, selectedModelRef)
+      );
+    }
+  }, [
+    generationType,
+    selectedCount,
+    selectedModel,
+    selectedModelRef,
+    selectedParams,
+  ]);
+
+  const applyModelSelection = useCallback(
+    (model: ModelConfig) => {
+      const nextGenerationType = resolveGenerationTypeForModelSelection(
+        generationType,
+        model.type
+      );
+      const nextModelRef = getModelRefFromConfig(model);
+      setGenerationType(nextGenerationType);
+      setSelectedModel(model.id);
+      setSelectedModelRef(nextModelRef);
+      setSelectedParams(
+        nextGenerationType === 'agent'
+          ? {}
+          : loadScopedAIInputModelParams(
+              nextGenerationType,
+              model.id,
+              getSelectionKey(model.id, nextModelRef)
+            )
+      );
+    },
+    [generationType]
+  );
+
+  const handleModelSelect = useCallback(
+    (modelId: string, modelRef?: ModelRef | null) => {
+      const model =
+        findMatchingSelectableModel(currentModels, modelId, modelRef || null) ||
+        findMatchingSelectableModel(currentModels, modelId, null) ||
+        getModelConfig(modelId);
+      if (!model) return;
+      applyModelSelection(model);
+    },
+    [applyModelSelection, currentModels]
+  );
+
+  const handleModelConfigSelect = useCallback(
+    (model: ModelConfig) => {
+      applyModelSelection(model);
+    },
+    [applyModelSelection]
+  );
+
+  const handleParamSelect = useCallback((paramId: string, value?: string) => {
+    setSelectedParams((prev) => {
+      const next = { ...prev };
+      if (value === undefined || value === '') {
+        delete next[paramId];
+      } else {
+        next[paramId] = value;
+      }
+      return next;
+    });
+  }, []);
+
+  return {
+    generationType,
+    setGenerationType,
+    selectedModel,
+    selectedModelRef,
+    selectedSelectionKey: getSelectionKey(selectedModel, selectedModelRef),
+    selectedParams,
+    compatibleParams,
+    selectedCount,
+    setSelectedCount,
+    currentModels,
+    handleModelSelect,
+    handleModelConfigSelect,
+    handleParamSelect,
+  };
+}

--- a/packages/drawnix/src/components/chat-drawer/workflow-message-bubble.scss
+++ b/packages/drawnix/src/components/chat-drawer/workflow-message-bubble.scss
@@ -7,7 +7,8 @@
 .workflow-bubble {
   display: flex;
   gap: $spacing-md;
-  max-width: 90%;
+  width: min(620px, calc(100% - 44px));
+  max-width: calc(100% - 44px);
   align-self: flex-start;
 
   .chat-message-avatar {
@@ -171,6 +172,43 @@
     overflow: hidden;
   }
 
+  &__details-toggle {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    gap: 6px;
+    margin-bottom: $spacing-md;
+    padding: 4px 8px;
+    background: var(--td-bg-color-container);
+    border: 1px solid var(--td-component-border);
+    border-radius: 6px;
+    color: var(--td-text-color-secondary);
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1.2;
+    transition:
+      background 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease;
+
+    &:hover {
+      background: var(--td-bg-color-container-hover);
+      border-color: var(--td-brand-color);
+      color: var(--td-brand-color);
+    }
+  }
+
+  &__details-toggle-icon {
+    display: inline-flex;
+    align-items: center;
+    font-size: 10px;
+    transition: transform 0.2s ease;
+
+    &--open {
+      transform: rotate(180deg);
+    }
+  }
+
   // 完成/失败摘要
   &__summary {
     display: flex;
@@ -260,6 +298,24 @@
       opacity: 0.6;
       cursor: not-allowed;
     }
+  }
+}
+
+.workflow-bubble.chat-message {
+  width: min(620px, calc(100% - 44px));
+  max-width: calc(100% - 44px);
+}
+
+@media (max-width: 640px) {
+  .workflow-bubble {
+    width: 100%;
+    max-width: 100%;
+    gap: $spacing-sm;
+  }
+
+  .workflow-bubble.chat-message {
+    width: 100%;
+    max-width: 100%;
   }
 }
 

--- a/packages/drawnix/src/contexts/ChatDrawerContext.tsx
+++ b/packages/drawnix/src/contexts/ChatDrawerContext.tsx
@@ -4,8 +4,23 @@
  * 提供 ChatDrawer 的 ref 访问，使其他组件可以控制 ChatDrawer
  */
 
-import React, { createContext, useContext, useRef, useCallback, useState, type MutableRefObject } from 'react';
-import type { ChatDrawerRef, WorkflowMessageData, WorkflowMessageParams, AgentLogEntry } from '../types/chat.types';
+import React, {
+  createContext,
+  useContext,
+  useRef,
+  useCallback,
+  useState,
+  type MutableRefObject,
+} from 'react';
+import type {
+  ChatDrawerRef,
+  WorkflowMessageData,
+  WorkflowMessageParams,
+  AgentLogEntry,
+} from '../types/chat.types';
+import type { GenerationType } from '../utils/ai-input-parser';
+import type { ModelRef } from '../utils/settings-manager';
+import type { Task } from '../types/task.types';
 
 /** 选中内容类型 */
 export type SelectedContentType = 'image' | 'video' | 'graphics' | 'text';
@@ -22,14 +37,35 @@ export interface SelectedContentItem {
 }
 
 /** 重试处理器类型 */
-export type RetryHandler = (workflow: WorkflowMessageData, startStepIndex: number, workZoneId?: string) => Promise<void>;
+export type RetryHandler = (
+  workflow: WorkflowMessageData,
+  startStepIndex: number,
+  workZoneId?: string
+) => Promise<void>;
+
+export interface DrawerGenerationSubmitParams {
+  prompt: string;
+  selectedContent: SelectedContentItem[];
+  generationType: GenerationType;
+  selectedModel: string;
+  selectedModelRef?: ModelRef | null;
+  selectedParams: Record<string, string>;
+  selectedCount: number;
+}
+
+export type DrawerGenerationSubmitter = (
+  params: DrawerGenerationSubmitParams
+) => Promise<void>;
 
 interface ChatDrawerContextValue {
   chatDrawerRef: MutableRefObject<ChatDrawerRef | null>;
   /** 注册重试处理器 */
   registerRetryHandler: (handler: RetryHandler) => void;
   /** 执行重试 */
-  executeRetry: (workflow: WorkflowMessageData, startStepIndex: number) => Promise<void>;
+  executeRetry: (
+    workflow: WorkflowMessageData,
+    startStepIndex: number
+  ) => Promise<void>;
   /** 选中内容 */
   selectedContent: SelectedContentItem[];
   /** 设置选中内容 */
@@ -42,6 +78,16 @@ interface ChatDrawerContextValue {
   drawerWidth: number;
   /** 设置抽屉宽度 */
   setDrawerWidth: (width: number) => void;
+  /** 注册抽屉生成提交处理器 */
+  registerGenerationSubmitter: (
+    submitter: DrawerGenerationSubmitter | null
+  ) => void;
+  /** 从抽屉提交生成任务 */
+  submitGenerationFromDrawer: (
+    params: DrawerGenerationSubmitParams
+  ) => Promise<boolean>;
+  /** 根据任务队列事件同步已有工作流消息 */
+  syncWorkflowTaskUpdate: (task: Task) => boolean;
 }
 
 const ChatDrawerContext = createContext<ChatDrawerContextValue | null>(null);
@@ -51,18 +97,22 @@ export interface ChatDrawerProviderProps {
 }
 
 // 默认抽屉宽度
-const DEFAULT_DRAWER_WIDTH = typeof window !== 'undefined' 
-  ? Math.max(375, window.innerWidth * 0.5) 
-  : 600;
+const DEFAULT_DRAWER_WIDTH =
+  typeof window !== 'undefined' ? Math.max(375, window.innerWidth * 0.5) : 600;
 
 /**
  * ChatDrawer Provider
  * 提供 ChatDrawer ref 的访问
  */
-export const ChatDrawerProvider: React.FC<ChatDrawerProviderProps> = ({ children }) => {
+export const ChatDrawerProvider: React.FC<ChatDrawerProviderProps> = ({
+  children,
+}) => {
   const chatDrawerRef = useRef<ChatDrawerRef>(null);
   const retryHandlerRef = useRef<RetryHandler | null>(null);
-  const [selectedContent, setSelectedContent] = useState<SelectedContentItem[]>([]);
+  const generationSubmitterRef = useRef<DrawerGenerationSubmitter | null>(null);
+  const [selectedContent, setSelectedContent] = useState<SelectedContentItem[]>(
+    []
+  );
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [drawerWidth, setDrawerWidth] = useState(DEFAULT_DRAWER_WIDTH);
 
@@ -70,26 +120,57 @@ export const ChatDrawerProvider: React.FC<ChatDrawerProviderProps> = ({ children
     retryHandlerRef.current = handler;
   }, []);
 
-  const executeRetry = useCallback(async (workflow: WorkflowMessageData, startStepIndex: number) => {
-    if (retryHandlerRef.current) {
-      await retryHandlerRef.current(workflow, startStepIndex);
-    } else {
-      console.warn('[ChatDrawerContext] No retry handler registered');
-    }
+  const executeRetry = useCallback(
+    async (workflow: WorkflowMessageData, startStepIndex: number) => {
+      if (retryHandlerRef.current) {
+        await retryHandlerRef.current(workflow, startStepIndex);
+      } else {
+        console.warn('[ChatDrawerContext] No retry handler registered');
+      }
+    },
+    []
+  );
+
+  const registerGenerationSubmitter = useCallback(
+    (submitter: DrawerGenerationSubmitter | null) => {
+      generationSubmitterRef.current = submitter;
+    },
+    []
+  );
+
+  const submitGenerationFromDrawer = useCallback(
+    async (params: DrawerGenerationSubmitParams) => {
+      if (!generationSubmitterRef.current) {
+        return false;
+      }
+
+      await generationSubmitterRef.current(params);
+      return true;
+    },
+    []
+  );
+
+  const syncWorkflowTaskUpdate = useCallback((task: Task) => {
+    return chatDrawerRef.current?.syncWorkflowTaskUpdate(task) ?? false;
   }, []);
 
   return (
-    <ChatDrawerContext.Provider value={{ 
-      chatDrawerRef, 
-      registerRetryHandler, 
-      executeRetry, 
-      selectedContent, 
-      setSelectedContent,
-      isDrawerOpen,
-      setIsDrawerOpen,
-      drawerWidth,
-      setDrawerWidth,
-    }}>
+    <ChatDrawerContext.Provider
+      value={{
+        chatDrawerRef,
+        registerRetryHandler,
+        executeRetry,
+        selectedContent,
+        setSelectedContent,
+        isDrawerOpen,
+        setIsDrawerOpen,
+        drawerWidth,
+        setDrawerWidth,
+        registerGenerationSubmitter,
+        submitGenerationFromDrawer,
+        syncWorkflowTaskUpdate,
+      }}
+    >
       {children}
     </ChatDrawerContext.Provider>
   );
@@ -111,16 +192,19 @@ export function useChatDrawer(): ChatDrawerContextValue {
  * 提供便捷的方法来控制 ChatDrawer
  */
 export function useChatDrawerControl() {
-  const { 
-    chatDrawerRef, 
-    registerRetryHandler, 
-    executeRetry, 
-    selectedContent, 
+  const {
+    chatDrawerRef,
+    registerRetryHandler,
+    executeRetry,
+    selectedContent,
     setSelectedContent,
     isDrawerOpen,
     setIsDrawerOpen,
     drawerWidth,
     setDrawerWidth,
+    registerGenerationSubmitter,
+    submitGenerationFromDrawer,
+    syncWorkflowTaskUpdate,
   } = useChatDrawer();
 
   return {
@@ -171,13 +255,22 @@ export function useChatDrawerControl() {
     /** 注册重试处理器 */
     registerRetryHandler,
     /** 从失败步骤重试工作流 */
-    retryWorkflowFromStep: async (workflow: WorkflowMessageData, stepIndex: number) => {
+    retryWorkflowFromStep: async (
+      workflow: WorkflowMessageData,
+      stepIndex: number
+    ) => {
       await executeRetry(workflow, stepIndex);
     },
     /** 选中内容 */
     selectedContent,
     /** 设置选中内容 */
     setSelectedContent,
+    /** 注册抽屉生成提交处理器 */
+    registerGenerationSubmitter,
+    /** 从抽屉提交生成任务 */
+    submitGenerationFromDrawer,
+    /** 根据任务队列事件同步已有工作流消息 */
+    syncWorkflowTaskUpdate,
   };
 }
 

--- a/packages/drawnix/src/hooks/useChatHandler.ts
+++ b/packages/drawnix/src/hooks/useChatHandler.ts
@@ -62,6 +62,10 @@ export function useChatHandler(options: UseChatHandlerOptions): ChatHandler & {
     newMessages: Message[],
     rawChatMessages?: ChatMessage[]
   ) => void;
+  appendMessagesWithRaw: (
+    newMessages: Message[],
+    rawChatMessages?: ChatMessage[]
+  ) => void;
   updateRawMessageWorkflow: (
     messageId: string,
     workflow: WorkflowMessageData
@@ -421,6 +425,16 @@ export function useChatHandler(options: UseChatHandlerOptions): ChatHandler & {
     []
   );
 
+  const appendMessagesWithRaw = useCallback(
+    (newMessages: Message[], rawChatMessages?: ChatMessage[]) => {
+      setMessages((prev) => [...prev, ...newMessages]);
+      if (rawChatMessages) {
+        rawMessagesRef.current = [...rawMessagesRef.current, ...rawChatMessages];
+      }
+    },
+    []
+  );
+
   // 更新原始消息中的工作流数据（用于工作流更新场景）
   const updateRawMessageWorkflow = useCallback(
     (messageId: string, workflow: WorkflowMessageData) => {
@@ -439,6 +453,7 @@ export function useChatHandler(options: UseChatHandlerOptions): ChatHandler & {
     regenerate,
     setMessages,
     setMessagesWithRaw,
+    appendMessagesWithRaw,
     updateRawMessageWorkflow,
     isLoading,
   };

--- a/packages/drawnix/src/hooks/useTaskWorkflowSync.ts
+++ b/packages/drawnix/src/hooks/useTaskWorkflowSync.ts
@@ -20,6 +20,7 @@ import type { TaskEvent, Task } from '../types/task.types';
 
 import type { WorkflowStep, WorkflowDefinition } from '../components/ai-input-bar/workflow-converter';
 import type { PlaitWorkZone } from '../types/workzone.types';
+import { findWorkflowStepForTask } from '../utils/workflow-task-linking';
 
 interface WorkflowControl {
   updateStep: (
@@ -37,6 +38,7 @@ interface WorkflowControl {
 export interface UseTaskWorkflowSyncOptions {
   workflowControl: WorkflowControl;
   updateWorkflowMessage: (data: WorkflowMessageData) => void;
+  syncWorkflowTaskUpdate?: (task: Task) => boolean;
   boardRef: React.MutableRefObject<PlaitBoard | null>;
   workZoneIdRef: React.MutableRefObject<string | null>;
 }
@@ -45,21 +47,11 @@ const MAX_BUFFER_SIZE = 20;
 const REPLAY_INTERVAL = 2000;
 const MAX_REPLAY_DURATION = 30000;
 
-/**
- * Build taskId → stepId mapping from workflow steps
- */
-function buildTaskStepMap(
-  steps: Array<{ id: string; result?: unknown }> | undefined
-): Map<string, string> {
-  const map = new Map<string, string>();
-  if (!steps) return map;
-  for (const step of steps) {
-    const result = step.result as { taskId?: string } | undefined;
-    if (result?.taskId) {
-      map.set(result.taskId, step.id);
-    }
-  }
-  return map;
+function areAllWorkflowStepsCompleted(workflow: WorkflowDefinition): boolean {
+  return (
+    workflow.steps.length > 0 &&
+    workflow.steps.every((step) => step.status === 'completed')
+  );
 }
 
 /**
@@ -69,9 +61,13 @@ function mapTaskToStepStatus(task: Task): {
   status: WorkflowStep['status']; result?: unknown; error?: string;
 } | null {
   if (task.status === TaskStatus.PROCESSING) {
-    return { status: 'running' };
+    return { status: 'running', result: { taskId: task.id } };
   } else if (task.status === TaskStatus.COMPLETED && task.result) {
-    return { status: 'completed', result: { ...task.result, taskId: task.id } };
+    const result =
+      typeof task.result === 'object' && task.result !== null
+        ? { ...task.result, taskId: task.id }
+        : { result: task.result, taskId: task.id };
+    return { status: 'completed', result };
   } else if (task.status === TaskStatus.FAILED) {
     const errorMsg = typeof task.error === 'string'
       ? task.error
@@ -94,20 +90,31 @@ function processViaContext(
   workZoneIdRef: React.MutableRefObject<string | null>,
 ): boolean {
   const workflow = workflowControl.getWorkflow();
-  const taskStepMap = buildTaskStepMap(workflow?.steps);
-  const stepId = taskStepMap.get(task.id);
-  if (!stepId) return false;
+  const step = findWorkflowStepForTask(workflow, task);
+  if (!step) return false;
   const shouldSyncWorkZone =
     task.type !== TaskType.IMAGE && workflow?.generationType !== 'image';
 
   if (mapped.status === 'running') {
     workflowControl.resumeWorkflow();
   }
-  workflowControl.updateStep(stepId, mapped.status, mapped.result, mapped.error);
+  workflowControl.updateStep(
+    step.id,
+    mapped.status,
+    mapped.result,
+    mapped.error
+  );
 
   const updatedWorkflow = workflowControl.getWorkflow();
   if (updatedWorkflow) {
-    const workflowData = toWorkflowMessageData(updatedWorkflow);
+    const workflowData = toWorkflowMessageData(
+      updatedWorkflow,
+      undefined,
+      updatedWorkflow.generationType === 'image' &&
+        areAllWorkflowStepsCompleted(updatedWorkflow)
+        ? 'completed'
+        : undefined
+    );
     updateWorkflowMessageRef.current(workflowData);
     const board = boardRef.current;
     const workZoneId = workZoneIdRef.current;
@@ -142,13 +149,12 @@ function processViaWorkZone(
     if (wz.workflow.generationType === 'image') {
       continue;
     }
-    const wzStepMap = buildTaskStepMap(wz.workflow?.steps);
-    const wzStepId = wzStepMap.get(task.id);
-    if (!wzStepId) continue;
+    const wzStep = findWorkflowStepForTask(wz.workflow, task);
+    if (!wzStep) continue;
 
     // Update the WorkZone's workflow steps
     const updatedSteps = wz.workflow.steps.map(step => {
-      if (step.id !== wzStepId) return step;
+      if (step.id !== wzStep.id) return step;
       return {
         ...step,
         status: mapped.status,
@@ -213,7 +219,12 @@ function processViaWorkZone(
 function processTaskEvent(
   event: TaskEvent,
   workflowControl: WorkflowControl,
-  updateWorkflowMessageRef: React.MutableRefObject<(data: WorkflowMessageData) => void>,
+  updateWorkflowMessageRef: React.MutableRefObject<
+    (data: WorkflowMessageData) => void
+  >,
+  syncWorkflowTaskUpdateRef: React.MutableRefObject<
+    ((task: Task) => boolean) | undefined
+  >,
   boardRef: React.MutableRefObject<PlaitBoard | null>,
   workZoneIdRef: React.MutableRefObject<string | null>,
 ): boolean {
@@ -222,15 +233,33 @@ function processTaskEvent(
   if (!mapped) return false;
 
   // Primary: update via WorkflowContext
-  if (processViaContext(task, mapped, workflowControl, updateWorkflowMessageRef, boardRef, workZoneIdRef)) {
+  if (
+    processViaContext(
+      task,
+      mapped,
+      workflowControl,
+      updateWorkflowMessageRef,
+      boardRef,
+      workZoneIdRef
+    )
+  ) {
     return true;
   }
   // Fallback: update WorkZone Plait element directly
-  if (processViaWorkZone(task, mapped, workflowControl, updateWorkflowMessageRef, boardRef, workZoneIdRef)) {
+  if (
+    processViaWorkZone(
+      task,
+      mapped,
+      workflowControl,
+      updateWorkflowMessageRef,
+      boardRef,
+      workZoneIdRef
+    )
+  ) {
     return true;
   }
 
-  return false;
+  return syncWorkflowTaskUpdateRef.current?.(task) ?? false;
 }
 
 /**
@@ -245,6 +274,10 @@ export function useTaskWorkflowSync(options: UseTaskWorkflowSyncOptions): void {
   useEffect(() => {
     updateWorkflowMessageRef.current = options.updateWorkflowMessage;
   }, [options.updateWorkflowMessage]);
+  const syncWorkflowTaskUpdateRef = useRef(options.syncWorkflowTaskUpdate);
+  useEffect(() => {
+    syncWorkflowTaskUpdateRef.current = options.syncWorkflowTaskUpdate;
+  }, [options.syncWorkflowTaskUpdate]);
 
   const eventBufferRef = useRef<Map<string, TaskEvent>>(new Map());
   const replayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -272,6 +305,7 @@ export function useTaskWorkflowSync(options: UseTaskWorkflowSyncOptions): void {
           buffered,
           workflowControl,
           updateWorkflowMessageRef,
+          syncWorkflowTaskUpdateRef,
           boardRef,
           workZoneIdRef,
         );
@@ -301,41 +335,58 @@ export function useTaskWorkflowSync(options: UseTaskWorkflowSyncOptions): void {
         if (mapped.status === 'completed' || mapped.status === 'failed') {
           processTaskEvent(
             { type: 'taskUpdated', task, timestamp: Date.now() },
-            workflowControl, updateWorkflowMessageRef, boardRef, workZoneIdRef,
+            workflowControl,
+            updateWorkflowMessageRef,
+            syncWorkflowTaskUpdateRef,
+            boardRef,
+            workZoneIdRef
           );
         }
       }
     }
 
-    const subscription = taskQueueService.observeTaskUpdates().subscribe((event) => {
-      if (event.type !== 'taskUpdated') return;
+    const subscription = taskQueueService
+      .observeTaskUpdates()
+      .subscribe((event) => {
+        if (event.type !== 'taskUpdated') return;
 
-      if (
-        event.task.status === TaskStatus.PROCESSING &&
-        eventBufferRef.current.has(event.task.id)
-      ) {
-        bufferEvent(event);
-        if (!replayTimerRef.current) {
-          replayStartRef.current = Date.now();
-          replayTimerRef.current = setInterval(tryReplayBuffer, REPLAY_INTERVAL);
+        if (
+          event.task.status === TaskStatus.PROCESSING &&
+          eventBufferRef.current.has(event.task.id)
+        ) {
+          bufferEvent(event);
+          if (!replayTimerRef.current) {
+            replayStartRef.current = Date.now();
+            replayTimerRef.current = setInterval(
+              tryReplayBuffer,
+              REPLAY_INTERVAL
+            );
+          }
+          return;
         }
-        return;
-      }
 
-      const handled = processTaskEvent(
-        event, workflowControl, updateWorkflowMessageRef, boardRef, workZoneIdRef,
-      );
+        const handled = processTaskEvent(
+          event,
+          workflowControl,
+          updateWorkflowMessageRef,
+          syncWorkflowTaskUpdateRef,
+          boardRef,
+          workZoneIdRef
+        );
 
-      if (handled) {
-        eventBufferRef.current.delete(event.task.id);
-      } else {
-        bufferEvent(event);
-        if (!replayTimerRef.current) {
-          replayStartRef.current = Date.now();
-          replayTimerRef.current = setInterval(tryReplayBuffer, REPLAY_INTERVAL);
+        if (handled) {
+          eventBufferRef.current.delete(event.task.id);
+        } else {
+          bufferEvent(event);
+          if (!replayTimerRef.current) {
+            replayStartRef.current = Date.now();
+            replayTimerRef.current = setInterval(
+              tryReplayBuffer,
+              REPLAY_INTERVAL
+            );
+          }
         }
-      }
-    });
+      });
 
     return () => {
       subscription.unsubscribe();

--- a/packages/drawnix/src/hooks/useWorkflowSubmission.ts
+++ b/packages/drawnix/src/hooks/useWorkflowSubmission.ts
@@ -57,7 +57,10 @@ export interface UseWorkflowSubmissionReturn {
     parsedInput: ParsedGenerationParams,
     referenceImages: string[],
     retryContext?: WorkflowRetryContext,
-    existingWorkflow?: LegacyWorkflowDefinition
+    existingWorkflow?: LegacyWorkflowDefinition,
+    options?: {
+      appendToCurrentChatSession?: boolean;
+    }
   ) => Promise<{ workflowId: string; usedSW: boolean }>;
   /** Cancel a workflow */
   cancelWorkflow: (workflowId: string) => Promise<void>;
@@ -140,6 +143,7 @@ export function useWorkflowSubmission(
   useTaskWorkflowSync({
     workflowControl,
     updateWorkflowMessage: chatDrawerControl.updateWorkflowMessage,
+    syncWorkflowTaskUpdate: chatDrawerControl.syncWorkflowTaskUpdate,
     boardRef,
     workZoneIdRef,
   });
@@ -453,7 +457,10 @@ export function useWorkflowSubmission(
     parsedInput: ParsedGenerationParams,
     referenceImages: string[],
     retryContext?: WorkflowRetryContext,
-    existingWorkflow?: LegacyWorkflowDefinition
+    existingWorkflow?: LegacyWorkflowDefinition,
+    options?: {
+      appendToCurrentChatSession?: boolean;
+    }
   ): Promise<{ workflowId: string; usedSW: boolean }> => {
     // Use existing workflow if provided, otherwise create a new one
     const legacyWorkflow = existingWorkflow || convertToWorkflow(parsedInput, referenceImages);
@@ -511,6 +518,7 @@ export function useWorkflowSubmission(
       workflow: workflowMessageData,
       textModel,
       autoOpen: false,
+      appendToCurrentSession: options?.appendToCurrentChatSession,
     });
 
     // Always use main thread execution

--- a/packages/drawnix/src/plugins/with-hotkey.test.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment jsdom
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlaitBoard } from '@plait/core';
+import { buildDrawnixHotkeyPlugin } from './with-hotkey';
 
 const {
   updatePointerTypeMock,
@@ -159,8 +162,6 @@ vi.mock('./with-lasso-selection', () => ({
   LassoPointerType: 'lasso',
 }));
 
-import { buildDrawnixHotkeyPlugin } from './with-hotkey';
-
 type TestBoard = PlaitBoard & {
   globalKeyDown: (event: KeyboardEvent) => void;
   keyDown: (event: KeyboardEvent) => void;
@@ -247,6 +248,62 @@ describe('buildDrawnixHotkeyPlugin', () => {
 
     expect(updatePointerTypeMock).not.toHaveBeenCalled();
     expect(updateAppStateMock).not.toHaveBeenCalled();
+    expect(globalKeyDownMock).toHaveBeenCalledWith(event);
+  });
+
+  it.each(['felt-tip-pen', 'mask'])(
+    'undoes the last stroke with Backspace while using %s',
+    (pointer) => {
+      const board = buildDrawnixHotkeyPlugin(updateAppStateMock)({
+        ...createBoard(),
+        pointer,
+      } as TestBoard & { pointer: string }) as TestBoard;
+      const event = new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        cancelable: true,
+      });
+
+      board.globalKeyDown(event);
+
+      expect(board.undo).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+      expect(globalKeyDownMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['eraser', 'laser-pointer', 'selection'])(
+    'does not undo with Backspace while using %s',
+    (pointer) => {
+      const board = buildDrawnixHotkeyPlugin(updateAppStateMock)({
+        ...createBoard(),
+        pointer,
+      } as TestBoard & { pointer: string }) as TestBoard;
+      const event = new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        cancelable: true,
+      });
+
+      board.globalKeyDown(event);
+
+      expect(board.undo).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not undo with Backspace while typing in an input', () => {
+    const board = buildDrawnixHotkeyPlugin(updateAppStateMock)({
+      ...createBoard(),
+      pointer: 'felt-tip-pen',
+    } as TestBoard & { pointer: string }) as TestBoard;
+    const input = document.createElement('input');
+    const event = new KeyboardEvent('keydown', {
+      key: 'Backspace',
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'target', { value: input });
+
+    board.globalKeyDown(event);
+
+    expect(board.undo).not.toHaveBeenCalled();
     expect(globalKeyDownMock).toHaveBeenCalledWith(event);
   });
 

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -337,6 +337,17 @@ export const buildDrawnixHotkeyPlugin = (
             event.preventDefault();
             return;
           }
+          if (
+            event.key === 'Backspace' &&
+            PlaitBoard.isInPointer(board, [
+              FreehandShape.feltTipPen,
+              FreehandShape.mask,
+            ])
+          ) {
+            board.undo();
+            event.preventDefault();
+            return;
+          }
           if (event.key === 'h') {
             BoardTransforms.updatePointerType(board, PlaitPointerType.hand);
             updateAppState({ pointer: PlaitPointerType.hand });

--- a/packages/drawnix/src/types/chat.types.ts
+++ b/packages/drawnix/src/types/chat.types.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ModelRef } from '../utils/settings-manager';
-import type { KnowledgeContextRef } from './task.types';
+import type { KnowledgeContextRef, Task } from './task.types';
 
 // ============================================================================
 // Enums
@@ -304,6 +304,8 @@ export interface WorkflowMessageParams {
   textModel?: string;
   /** 是否自动打开 ChatDrawer，默认 true */
   autoOpen?: boolean;
+  /** 是否追加到当前会话，默认保持创建新会话 */
+  appendToCurrentSession?: boolean;
 }
 
 /** ChatDrawer Ref API - 用于外部控制 ChatDrawer */
@@ -320,6 +322,8 @@ export interface ChatDrawerRef {
   sendWorkflowMessage: (params: WorkflowMessageParams) => Promise<void>;
   /** 更新当前工作流消息 */
   updateWorkflowMessage: (workflow: WorkflowMessageData) => void;
+  /** 根据任务队列事件同步已有工作流消息 */
+  syncWorkflowTaskUpdate: (task: Task) => boolean;
   /** 追加 Agent 执行日志 */
   appendAgentLog: (log: AgentLogEntry) => void;
   /** 更新 AI 思考内容（流式追加） */

--- a/packages/drawnix/src/utils/__tests__/chat-drawer-session-target.test.ts
+++ b/packages/drawnix/src/utils/__tests__/chat-drawer-session-target.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { resolveWorkflowSessionTarget } from '../chat-drawer-session-target';
+
+describe('chat drawer workflow session target', () => {
+  it('appends workflow messages to the active session when requested', () => {
+    expect(resolveWorkflowSessionTarget('session-1', true)).toEqual({
+      mode: 'append',
+      sessionId: 'session-1',
+    });
+  });
+
+  it('creates a session when no active session exists', () => {
+    expect(resolveWorkflowSessionTarget(null, true)).toEqual({
+      mode: 'create',
+    });
+  });
+
+  it('preserves the existing new-session behavior by default', () => {
+    expect(resolveWorkflowSessionTarget('session-1')).toEqual({
+      mode: 'create',
+    });
+  });
+});

--- a/packages/drawnix/src/utils/__tests__/workflow-task-linking.test.ts
+++ b/packages/drawnix/src/utils/__tests__/workflow-task-linking.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { TaskStatus, TaskType, type Task } from '../../types/task.types';
+import {
+  extractTaskIdFromStepResult,
+  findTaskForWorkflowStep,
+  findWorkflowStepForTask,
+  isWorkflowStepTaskCompleted,
+} from '../workflow-task-linking';
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    type: TaskType.IMAGE,
+    status: TaskStatus.COMPLETED,
+    params: {
+      prompt: '生成图片',
+      workflowId: 'wf-1',
+      batchId: 'wf_batch_wf-1',
+      batchIndex: 1,
+    },
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe('workflow-task-linking', () => {
+  it('extracts task ids from direct and nested step results', () => {
+    expect(extractTaskIdFromStepResult({ taskId: 'task-direct' })).toBe(
+      'task-direct'
+    );
+    expect(
+      extractTaskIdFromStepResult({ data: { taskId: 'task-data' } })
+    ).toBe('task-data');
+    expect(
+      extractTaskIdFromStepResult({ result: { taskId: 'task-result' } })
+    ).toBe('task-result');
+    expect(extractTaskIdFromStepResult({ taskIds: ['task-list'] })).toBe(
+      'task-list'
+    );
+  });
+
+  it('matches an image task to its workflow step before taskId is written', () => {
+    const task = createTask();
+    const workflow = {
+      id: 'wf-1',
+      generationType: 'image',
+      steps: [
+        {
+          id: 'step-1',
+          mcp: 'generate_image',
+          args: {},
+          status: 'running' as const,
+          options: {
+            batchId: 'wf_batch_wf-1',
+            batchIndex: 1,
+          },
+        },
+      ],
+    };
+
+    expect(findWorkflowStepForTask(workflow, task)?.id).toBe('step-1');
+  });
+
+  it('does not match a task from another workflow', () => {
+    const task = createTask({
+      params: {
+        prompt: '生成图片',
+        workflowId: 'wf-other',
+        batchId: 'wf_batch_wf-other',
+        batchIndex: 1,
+      },
+    });
+    const workflow = {
+      id: 'wf-1',
+      generationType: 'image',
+      steps: [
+        {
+          id: 'step-1',
+          mcp: 'generate_image',
+          args: {},
+          status: 'running' as const,
+          options: {
+            batchId: 'wf_batch_wf-1',
+            batchIndex: 1,
+          },
+        },
+      ],
+    };
+
+    expect(findWorkflowStepForTask(workflow, task)).toBeUndefined();
+  });
+
+  it('finds the completed task for a workflow step before taskId is written', () => {
+    const task = createTask();
+    const workflow = {
+      id: 'wf-1',
+      generationType: 'image',
+      steps: [
+        {
+          id: 'step-1',
+          mcp: 'generate_image',
+          args: {},
+          status: 'running' as const,
+          options: {
+            batchId: 'wf_batch_wf-1',
+            batchIndex: 1,
+          },
+        },
+      ],
+    };
+
+    const [step] = workflow.steps;
+
+    expect(findTaskForWorkflowStep(workflow, step, [task])?.id).toBe('task-1');
+    expect(isWorkflowStepTaskCompleted(workflow, step, [task])).toBe(true);
+  });
+});

--- a/packages/drawnix/src/utils/__tests__/workflow-task-sync.test.ts
+++ b/packages/drawnix/src/utils/__tests__/workflow-task-sync.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowMessageData } from '../../types/chat.types';
+import { TaskStatus, TaskType, type Task } from '../../types/task.types';
+import { applyTaskUpdateToWorkflowMessage } from '../workflow-task-sync';
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-2',
+    type: TaskType.IMAGE,
+    status: TaskStatus.PROCESSING,
+    params: {
+      prompt: '生成皮特格里芬。',
+      workflowId: 'wf-1',
+      batchId: 'wf_batch_wf-1',
+      batchIndex: 2,
+    },
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+function createImageWorkflow(
+  overrides: Partial<WorkflowMessageData> = {}
+): WorkflowMessageData {
+  return {
+    id: 'wf-1',
+    name: '图片生成',
+    generationType: 'image',
+    prompt: '生成皮特格里芬。',
+    count: 3,
+    status: 'failed',
+    steps: [1, 2, 3].map((index) => ({
+      id: `step-${index}`,
+      description: `生成图片 (${index}/3)`,
+      status: 'failed' as const,
+      mcp: 'generate_image',
+      args: {
+        prompt: '生成皮特格里芬。',
+      },
+      result: {
+        taskId: `task-${index}`,
+      },
+      error: '任务执行失败',
+      options: {
+        batchId: 'wf_batch_wf-1',
+        batchIndex: index,
+        batchTotal: 3,
+      },
+    })),
+    ...overrides,
+  };
+}
+
+describe('workflow-task-sync', () => {
+  it('moves a failed retried image step back to running and clears stale error', () => {
+    const workflow = createImageWorkflow();
+    const updated = applyTaskUpdateToWorkflowMessage(
+      workflow,
+      createTask({ status: TaskStatus.PROCESSING })
+    );
+
+    expect(updated?.steps[1].status).toBe('running');
+    expect(updated?.steps[1].error).toBeUndefined();
+    expect(updated?.steps[1].result).toMatchObject({ taskId: 'task-2' });
+  });
+
+  it('matches a retry completion by workflow batch slot when the failed step has no taskId', () => {
+    const workflow = createImageWorkflow({
+      steps: createImageWorkflow().steps.map((step) =>
+        step.id === 'step-2' ? { ...step, result: undefined } : step
+      ),
+    });
+
+    const updated = applyTaskUpdateToWorkflowMessage(
+      workflow,
+      createTask({
+        status: TaskStatus.COMPLETED,
+        result: {
+          url: '/__aitu_cache__/image/task-2.png',
+          format: 'png',
+          size: 123,
+        },
+      })
+    );
+
+    expect(updated?.steps[1].status).toBe('completed');
+    expect(updated?.steps[1].error).toBeUndefined();
+    expect(updated?.steps[1].result).toMatchObject({
+      taskId: 'task-2',
+      result: {
+        url: '/__aitu_cache__/image/task-2.png',
+      },
+    });
+  });
+
+  it('marks an image workflow completed when queue retry completes the last failed step', () => {
+    const workflow = createImageWorkflow({
+      steps: createImageWorkflow().steps.map((step) =>
+        step.id === 'step-2'
+          ? step
+          : {
+              ...step,
+              status: 'completed',
+              error: undefined,
+              result: { taskId: `task-${step.options?.batchIndex}` },
+            }
+      ),
+    });
+
+    const updated = applyTaskUpdateToWorkflowMessage(
+      workflow,
+      createTask({
+        status: TaskStatus.COMPLETED,
+        result: {
+          url: '/__aitu_cache__/image/task-2.png',
+          format: 'png',
+          size: 123,
+        },
+      })
+    );
+
+    expect(updated?.status).toBe('completed');
+    expect(updated?.postProcessingStatus).toBe('completed');
+    expect(updated?.steps.every((step) => step.status === 'completed')).toBe(
+      true
+    );
+  });
+
+  it('does not downgrade an already completed image step on a stale processing event', () => {
+    const workflow = createImageWorkflow({
+      status: 'completed',
+      postProcessingStatus: 'completed',
+      steps: createImageWorkflow().steps.map((step) => ({
+        ...step,
+        status: 'completed',
+        error: undefined,
+      })),
+    });
+
+    const updated = applyTaskUpdateToWorkflowMessage(
+      workflow,
+      createTask({ status: TaskStatus.PROCESSING })
+    );
+
+    expect(updated?.steps[1].status).toBe('completed');
+    expect(updated?.postProcessingStatus).toBe('completed');
+  });
+});

--- a/packages/drawnix/src/utils/chat-drawer-session-target.ts
+++ b/packages/drawnix/src/utils/chat-drawer-session-target.ts
@@ -1,0 +1,14 @@
+export type WorkflowSessionTarget =
+  | { mode: 'append'; sessionId: string }
+  | { mode: 'create' };
+
+export function resolveWorkflowSessionTarget(
+  activeSessionId: string | null,
+  appendToCurrentSession?: boolean
+): WorkflowSessionTarget {
+  if (appendToCurrentSession && activeSessionId) {
+    return { mode: 'append', sessionId: activeSessionId };
+  }
+
+  return { mode: 'create' };
+}

--- a/packages/drawnix/src/utils/workflow-bubble-status.ts
+++ b/packages/drawnix/src/utils/workflow-bubble-status.ts
@@ -1,0 +1,60 @@
+import type { WorkflowMessageData } from '../types/chat.types';
+import { extractTaskIdFromStepResult } from './workflow-task-linking';
+
+export type WorkflowBubbleStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed';
+
+export interface WorkflowBubbleStatusResult {
+  status: WorkflowBubbleStatus;
+  totalSteps: number;
+  completedSteps: number;
+}
+
+export function normalizeWorkflowStepsForDisplay(
+  steps: WorkflowMessageData['steps']
+): WorkflowMessageData['steps'] {
+  return steps.map((step) => {
+    const hasPendingTask = Boolean(extractTaskIdFromStepResult(step.result));
+    const hasCompletedResult = step.result !== undefined && step.result !== null;
+    const hasDuration = step.duration !== undefined;
+
+    if (
+      (step.status === 'running' || step.status === 'pending') &&
+      !hasPendingTask
+    ) {
+      if (step.error) {
+        return { ...step, status: 'failed' as const };
+      }
+      if (hasCompletedResult || hasDuration) {
+        return { ...step, status: 'completed' as const };
+      }
+    }
+
+    return step;
+  });
+}
+
+export function getWorkflowBubbleStatus(
+  steps: WorkflowMessageData['steps']
+): WorkflowBubbleStatusResult {
+  const totalSteps = steps.length;
+  const completedSteps = steps.filter(
+    (step) => step.status === 'completed'
+  ).length;
+  const failedSteps = steps.filter((step) => step.status === 'failed').length;
+  const runningSteps = steps.filter((step) => step.status === 'running').length;
+
+  let status: WorkflowBubbleStatus = 'pending';
+  if (failedSteps > 0) {
+    status = 'failed';
+  } else if (completedSteps === totalSteps && totalSteps > 0) {
+    status = 'completed';
+  } else if (runningSteps > 0 || completedSteps > 0) {
+    status = 'running';
+  }
+
+  return { status, totalSteps, completedSteps };
+}

--- a/packages/drawnix/src/utils/workflow-task-linking.ts
+++ b/packages/drawnix/src/utils/workflow-task-linking.ts
@@ -1,0 +1,239 @@
+import { TaskStatus, TaskType, type Task } from '../types/task.types';
+
+type StepStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+
+export interface WorkflowTaskLinkStep {
+  id: string;
+  mcp?: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  status?: StepStatus;
+  options?: {
+    batchId?: string;
+    batchIndex?: number;
+    batchTotal?: number;
+    globalIndex?: number;
+  };
+}
+
+export interface WorkflowTaskLinkWorkflow<TStep extends WorkflowTaskLinkStep> {
+  id: string;
+  generationType?: string;
+  steps: TStep[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export function extractTaskIdFromStepResult(
+  result: unknown
+): string | undefined {
+  if (!isRecord(result)) {
+    return undefined;
+  }
+
+  const directTaskId = getString(result.taskId);
+  if (directTaskId) {
+    return directTaskId;
+  }
+
+  const dataTaskId = isRecord(result.data)
+    ? getString(result.data.taskId)
+    : undefined;
+  if (dataTaskId) {
+    return dataTaskId;
+  }
+
+  const nestedResultTaskId = isRecord(result.result)
+    ? getString(result.result.taskId)
+    : undefined;
+  if (nestedResultTaskId) {
+    return nestedResultTaskId;
+  }
+
+  const [firstTaskId] = Array.isArray(result.taskIds) ? result.taskIds : [];
+  return getString(firstTaskId);
+}
+
+export function getTaskWorkflowId(task: Task): string | undefined {
+  return getString(task.params.workflowId);
+}
+
+export function getTaskBatchId(task: Task): string | undefined {
+  return getString(task.params.batchId);
+}
+
+export function getTaskBatchIndex(task: Task): number | undefined {
+  return getNumber(task.params.batchIndex);
+}
+
+function getStepBatchId(step: WorkflowTaskLinkStep): string | undefined {
+  return getString(step.options?.batchId) || getString(step.args?.batchId);
+}
+
+function getStepBatchIndex(step: WorkflowTaskLinkStep): number | undefined {
+  return getNumber(step.options?.batchIndex) ?? getNumber(step.args?.batchIndex);
+}
+
+function isTaskTypeCompatibleWithStep(
+  task: Task,
+  step: WorkflowTaskLinkStep
+): boolean {
+  switch (task.type) {
+    case TaskType.IMAGE:
+      return (
+        step.mcp === 'generate_image' ||
+        step.mcp === 'generate_grid_image' ||
+        step.mcp === 'generate_inspiration_board'
+      );
+    case TaskType.VIDEO:
+      return step.mcp === 'generate_video' || step.mcp === 'generate_long_video';
+    case TaskType.AUDIO:
+      return step.mcp === 'generate_audio';
+    case TaskType.CHAT:
+      return step.mcp === 'generate_text' || step.mcp === 'ai_analyze';
+    default:
+      return true;
+  }
+}
+
+function hasSameBatchSlot(task: Task, step: WorkflowTaskLinkStep): boolean {
+  const taskBatchIndex = getTaskBatchIndex(task);
+  const stepBatchIndex = getStepBatchIndex(step);
+  if (
+    typeof taskBatchIndex !== 'number' ||
+    typeof stepBatchIndex !== 'number' ||
+    taskBatchIndex !== stepBatchIndex
+  ) {
+    return false;
+  }
+
+  const taskBatchId = getTaskBatchId(task);
+  const stepBatchId = getStepBatchId(step);
+  return !taskBatchId || !stepBatchId || taskBatchId === stepBatchId;
+}
+
+export function findWorkflowStepByTaskId<
+  TStep extends WorkflowTaskLinkStep
+>(
+  workflow: WorkflowTaskLinkWorkflow<TStep> | null | undefined,
+  taskId: string
+): TStep | undefined {
+  return workflow?.steps.find(
+    (step) => extractTaskIdFromStepResult(step.result) === taskId
+  );
+}
+
+export function findWorkflowStepForTask<
+  TStep extends WorkflowTaskLinkStep
+>(
+  workflow: WorkflowTaskLinkWorkflow<TStep> | null | undefined,
+  task: Task
+): TStep | undefined {
+  const directMatch = findWorkflowStepByTaskId(workflow, task.id);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  if (!workflow || getTaskWorkflowId(task) !== workflow.id) {
+    return undefined;
+  }
+
+  const compatibleSteps = workflow.steps.filter((step) =>
+    isTaskTypeCompatibleWithStep(task, step)
+  );
+
+  const batchSlotMatch = compatibleSteps.find((step) =>
+    hasSameBatchSlot(task, step)
+  );
+  if (batchSlotMatch) {
+    return batchSlotMatch;
+  }
+
+  const unboundSteps = compatibleSteps.filter(
+    (step) => !extractTaskIdFromStepResult(step.result)
+  );
+  if (unboundSteps.length === 1) {
+    return unboundSteps[0];
+  }
+
+  if (compatibleSteps.length === 1) {
+    return compatibleSteps[0];
+  }
+
+  return undefined;
+}
+
+export function findTaskForWorkflowStep<TStep extends WorkflowTaskLinkStep>(
+  workflow: WorkflowTaskLinkWorkflow<TStep>,
+  step: TStep,
+  tasks: Task[]
+): Task | undefined {
+  const taskId = extractTaskIdFromStepResult(step.result);
+  if (taskId) {
+    return tasks.find((task) => task.id === taskId);
+  }
+
+  const compatibleTasks = tasks.filter(
+    (task) =>
+      getTaskWorkflowId(task) === workflow.id &&
+      isTaskTypeCompatibleWithStep(task, step)
+  );
+
+  const stepBatchIndex = getStepBatchIndex(step);
+  const stepBatchId = getStepBatchId(step);
+  if (typeof stepBatchIndex === 'number') {
+    const batchSlotMatch = compatibleTasks.find((task) => {
+      const taskBatchIndex = getTaskBatchIndex(task);
+      const taskBatchId = getTaskBatchId(task);
+
+      return (
+        taskBatchIndex === stepBatchIndex &&
+        (!stepBatchId || !taskBatchId || stepBatchId === taskBatchId)
+      );
+    });
+
+    if (batchSlotMatch) {
+      return batchSlotMatch;
+    }
+  }
+
+  return compatibleTasks.length === 1 ? compatibleTasks[0] : undefined;
+}
+
+export function isWorkflowStepTaskCompleted<
+  TStep extends WorkflowTaskLinkStep
+>(
+  workflow: WorkflowTaskLinkWorkflow<TStep>,
+  step: TStep,
+  tasks: Task[]
+): boolean {
+  return (
+    findTaskForWorkflowStep(workflow, step, tasks)?.status ===
+    TaskStatus.COMPLETED
+  );
+}
+
+export function ensureTaskIdInStepResult(
+  result: unknown,
+  taskId: string
+): Record<string, unknown> {
+  if (isRecord(result)) {
+    return extractTaskIdFromStepResult(result)
+      ? { ...result }
+      : { ...result, taskId };
+  }
+
+  return { taskId };
+}

--- a/packages/drawnix/src/utils/workflow-task-sync.ts
+++ b/packages/drawnix/src/utils/workflow-task-sync.ts
@@ -1,0 +1,153 @@
+import type { WorkflowMessageData } from '../types/chat.types';
+import { TaskStatus, type Task } from '../types/task.types';
+import {
+  ensureTaskIdInStepResult,
+  findWorkflowStepForTask,
+} from './workflow-task-linking';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getTaskErrorMessage(task: Task): string | undefined {
+  if (!task.error) {
+    return undefined;
+  }
+
+  return task.error.message || task.error.code || '任务执行失败';
+}
+
+function getCompletedStepResult(
+  currentResult: unknown,
+  task: Task
+): Record<string, unknown> {
+  const base = isRecord(currentResult) ? { ...currentResult } : {};
+  return {
+    ...base,
+    taskId: task.id,
+    result: task.result,
+  };
+}
+
+function getWorkflowStatusFromSteps(
+  steps: WorkflowMessageData['steps']
+): WorkflowMessageData['status'] {
+  const failedSteps = steps.filter((step) => step.status === 'failed').length;
+  const runningSteps = steps.filter((step) => step.status === 'running').length;
+  const pendingSteps = steps.filter((step) => step.status === 'pending').length;
+  const completedSteps = steps.filter(
+    (step) => step.status === 'completed'
+  ).length;
+
+  if (failedSteps > 0) {
+    return 'failed';
+  }
+
+  if (runningSteps > 0) {
+    return 'running';
+  }
+
+  if (pendingSteps === 0 && completedSteps > 0) {
+    return 'completed';
+  }
+
+  return 'pending';
+}
+
+function areAllStepsCompleted(
+  steps: WorkflowMessageData['steps']
+): boolean {
+  return (
+    steps.length > 0 && steps.every((step) => step.status === 'completed')
+  );
+}
+
+/**
+ * Apply a task queue update directly to a persisted Chat Drawer workflow.
+ *
+ * This is the drawer fallback path for task-queue retries: the retried task may
+ * no longer be attached to the active WorkflowContext, but the stored workflow
+ * message still has enough task metadata to update the visible bubble.
+ */
+export function applyTaskUpdateToWorkflowMessage(
+  workflow: WorkflowMessageData,
+  task: Task
+): WorkflowMessageData | null {
+  const targetStep = findWorkflowStepForTask(workflow, task);
+  if (!targetStep) {
+    return null;
+  }
+
+  const updatedSteps = workflow.steps.map((step) => {
+    if (step.id !== targetStep.id) {
+      return step;
+    }
+
+    switch (task.status) {
+      case TaskStatus.PENDING:
+      case TaskStatus.PROCESSING: {
+        if (step.status === 'completed') {
+          return {
+            ...step,
+            result: ensureTaskIdInStepResult(step.result, task.id),
+          };
+        }
+
+        return {
+          ...step,
+          status: 'running' as const,
+          result: ensureTaskIdInStepResult(step.result, task.id),
+          error: undefined,
+        };
+      }
+
+      case TaskStatus.COMPLETED:
+        return {
+          ...step,
+          status: 'completed' as const,
+          result: getCompletedStepResult(step.result, task),
+          error: undefined,
+        };
+
+      case TaskStatus.FAILED:
+        return {
+          ...step,
+          status: 'failed' as const,
+          result: ensureTaskIdInStepResult(step.result, task.id),
+          error: getTaskErrorMessage(task),
+        };
+
+      case TaskStatus.CANCELLED:
+        return {
+          ...step,
+          status: 'skipped' as const,
+          result: ensureTaskIdInStepResult(step.result, task.id),
+          error: getTaskErrorMessage(task),
+        };
+
+      default:
+        return step;
+    }
+  });
+
+  const allStepsCompleted = areAllStepsCompleted(updatedSteps);
+  const nextWorkflowStatus = getWorkflowStatusFromSteps(updatedSteps);
+  const shouldMarkImageCompleted =
+    workflow.generationType === 'image' && allStepsCompleted;
+  const shouldClearImagePostProcessing =
+    workflow.generationType === 'image' &&
+    task.status !== TaskStatus.COMPLETED &&
+    workflow.postProcessingStatus !== 'completed';
+
+  return {
+    ...workflow,
+    status: nextWorkflowStatus,
+    steps: updatedSteps,
+    error: nextWorkflowStatus === 'failed' ? workflow.error : undefined,
+    postProcessingStatus: shouldMarkImageCompleted
+      ? 'completed'
+      : shouldClearImagePostProcessing
+      ? undefined
+      : workflow.postProcessingStatus,
+  };
+}


### PR DESCRIPTION
## Summary
- Add Chat Drawer generation controls for upload, media library selection, generation type, model, parameters, and count.
- Keep workflow generation inside the current chat session when launched from the drawer, and sync task queue updates back into existing workflow bubbles.
- Collapse completed media workflow details by default while keeping details available on demand.
- Fix Backspace undo for freehand pen and mask brush modes.

## Verification
- `pnpm --dir packages/drawnix exec vitest run src/plugins/with-hotkey.test.ts src/components/chat-drawer/__tests__/EnhancedChatInput.test.tsx src/components/chat-drawer/__tests__/WorkflowMessageBubble.test.tsx src/utils/__tests__/chat-drawer-session-target.test.ts src/utils/__tests__/workflow-task-linking.test.ts src/utils/__tests__/workflow-task-sync.test.ts`
- `pnpm nx run drawnix:typecheck`
- `pnpm --dir packages/drawnix exec eslint src/components/chat-drawer/EnhancedChatInput.tsx src/components/chat-drawer/ChatDrawer.tsx src/components/chat-drawer/WorkflowMessageBubble.tsx src/components/ai-input-bar/AIInputBar.tsx src/hooks/useTaskWorkflowSync.ts src/plugins/with-hotkey.ts src/plugins/with-hotkey.test.ts src/utils/workflow-task-linking.ts src/utils/workflow-task-sync.ts src/utils/chat-drawer-session-target.ts src/utils/workflow-bubble-status.ts --ext .ts,.tsx,.js,.jsx`
- `git diff --check`

## Notes
- Full `drawnix:test` / `drawnix:lint` currently include pre-existing repository failures unrelated to this PR. The touched-file ESLint check exits with warnings only, no errors.
- `node packages/drawnix/scripts/check-hover-usage.mjs` still reports pre-existing native `title` usage in unrelated files; this PR removes the newly added Chat Drawer native `title` usage.
