### PR TITLE
Improve chat drawer workflow generation

### DIFF
--- a/packages/drawnix/src/components/chat-drawer/ChatDrawer.tsx
+++ b/packages/drawnix/src/components/chat-drawer/ChatDrawer.tsx
@@ -45,6 +45,10 @@ import type { Message } from '../../types/chat-ui.types';
 import { useTextSelection } from '../../hooks/useTextSelection';
 import { applyTaskUpdateToWorkflowMessage } from '../../utils/workflow-task-sync';
 import { resolveWorkflowSessionTarget } from '../../utils/chat-drawer-session-target';
+import {
+  getLatestWorkflowImageReferences,
+  shouldUseImplicitWorkflowReferences,
+} from './workflow-media-results';
 
 import { analytics } from '../../utils/posthog-analytics';
 import { HoverTip } from '../shared';
@@ -170,6 +174,10 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
     const [retryingWorkflowId, setRetryingWorkflowId] = useState<string | null>(
       null
     );
+    const [replyTarget, setReplyTarget] = useState<{
+      messageId: string;
+      workflow: WorkflowMessageData;
+    } | null>(null);
 
     // 获取重试执行器和选中内容（从 Context），以及状态同步方法
     const {
@@ -1102,6 +1110,80 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
       [activeSessionId, chatHandler, onOpenChange]
     );
 
+    const [shouldRenderChat, setShouldRenderChat] = useState(false);
+
+    useEffect(() => {
+      if (isOpen) {
+        setShouldRenderChat(true);
+      }
+    }, [isOpen]);
+
+    const implicitReferenceContent = useMemo(() => {
+      if (replyTarget) {
+        return getLatestWorkflowImageReferences([replyTarget.workflow]);
+      }
+
+      if (!shouldRenderChat) {
+        return [];
+      }
+
+      return getLatestWorkflowImageReferences(workflowMessages.values());
+    }, [replyTarget, shouldRenderChat, workflowMessages]);
+
+    const implicitReferenceLabel = replyTarget
+      ? `回复：${replyTarget.workflow.name || '生成结果'}`
+      : undefined;
+
+    const handleWorkflowReply = useCallback(
+      (messageId: string, workflow: WorkflowMessageData) => {
+        setReplyTarget({ messageId, workflow });
+      },
+      []
+    );
+
+    const handleClearReplyTarget = useCallback(() => {
+      setReplyTarget(null);
+    }, []);
+
+    const handleSubmitDrawerGeneration = useCallback(
+      async (message: Message) => {
+        const textPart = message.parts.find((part) => part.type === 'text');
+        const prompt =
+          textPart && 'text' in textPart && typeof textPart.text === 'string'
+            ? textPart.text
+            : '';
+        const hasFilePart = message.parts.some(
+          (part) => part.type === 'data-file' || part.type === 'image_url'
+        );
+
+        if (
+          !hasFilePart &&
+          implicitReferenceContent.length > 0 &&
+          (replyTarget || shouldUseImplicitWorkflowReferences(prompt))
+        ) {
+          const referenceParts: Message['parts'] = implicitReferenceContent
+            .filter((item) => item.url)
+            .map((item, index) => ({
+              type: 'data-file' as const,
+              data: {
+                filename: `previous-result-${index + 1}.png`,
+                mediaType: 'image/png',
+                url: item.url,
+              },
+            }));
+
+          await handleSendWrapper({
+            ...message,
+            parts: [...message.parts, ...referenceParts],
+          });
+          return;
+        }
+
+        await handleSendWrapper(message);
+      },
+      [handleSendWrapper, implicitReferenceContent, replyTarget]
+    );
+
     // 更新当前工作流消息（同时持久化到本地存储）
     const handleUpdateWorkflowMessage = useCallback(
       async (workflow: WorkflowMessageData) => {
@@ -1440,12 +1522,6 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
       stopPropagation: true,
     });
 
-    const [shouldRenderChat, setShouldRenderChat] = useState(false);
-    useEffect(() => {
-      if (isOpen) {
-        setShouldRenderChat(true);
-      }
-    }, [isOpen]);
     return (
       <>
         <ChatDrawerTrigger
@@ -1566,6 +1642,7 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
                     handler={wrappedHandler}
                     workflowMessages={workflowMessages}
                     retryingWorkflowId={retryingWorkflowId}
+                    handleWorkflowReply={handleWorkflowReply}
                     handleWorkflowRetry={handleWorkflowRetry}
                   />
                 </Suspense>
@@ -1573,7 +1650,16 @@ export const ChatDrawer = forwardRef<ChatDrawerRef, ChatDrawerProps>(
 
               <EnhancedChatInput
                 selectedContent={selectedContent}
-                onSend={handleSendWrapper}
+                implicitReferenceContent={implicitReferenceContent}
+                implicitReferenceLabel={implicitReferenceLabel}
+                implicitReferencePinned={Boolean(replyTarget)}
+                onClearImplicitReference={
+                  replyTarget ? handleClearReplyTarget : undefined
+                }
+                onImplicitReferenceConsumed={
+                  replyTarget ? handleClearReplyTarget : undefined
+                }
+                onSend={handleSubmitDrawerGeneration}
                 placeholder="继续描述要修改的内容..."
               />
             </div>

--- a/packages/drawnix/src/components/chat-drawer/ChatMessagesArea.tsx
+++ b/packages/drawnix/src/components/chat-drawer/ChatMessagesArea.tsx
@@ -12,6 +12,10 @@ interface ChatMessagesAreaProps {
   handler: ChatHandler;
   workflowMessages: Map<string, WorkflowMessageData>;
   retryingWorkflowId: string | null;
+  handleWorkflowReply?: (
+    messageId: string,
+    workflow: WorkflowMessageData
+  ) => void;
   handleWorkflowRetry: (
     messageId: string,
     workflow: WorkflowMessageData,
@@ -24,6 +28,7 @@ export const ChatMessagesArea: React.FC<ChatMessagesAreaProps> = ({
   handler,
   workflowMessages,
   retryingWorkflowId,
+  handleWorkflowReply,
   handleWorkflowRetry,
   className = 'chat-section',
 }) => {
@@ -83,6 +88,11 @@ export const ChatMessagesArea: React.FC<ChatMessagesAreaProps> = ({
                     workflow={workflowData}
                     onRetry={(stepIndex) =>
                       handleWorkflowRetry(workflowMsgId, workflowData, stepIndex)
+                    }
+                    onReply={
+                      handleWorkflowReply
+                        ? () => handleWorkflowReply(workflowMsgId, workflowData)
+                        : undefined
                     }
                     isRetrying={retryingWorkflowId === workflowMsgId}
                   />

--- a/packages/drawnix/src/components/chat-drawer/EnhancedChatInput.tsx
+++ b/packages/drawnix/src/components/chat-drawer/EnhancedChatInput.tsx
@@ -38,10 +38,16 @@ import { MediaLibraryModal } from '../media-library/MediaLibraryModal';
 import { ImageUploadIcon, MediaLibraryIcon } from '../icons';
 import { HoverTip } from '../shared';
 import { useChatDrawerGenerationControls } from './useChatDrawerGenerationControls';
+import { shouldUseImplicitWorkflowReferences } from './workflow-media-results';
 import '../ai-input-bar/ai-input-bar.scss';
 
 interface EnhancedChatInputProps {
   selectedContent: SelectedContentItem[];
+  implicitReferenceContent?: SelectedContentItem[];
+  implicitReferenceLabel?: string;
+  implicitReferencePinned?: boolean;
+  onClearImplicitReference?: () => void;
+  onImplicitReferenceConsumed?: () => void;
   onSend: (message: Message) => void | Promise<void>;
   disabled?: boolean;
   placeholder?: string;
@@ -64,7 +70,17 @@ export const EnhancedChatInput = forwardRef<
   EnhancedChatInputProps
 >(
   (
-    { selectedContent, onSend, disabled = false, placeholder = '输入消息...' },
+    {
+      selectedContent,
+      implicitReferenceContent = [],
+      implicitReferenceLabel,
+      implicitReferencePinned = false,
+      onClearImplicitReference,
+      onImplicitReferenceConsumed,
+      onSend,
+      disabled = false,
+      placeholder = '输入消息...',
+    },
     ref
   ) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -79,6 +95,7 @@ export const EnhancedChatInput = forwardRef<
       () => [...uploadedContent, ...selectedContent],
       [selectedContent, uploadedContent]
     );
+    const hasExplicitContent = allContent.length > 0;
     const hasSelection = allContent.length > 0;
     const { addHistory: addPromptHistory } = usePromptHistory();
     const { language } = useI18n();
@@ -219,9 +236,18 @@ export const EnhancedChatInput = forwardRef<
     // 发送消息
     const submitGeneration = useCallback(
       async (trimmedInput: string) => {
+        const shouldUseImplicitReferences =
+          allContent.length === 0 &&
+          implicitReferenceContent.length > 0 &&
+          generationControls.generationType !== 'agent' &&
+          (implicitReferencePinned ||
+            shouldUseImplicitWorkflowReferences(trimmedInput));
+        const generationContent = shouldUseImplicitReferences
+          ? implicitReferenceContent
+          : allContent;
         const submitted = await chatDrawerControl.submitGenerationFromDrawer({
           prompt: trimmedInput,
-          selectedContent: allContent,
+          selectedContent: generationContent,
           generationType: generationControls.generationType,
           selectedModel: generationControls.selectedModel,
           selectedModelRef: generationControls.selectedModelRef,
@@ -236,6 +262,9 @@ export const EnhancedChatInput = forwardRef<
 
         setInput('');
         setUploadedContent([]);
+        if (shouldUseImplicitReferences) {
+          onImplicitReferenceConsumed?.();
+        }
       },
       [
         chatDrawerControl,
@@ -245,6 +274,9 @@ export const EnhancedChatInput = forwardRef<
         generationControls.selectedModelRef,
         generationControls.selectedParams,
         allContent,
+        implicitReferenceContent,
+        implicitReferencePinned,
+        onImplicitReferenceConsumed,
       ]
     );
 
@@ -278,7 +310,7 @@ export const EnhancedChatInput = forwardRef<
               mediaType: 'image/png',
               url: item.url || '',
             },
-          } as any);
+          });
         } else if (item.type === 'video') {
           parts.push({
             type: 'data-file',
@@ -287,7 +319,7 @@ export const EnhancedChatInput = forwardRef<
               mediaType: 'video/mp4',
               url: item.url || '',
             },
-          } as any);
+          });
         }
       });
 
@@ -307,6 +339,14 @@ export const EnhancedChatInput = forwardRef<
       });
       setInput('');
       setUploadedContent([]);
+      if (
+        allContent.length === 0 &&
+        implicitReferenceContent.length > 0 &&
+        (implicitReferencePinned ||
+          shouldUseImplicitWorkflowReferences(trimmedInput))
+      ) {
+        onImplicitReferenceConsumed?.();
+      }
     }, [
       input,
       allContent,
@@ -315,6 +355,9 @@ export const EnhancedChatInput = forwardRef<
       onSend,
       addPromptHistory,
       hasSelection,
+      implicitReferenceContent,
+      implicitReferencePinned,
+      onImplicitReferenceConsumed,
     ]);
 
     // 键盘事件处理
@@ -361,6 +404,46 @@ export const EnhancedChatInput = forwardRef<
       );
     };
 
+    const renderImplicitReferenceContent = () => {
+      const shouldShowImplicitReferences =
+        !hasExplicitContent &&
+        implicitReferenceContent.length > 0 &&
+        (implicitReferencePinned ||
+          shouldUseImplicitWorkflowReferences(input));
+
+      if (!shouldShowImplicitReferences) {
+        return null;
+      }
+
+      return (
+        <div className="enhanced-chat-input__selection enhanced-chat-input__selection--implicit">
+          <div className="enhanced-chat-input__implicit-reference-header">
+            <span className="enhanced-chat-input__implicit-reference-label">
+              {implicitReferenceLabel ||
+                (language === 'zh'
+                  ? '输入修改描述后，将以上一次生成结果作为参考'
+                  : 'Using the previous generated results as references')}
+            </span>
+            {onClearImplicitReference && (
+              <button
+                type="button"
+                className="enhanced-chat-input__implicit-reference-clear"
+                onClick={onClearImplicitReference}
+                aria-label={language === 'zh' ? '取消回复' : 'Cancel reply'}
+              >
+                ×
+              </button>
+            )}
+          </div>
+          <SelectedContentPreview
+            items={implicitReferenceContent}
+            language="zh"
+            enableHoverPreview={true}
+          />
+        </div>
+      );
+    };
+
     const isActive = (input.trim() || allContent.length > 0) && !disabled;
     const isGenerationMode = generationControls.generationType !== 'agent';
 
@@ -368,6 +451,7 @@ export const EnhancedChatInput = forwardRef<
       <div className="enhanced-chat-input" ref={containerRef}>
         <div className="enhanced-chat-input__form">
           {renderSelectedContent()}
+          {renderImplicitReferenceContent()}
 
           <div className="enhanced-chat-input__input-wrapper">
             <textarea

--- a/packages/drawnix/src/components/chat-drawer/WorkflowMessageBubble.tsx
+++ b/packages/drawnix/src/components/chat-drawer/WorkflowMessageBubble.tsx
@@ -16,11 +16,14 @@ import type {
   WorkflowMessageData,
   AgentLogEntry,
 } from '../../types/chat.types';
+import { MediaViewer } from '../shared/MediaViewer';
+import { useMediaViewer } from '../../hooks/useMediaViewer';
 import MarkdownReadonly from '../MarkdownReadonly';
 import {
   getWorkflowBubbleStatus,
   normalizeWorkflowStepsForDisplay,
 } from '../../utils/workflow-bubble-status';
+import { collectWorkflowMediaResults } from './workflow-media-results';
 import './workflow-message-bubble.scss';
 
 const MermaidRenderer = lazy(() =>
@@ -48,6 +51,13 @@ const STATUS_LABELS: Record<StepStatus, string> = {
   failed: '失败',
   skipped: '已跳过',
 };
+
+const WORKFLOW_STATUS_LABELS = {
+  pending: '待开始',
+  running: '执行中',
+  completed: '已完成',
+  failed: '执行失败',
+} as const;
 
 function renderWorkflowCodeBlock(
   code: string,
@@ -219,7 +229,9 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
     return (
       <div className="agent-log agent-log--thinking">
         <div className="agent-log__header">
-          <span className="agent-log__icon">💭</span>
+          <span className="agent-log__icon" role="img" aria-label="思考">
+            💭
+          </span>
           <span className="agent-log__title">AI 分析</span>
         </div>
         <div className="agent-log__content">
@@ -247,7 +259,9 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
           className="agent-log__header agent-log__header--clickable"
           onClick={() => setExpanded(!expanded)}
         >
-          <span className="agent-log__icon">🔧</span>
+          <span className="agent-log__icon" role="img" aria-label="工具">
+            🔧
+          </span>
           <span className="agent-log__title">调用工具: {log.toolName}</span>
           <span
             className={`agent-log__expand ${
@@ -271,6 +285,7 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
   if (log.type === 'tool_result') {
     const statusClass = log.success ? 'success' : 'error';
     const statusIcon = log.success ? '✅' : '❌';
+    const statusIconLabel = log.success ? '成功' : '失败';
     const hasData = log.data !== undefined && log.data !== null;
 
     return (
@@ -281,7 +296,13 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
           className="agent-log__header agent-log__header--clickable"
           onClick={() => setExpanded(!expanded)}
         >
-          <span className="agent-log__icon">{statusIcon}</span>
+          <span
+            className="agent-log__icon"
+            role="img"
+            aria-label={statusIconLabel}
+          >
+            {statusIcon}
+          </span>
           <span className="agent-log__title">
             {log.toolName} {log.success ? '执行成功' : '执行失败'}
           </span>
@@ -313,7 +334,9 @@ const AgentLogItem: React.FC<AgentLogItemProps> = ({ log }) => {
     return (
       <div className="agent-log agent-log--retry">
         <div className="agent-log__header">
-          <span className="agent-log__icon">🔄</span>
+          <span className="agent-log__icon" role="img" aria-label="重试">
+            🔄
+          </span>
           <span className="agent-log__title">
             重试 #{log.attempt}: {log.reason}
           </span>
@@ -332,6 +355,8 @@ interface WorkflowMessageBubbleProps {
   className?: string;
   /** 重试回调，从指定步骤索引开始重试 */
   onRetry?: (stepIndex: number) => void;
+  /** 基于该工作流结果继续生成 */
+  onReply?: () => void;
   /** 是否正在重试 */
   isRetrying?: boolean;
 }
@@ -340,6 +365,7 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
   workflow,
   className = '',
   onRetry,
+  onReply,
   isRetrying = false,
 }) => {
   const normalizedSteps = useMemo(() => {
@@ -358,20 +384,35 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
       : 0;
 
   // 状态标签（考虑后处理状态）
-  const statusLabel = useMemo(() => {
-    const baseLabels: Record<typeof workflowStatus.status, string> = {
-      pending: '待开始',
-      running: '执行中',
-      completed: '已完成',
-      failed: '执行失败',
-    };
-
-    return baseLabels[workflowStatus.status];
-  }, [workflowStatus.status]);
+  const statusLabel = WORKFLOW_STATUS_LABELS[workflowStatus.status];
 
   const isCompleted = workflowStatus.status === 'completed';
   const isFailed = workflowStatus.status === 'failed';
   const isRunning = workflowStatus.status === 'running';
+  const { openViewer, viewerProps } = useMediaViewer({
+    showNavbar: true,
+    showToolbar: true,
+    showTitle: true,
+  });
+  const mediaResults = useMemo(
+    () => collectWorkflowMediaResults(workflow, normalizedSteps),
+    [workflow, normalizedSteps]
+  );
+  const mediaViewerItems = useMemo(
+    () =>
+      mediaResults.map((item, index) => ({
+        url: item.url,
+        type: item.type,
+        title: item.title || `生成结果 ${index + 1}`,
+        alt: item.title || `生成结果 ${index + 1}`,
+        posterUrl: item.thumbnailUrl,
+      })),
+    [mediaResults]
+  );
+
+  const handleMediaPreview = (index: number): void => {
+    openViewer(mediaViewerItems, index);
+  };
 
   /**
    * 获取工作流最后一个 content
@@ -438,6 +479,10 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
       return { variant: 'info' as const, icon: '❌', text: '生成失败' };
     }
 
+    if (mediaResults.length > 0) {
+      return null;
+    }
+
     // 直接展示最后一个 content
     if (lastContent) {
       return {
@@ -454,7 +499,7 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
 
     // 没有任何内容
     return { variant: 'info' as const, icon: 'ℹ️', text: '未生成任何内容' };
-  }, [isCompleted, isFailed, lastContent, hasMediaGeneration]);
+  }, [isCompleted, isFailed, lastContent, hasMediaGeneration, mediaResults]);
 
   const markdownSummary = useMemo(() => {
     if (!summaryView || summaryView.variant !== 'markdown') return null;
@@ -494,8 +539,6 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
   const shouldShowDetailsToggle =
     shouldCollapseCompletedDetails && hasDetailsContent;
 
-  // 当前执行步骤的 ref，用于自动滚动
-  const currentStepRef = useRef<HTMLDivElement>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);
 
   // 当步骤状态变化时，自动滚动到当前执行的步骤
@@ -578,28 +621,98 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
           </div>
         )}
 
-        {shouldShowDetailsToggle && (
-          <button
-            type="button"
-            className="workflow-bubble__details-toggle"
-            onClick={() => setShowCompletedDetails((value) => !value)}
-            aria-expanded={showCompletedDetails}
-            aria-label={
-              showCompletedDetails ? '收起执行详情' : '查看执行详情'
-            }
+        {isCompleted && mediaResults.length > 0 && (
+          <div
+            className={`workflow-bubble__media-grid workflow-bubble__media-grid--${Math.min(
+              mediaResults.length,
+              4
+            )}`}
+            aria-label="生成结果"
           >
-            <span>{showCompletedDetails ? '收起详情' : '查看详情'}</span>
-            <span
-              className={`workflow-bubble__details-toggle-icon ${
-                showCompletedDetails
-                  ? 'workflow-bubble__details-toggle-icon--open'
-                  : ''
-              }`}
-              aria-hidden="true"
+            {mediaResults.map((item, index) => (
+              <button
+                key={`${item.url}-${index}`}
+                type="button"
+                className="workflow-bubble__media-item"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onDoubleClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  handleMediaPreview(index);
+                }}
+                aria-label={`查看生成结果 ${index + 1}`}
+              >
+                {item.type === 'video' ? (
+                  <video
+                    className="workflow-bubble__media-preview"
+                    src={item.url}
+                    poster={item.thumbnailUrl}
+                    muted
+                    playsInline
+                    preload="metadata"
+                  />
+                ) : item.type === 'audio' ? (
+                  <div className="workflow-bubble__audio-preview">
+                    {item.thumbnailUrl ? (
+                      <img
+                        src={item.thumbnailUrl}
+                        alt={item.title || `生成结果 ${index + 1}`}
+                        className="workflow-bubble__media-preview"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <span className="workflow-bubble__audio-icon">♪</span>
+                    )}
+                  </div>
+                ) : (
+                  <img
+                    src={item.thumbnailUrl || item.url}
+                    alt={item.title || `生成结果 ${index + 1}`}
+                    className="workflow-bubble__media-preview"
+                    loading="lazy"
+                  />
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {shouldShowDetailsToggle && (
+          <div className="workflow-bubble__actions">
+            <button
+              type="button"
+              className="workflow-bubble__details-toggle"
+              onClick={() => setShowCompletedDetails((value) => !value)}
+              aria-expanded={showCompletedDetails}
+              aria-label={
+                showCompletedDetails ? '收起执行详情' : '查看执行详情'
+              }
             >
-              ▼
-            </span>
-          </button>
+              <span>{showCompletedDetails ? '收起详情' : '查看详情'}</span>
+              <span
+                className={`workflow-bubble__details-toggle-icon ${
+                  showCompletedDetails
+                    ? 'workflow-bubble__details-toggle-icon--open'
+                    : ''
+                }`}
+                aria-hidden="true"
+              >
+                ▼
+              </span>
+            </button>
+            {onReply && mediaResults.length > 0 && (
+              <button
+                type="button"
+                className="workflow-bubble__reply-btn"
+                onClick={onReply}
+              >
+                回复
+              </button>
+            )}
+          </div>
         )}
 
         {/* 步骤列表 */}
@@ -662,7 +775,13 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
         {/* 失败提示 */}
         {isFailed && (
           <div className="workflow-bubble__summary workflow-bubble__summary--error">
-            <span className="workflow-bubble__summary-icon">❌</span>
+            <span
+              className="workflow-bubble__summary-icon"
+              role="img"
+              aria-label="失败"
+            >
+              ❌
+            </span>
             <span>执行失败，请重试</span>
             {canRetry && onRetry && (
               <button
@@ -670,12 +789,19 @@ export const WorkflowMessageBubble: React.FC<WorkflowMessageBubbleProps> = ({
                 onClick={handleRetry}
                 disabled={isRetrying}
               >
-                {isRetrying ? '重试中...' : '🔄 从失败步骤重试'}
+                {isRetrying ? (
+                  '重试中...'
+                ) : (
+                  <>
+                    <span aria-hidden="true">🔄</span> 从失败步骤重试
+                  </>
+                )}
               </button>
             )}
           </div>
         )}
       </div>
+      <MediaViewer {...viewerProps} />
     </div>
   );
 };

--- a/packages/drawnix/src/components/chat-drawer/__tests__/EnhancedChatInput.test.tsx
+++ b/packages/drawnix/src/components/chat-drawer/__tests__/EnhancedChatInput.test.tsx
@@ -1,11 +1,23 @@
+// @vitest-environment jsdom
+
 import React from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { EnhancedChatInput } from '../EnhancedChatInput';
+
+const submitGenerationFromDrawerMock = vi.fn(async () => true);
+type GenerationType = 'image' | 'video' | 'audio' | 'text' | 'agent';
+let generationTypeMock: GenerationType = 'agent';
 
 vi.mock('../../../contexts/ChatDrawerContext', () => ({
   useChatDrawerControl: () => ({
-    submitGenerationFromDrawer: async () => true,
+    submitGenerationFromDrawer: submitGenerationFromDrawerMock,
   }),
 }));
 
@@ -29,7 +41,7 @@ vi.mock('../../../contexts/AssetContext', () => ({
 
 vi.mock('../useChatDrawerGenerationControls', () => ({
   useChatDrawerGenerationControls: () => ({
-    generationType: 'agent',
+    generationType: generationTypeMock,
     setGenerationType: () => undefined,
     selectedModel: 'gpt-5.4',
     selectedModelRef: null,
@@ -76,6 +88,11 @@ vi.mock('../../icons', () => ({
   MediaLibraryIcon: () => <span aria-hidden="true">library</span>,
 }));
 
+beforeEach(() => {
+  generationTypeMock = 'agent';
+  submitGenerationFromDrawerMock.mockClear();
+});
+
 afterEach(() => {
   cleanup();
 });
@@ -111,5 +128,96 @@ describe('EnhancedChatInput placeholder', () => {
     );
 
     expect(screen.getByPlaceholderText('描述你想要的效果...')).toBeTruthy();
+  });
+});
+
+describe('EnhancedChatInput implicit workflow references', () => {
+  const implicitReferenceContent = [
+    {
+      type: 'image' as const,
+      name: '上一次生成结果',
+      url: '/previous-result.png',
+    },
+  ];
+
+  it('uses implicit references for image edits that mention prior results', async () => {
+    generationTypeMock = 'image';
+
+    render(
+      <EnhancedChatInput
+        selectedContent={[]}
+        implicitReferenceContent={implicitReferenceContent}
+        onSend={() => undefined}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '把上面的人改成小李子' },
+    });
+    fireEvent.click(screen.getByTestId('drawer-ai-send-btn'));
+
+    expect(submitGenerationFromDrawerMock).toHaveBeenCalledTimes(1);
+    expect(submitGenerationFromDrawerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: '把上面的人改成小李子',
+        selectedContent: implicitReferenceContent,
+        generationType: 'image',
+      })
+    );
+  });
+
+  it('does not use implicit references for unrelated image prompts', async () => {
+    generationTypeMock = 'image';
+
+    render(
+      <EnhancedChatInput
+        selectedContent={[]}
+        implicitReferenceContent={implicitReferenceContent}
+        onSend={() => undefined}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '生成一只猫' },
+    });
+    fireEvent.click(screen.getByTestId('drawer-ai-send-btn'));
+
+    expect(submitGenerationFromDrawerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedContent: [],
+      })
+    );
+  });
+
+  it('uses pinned reply references and consumes them after submit', async () => {
+    generationTypeMock = 'image';
+    const onImplicitReferenceConsumed = vi.fn();
+
+    render(
+      <EnhancedChatInput
+        selectedContent={[]}
+        implicitReferenceContent={implicitReferenceContent}
+        implicitReferenceLabel="回复：图片生成"
+        implicitReferencePinned
+        onImplicitReferenceConsumed={onImplicitReferenceConsumed}
+        onSend={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('回复：图片生成')).toBeTruthy();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '换成小李子' },
+    });
+    fireEvent.click(screen.getByTestId('drawer-ai-send-btn'));
+
+    expect(submitGenerationFromDrawerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedContent: implicitReferenceContent,
+      })
+    );
+    await waitFor(() => {
+      expect(onImplicitReferenceConsumed).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/drawnix/src/components/chat-drawer/__tests__/WorkflowMessageBubble.test.tsx
+++ b/packages/drawnix/src/components/chat-drawer/__tests__/WorkflowMessageBubble.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import React from 'react';
 import {
   afterEach,
@@ -14,6 +16,27 @@ import {
   getWorkflowBubbleStatus,
   normalizeWorkflowStepsForDisplay,
 } from '../../../utils/workflow-bubble-status';
+
+vi.mock('../../shared/MediaViewer', () => ({
+  MediaViewer: ({
+    visible,
+    items,
+    initialIndex = 0,
+  }: {
+    visible: boolean;
+    items: Array<{ url: string; type: string; title?: string }>;
+    initialIndex?: number;
+  }) =>
+    visible ? (
+      <div
+        data-testid="media-viewer"
+        data-initial-index={initialIndex}
+        data-item-urls={items.map((item) => item.url).join('|')}
+      >
+        {items.length} items
+      </div>
+    ) : null,
+}));
 
 function createImageWorkflow(
   overrides: Partial<WorkflowMessageData> = {}
@@ -112,6 +135,9 @@ describe('WorkflowMessageBubble rendering', () => {
     expect(screen.getByText('3/3')).toBeTruthy();
     expect(screen.queryByText('生成图片 (1/3)')).toBeNull();
     expect(screen.queryByText('已生成')).toBeNull();
+    expect(screen.getByRole('img', { name: '生成结果 1' })).toBeTruthy();
+    expect(screen.getByRole('img', { name: '生成结果 2' })).toBeTruthy();
+    expect(screen.getByRole('img', { name: '生成结果 3' })).toBeTruthy();
     expect(
       screen
         .getByRole('button', { name: '查看执行详情' })
@@ -128,6 +154,38 @@ describe('WorkflowMessageBubble rendering', () => {
     expect(screen.getByText('生成图片 (1/3)')).toBeTruthy();
     expect(screen.getByText('生成图片 (2/3)')).toBeTruthy();
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('opens generated media in the shared preview on double click', () => {
+    render(<WorkflowMessageBubble workflow={createImageWorkflow()} />);
+
+    fireEvent.doubleClick(screen.getByRole('button', { name: '查看生成结果 2' }));
+
+    const viewer = screen.getByTestId('media-viewer');
+    expect(viewer.getAttribute('data-initial-index')).toBe('1');
+    expect(viewer.getAttribute('data-item-urls')).toBe(
+      [
+        '/__aitu_cache__/image/task-1.png',
+        '/__aitu_cache__/image/task-2.png',
+        '/__aitu_cache__/image/task-3.png',
+      ].join('|')
+    );
+    expect(viewer.textContent).toBe('3 items');
+  });
+
+  it('exposes a reply action for completed generated media workflows', () => {
+    const onReply = vi.fn();
+
+    render(
+      <WorkflowMessageBubble
+        workflow={createImageWorkflow()}
+        onReply={onReply}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '回复' }));
+
+    expect(onReply).toHaveBeenCalledTimes(1);
   });
 
   it('keeps running workflow steps visible immediately', () => {

--- a/packages/drawnix/src/components/chat-drawer/__tests__/workflow-media-results.test.ts
+++ b/packages/drawnix/src/components/chat-drawer/__tests__/workflow-media-results.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowMessageData } from '../../../types/chat.types';
+import {
+  collectWorkflowMediaResults,
+  getLatestWorkflowImageReferences,
+  shouldUseImplicitWorkflowReferences,
+} from '../workflow-media-results';
+
+function createWorkflow(
+  id: string,
+  urls: string[],
+  status: WorkflowMessageData['status'] = 'completed'
+): WorkflowMessageData {
+  return {
+    id,
+    name: '图片生成',
+    generationType: 'image',
+    prompt: '生成图片',
+    count: urls.length,
+    status,
+    steps: [
+      {
+        id: `${id}-step`,
+        description: '生成图片',
+        status: 'completed',
+        mcp: 'generate_image',
+        args: {},
+        result: {
+          data: {
+            urls,
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe('workflow media result helpers', () => {
+  it('collects media urls from nested workflow results', () => {
+    const workflow = createWorkflow('wf-1', [
+      '/images/one.png',
+      '/images/two.png',
+    ]);
+
+    expect(collectWorkflowMediaResults(workflow)).toEqual([
+      {
+        type: 'image',
+        url: '/images/one.png',
+        thumbnailUrl: undefined,
+        title: undefined,
+      },
+      {
+        type: 'image',
+        url: '/images/two.png',
+        thumbnailUrl: undefined,
+        title: undefined,
+      },
+    ]);
+  });
+
+  it('returns the latest workflow images as reference content', () => {
+    const first = createWorkflow('wf-1', ['/images/old.png']);
+    const latest = createWorkflow('wf-2', ['/images/latest-1.png']);
+
+    expect(getLatestWorkflowImageReferences([first, latest])).toEqual([
+      {
+        type: 'image',
+        url: '/images/latest-1.png',
+        name: '上一次生成结果 1',
+      },
+    ]);
+  });
+
+  it('recognizes continuation prompts without matching unrelated prompts', () => {
+    expect(shouldUseImplicitWorkflowReferences('把上面的人改成小李子')).toBe(
+      true
+    );
+    expect(shouldUseImplicitWorkflowReferences('生成一只猫')).toBe(false);
+  });
+});

--- a/packages/drawnix/src/components/chat-drawer/chat-drawer.scss
+++ b/packages/drawnix/src/components/chat-drawer/chat-drawer.scss
@@ -1348,6 +1348,57 @@ $drawer-input-max-height: 280px;
     align-items: center;
   }
 
+  &__selection--implicit {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 6px;
+    margin: 0 2px 2px;
+    padding: 8px 10px;
+    background: rgba(var(--td-brand-color-rgb), 0.04);
+    border: 1px solid rgba(var(--td-brand-color-rgb), 0.12);
+    border-radius: 10px;
+  }
+
+  &__implicit-reference-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  &__implicit-reference-label {
+    min-width: 0;
+    color: var(--td-text-color-secondary);
+    font-size: 12px;
+    line-height: 1.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__implicit-reference-clear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    border-radius: 50%;
+    color: var(--td-text-color-placeholder);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.06);
+      color: var(--td-text-color-secondary);
+    }
+  }
+
   &__selection-item {
     position: relative;
     width: 36px;
@@ -1408,8 +1459,8 @@ $drawer-input-max-height: 280px;
     transition: all 0.3s ease;
 
     &:focus-within {
-      border-color: var(--td-brand-color);
-      box-shadow: 0 4px 20px rgba(243, 156, 18, 0.15);
+      border-color: var(--td-component-border);
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
     }
   }
 
@@ -1511,6 +1562,14 @@ $drawer-input-max-height: 280px;
 
     &::placeholder {
       color: var(--td-text-color-placeholder);
+    }
+  }
+
+  & &__textarea {
+    &:hover,
+    &:focus {
+      border: none;
+      box-shadow: none;
     }
   }
 }

--- a/packages/drawnix/src/components/chat-drawer/workflow-media-results.ts
+++ b/packages/drawnix/src/components/chat-drawer/workflow-media-results.ts
@@ -1,0 +1,185 @@
+import type {
+  SelectedContentItem,
+  WorkflowMessageData,
+} from '../../types/chat.types';
+
+export interface WorkflowMediaResult {
+  type: 'image' | 'video' | 'audio';
+  url: string;
+  thumbnailUrl?: string;
+  title?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isMediaUrl(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    (value.startsWith('http://') ||
+      value.startsWith('https://') ||
+      value.startsWith('data:') ||
+      value.startsWith('blob:') ||
+      value.startsWith('/'))
+  );
+}
+
+function inferMediaType(
+  url: string,
+  stepType: WorkflowMessageData['generationType']
+): WorkflowMediaResult['type'] {
+  if (url.startsWith('data:video/') || /\.(mp4|webm|mov)(\?|#|$)/i.test(url)) {
+    return 'video';
+  }
+  if (
+    url.startsWith('data:audio/') ||
+    /\.(mp3|wav|ogg|m4a)(\?|#|$)/i.test(url)
+  ) {
+    return 'audio';
+  }
+  if (stepType === 'video' || stepType === 'audio') {
+    return stepType;
+  }
+  return 'image';
+}
+
+function getStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(isMediaUrl) : [];
+}
+
+function addMediaFromRecord(
+  record: Record<string, unknown>,
+  stepType: WorkflowMessageData['generationType'],
+  media: WorkflowMediaResult[],
+  seen: Set<string>
+): void {
+  const urls = [
+    ...getStringArray(record.urls),
+    ...getStringArray(record.imageUrls),
+    ...getStringArray(record.videoUrls),
+    ...getStringArray(record.audioUrls),
+  ];
+
+  if (isMediaUrl(record.url)) {
+    urls.unshift(record.url);
+  }
+  if (isMediaUrl(record.imageUrl)) {
+    urls.unshift(record.imageUrl);
+  }
+  if (isMediaUrl(record.videoUrl)) {
+    urls.unshift(record.videoUrl);
+  }
+  if (isMediaUrl(record.audioUrl)) {
+    urls.unshift(record.audioUrl);
+  }
+
+  const thumbnailUrls = [
+    ...getStringArray(record.thumbnailUrls),
+    ...getStringArray(record.previewImageUrls),
+  ];
+  if (isMediaUrl(record.thumbnailUrl)) {
+    thumbnailUrls.unshift(record.thumbnailUrl);
+  }
+  if (isMediaUrl(record.previewImageUrl)) {
+    thumbnailUrls.unshift(record.previewImageUrl);
+  }
+
+  urls.forEach((url, index) => {
+    if (seen.has(url)) {
+      return;
+    }
+    seen.add(url);
+    media.push({
+      type: inferMediaType(url, stepType),
+      url,
+      thumbnailUrl: thumbnailUrls[index] || thumbnailUrls[0],
+      title: typeof record.title === 'string' ? record.title : undefined,
+    });
+  });
+}
+
+export function collectWorkflowMediaResults(
+  workflow: WorkflowMessageData,
+  steps: WorkflowMessageData['steps'] = workflow.steps
+): WorkflowMediaResult[] {
+  const media: WorkflowMediaResult[] = [];
+  const seen = new Set<string>();
+
+  const visit = (value: unknown, depth = 0): void => {
+    if (depth > 4) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => visit(item, depth + 1));
+      return;
+    }
+
+    if (!isRecord(value)) {
+      if (isMediaUrl(value) && !seen.has(value)) {
+        seen.add(value);
+        media.push({
+          type: inferMediaType(value, workflow.generationType),
+          url: value,
+        });
+      }
+      return;
+    }
+
+    addMediaFromRecord(value, workflow.generationType, media, seen);
+
+    ['data', 'result', 'response', 'output'].forEach((key) => {
+      const nested = value[key];
+      if (Array.isArray(nested)) {
+        nested.forEach((item) => visit(item, depth + 1));
+      } else {
+        visit(nested, depth + 1);
+      }
+    });
+  };
+
+  steps.forEach((step) => {
+    if (step.status === 'completed') {
+      visit(step.result);
+    }
+  });
+
+  return media;
+}
+
+export function getLatestWorkflowImageReferences(
+  workflows: Iterable<WorkflowMessageData>
+): SelectedContentItem[] {
+  const orderedWorkflows = Array.from(workflows);
+
+  for (let index = orderedWorkflows.length - 1; index >= 0; index -= 1) {
+    const workflow = orderedWorkflows[index];
+    const mediaResults = collectWorkflowMediaResults(workflow).filter(
+      (item) => item.type === 'image'
+    );
+
+    if (mediaResults.length === 0) {
+      continue;
+    }
+
+    return mediaResults.map((item, mediaIndex) => ({
+      type: 'image',
+      url: item.url,
+      name: item.title || `上一次生成结果 ${mediaIndex + 1}`,
+    }));
+  }
+
+  return [];
+}
+
+export function shouldUseImplicitWorkflowReferences(prompt: string): boolean {
+  const normalizedPrompt = prompt.trim().toLowerCase();
+  if (!normalizedPrompt) {
+    return false;
+  }
+
+  return /上面|前面|刚才|上一|之前|这些|那些|这张|这几张|那张|原图|参考|基于|沿用|继续|修改|改成|换成|替换|变成|保持|previous|above|these|those|same|reference|continue|edit|modify|change|replace|turn.*into/i.test(
+    normalizedPrompt
+  );
+}

--- a/packages/drawnix/src/components/chat-drawer/workflow-message-bubble.scss
+++ b/packages/drawnix/src/components/chat-drawer/workflow-message-bubble.scss
@@ -162,6 +162,74 @@
     font-style: italic;
   }
 
+  &__media-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: $spacing-md;
+
+    &--1 {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    &--3,
+    &--4 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  &__media-item {
+    display: block;
+    position: relative;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    width: 100%;
+    padding: 0;
+    border: 1px solid var(--td-component-border);
+    border-radius: 8px;
+    background: var(--td-bg-color-secondarycontainer);
+    cursor: zoom-in;
+    appearance: none;
+    transition:
+      border-color 0.2s ease,
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
+
+    &:hover {
+      border-color: var(--td-brand-color);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      transform: translateY(-1px);
+    }
+  }
+
+  &__media-preview {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__audio-preview {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: var(--td-text-color-secondary);
+  }
+
+  &__audio-icon {
+    font-size: 24px;
+    line-height: 1;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 4px 0 $spacing-md;
+  }
+
   // 步骤列表
   &__steps {
     display: flex;
@@ -177,7 +245,6 @@
     align-items: center;
     align-self: flex-start;
     gap: 6px;
-    margin-bottom: $spacing-md;
     padding: 4px 8px;
     background: var(--td-bg-color-container);
     border: 1px solid var(--td-component-border);
@@ -195,6 +262,31 @@
       background: var(--td-bg-color-container-hover);
       border-color: var(--td-brand-color);
       color: var(--td-brand-color);
+    }
+  }
+
+  &__reply-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 24px;
+    padding: 4px 10px;
+    background: var(--td-brand-color-light);
+    border: 1px solid rgba(var(--td-brand-color-rgb), 0.18);
+    border-radius: 6px;
+    color: var(--td-brand-color);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.2;
+    transition:
+      background 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease;
+
+    &:hover {
+      background: rgba(var(--td-brand-color-rgb), 0.12);
+      border-color: var(--td-brand-color);
     }
   }
 


### PR DESCRIPTION
## Summary\n- Switch drawer workflow result preview to the shared project media viewer.\n- Add explicit "reply" binding from completed workflow results so follow-up prompts can target the exact prior generation.\n- Keep implicit continuation fallback for phrases like "上面"/"刚才" while avoiding accidental carryover on unrelated prompts.\n\n## Verification\n- pnpm exec vitest run packages/drawnix/src/components/chat-drawer/__tests__/WorkflowMessageBubble.test.tsx packages/drawnix/src/components/chat-drawer/__tests__/EnhancedChatInput.test.tsx packages/drawnix/src/components/chat-drawer/__tests__/workflow-media-results.test.ts\n- pnpm exec nx run drawnix:typecheck\n- Browser validation on http://localhost:7200/?board=f4afafb9-48e7-404f-a94c-8dac61f2ac77\n\n## Notes\n- The old PR #167 is already merged, so this is a fresh PR against develop from the updated branch.