### PR TITLE
 feat: 画布图片选中状态锁定优化

### DIFF
--- a/apps/web/public/version.json
+++ b/apps/web/public/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.9.9",
-  "buildTime": "2026-05-18T01:43:53.353Z",
+  "buildTime": "2026-05-21T10:27:39.475Z",
   "gitCommit": "unknown",
   "changelog": [
     "异步接口开关持久化 + 图片任务刷新后恢复轮询",

--- a/docs/IMAGE_SELECTION_LOCK_LESSONS.md
+++ b/docs/IMAGE_SELECTION_LOCK_LESSONS.md
@@ -1,0 +1,101 @@
+# 画布图片选中状态锁定优化经验
+
+## 问题描述
+
+当用户在画布中选中一张图片并在对话框中编辑修改提示词时，如果此时有其他之前生成失败的图片刚好生成完成并自动插入画布，选中的图片会被意外切换为刚插入的图片。这导致用户可能在发送修改提示词时，实际修改的是另一张图片。
+
+## 根本原因
+
+在 `insertImageFromUrl` 函数中，图片插入后会自动选中新插入的图片：
+
+```typescript
+const newElement = board.children[childrenCountBefore];
+if (newElement) {
+  clearSelectedElement(board);
+  addSelectedElement(board, newElement);
+}
+```
+
+这种行为在自动插入场景（如 AI 生成完成后自动插入）会覆盖用户当前的选中状态。
+
+## 解决方案
+
+### 方案设计
+
+在 `insertImageFromUrl` 函数中添加 `skipSelect` 参数，控制插入后是否自动选中新图片：
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `skipSelect` | `boolean` | `false` | 如果为 `true`，插入图片后不自动选中，避免覆盖用户当前选中状态 |
+
+### 修改的文件
+
+1. **`packages/drawnix/src/data/image.ts`**
+   - 在 `insertImageFromUrl` 函数中添加 `skipSelect` 参数
+   - 插入图片后，仅当 `skipSelect` 为 `false` 时才选中新图片
+
+2. **自动插入场景调用处**（传入 `skipSelect: true`）：
+   - `packages/drawnix/src/services/canvas-operations/canvas-insertion.ts` - 批量插入场景
+   - `packages/drawnix/src/mcp/tools/canvas-insertion.ts` - MCP 批量插入场景
+   - `packages/drawnix/src/services/canvas-operations/media-quick-insert.ts` - 快速插入场景
+   - `packages/drawnix/src/hooks/useWorkflowSubmission.ts` - 工作流自动插入场景
+   - `packages/drawnix/src/services/sw-capabilities/handler.ts` - Service Worker 自动插入场景
+
+### 保持原有行为的场景
+
+以下用户主动操作场景保持原有行为（插入后选中新图片）：
+
+- 剪贴板粘贴图片
+- 用户从工具栏插入图片
+- 用户从媒体库选择图片
+- 用户从任务队列点击插入按钮
+
+## 架构变更说明
+
+### 变更类型
+
+**非破坏性变更** - 添加新参数，默认行为保持不变
+
+### 影响范围
+
+- **新增**：`insertImageFromUrl` 函数新增 `skipSelect` 参数
+- **修改**：5 处自动插入场景调用点传入 `skipSelect: true`
+- **兼容**：所有现有调用不受影响（默认选中新图片）
+
+### 设计原则
+
+1. **最小侵入性**：仅添加一个可选参数，不修改现有函数签名
+2. **向后兼容**：默认行为保持不变，不影响现有功能
+3. **场景分离**：区分自动插入和用户主动操作场景，分别处理
+
+## 测试验证
+
+### 测试场景
+
+1. **选中图片后自动插入不应切换选中**：
+   - 选中画布中的图片 A
+   - 在对话框中编辑提示词
+   - 触发另一张图片 B 的自动插入
+   - 预期：图片 A 保持选中状态
+
+2. **用户主动插入仍应选中新图片**：
+   - 从媒体库选择图片插入
+   - 预期：新插入的图片被选中
+
+3. **批量插入不应影响选中状态**：
+   - 选中图片 A
+   - 触发批量图片生成
+   - 预期：图片 A 保持选中状态
+
+## 经验总结
+
+1. **状态隔离原则**：自动操作不应干扰用户当前的交互状态
+2. **参数化控制**：通过可选参数提供灵活的行为控制
+3. **场景区分**：区分自动操作和用户主动操作，提供不同的默认行为
+4. **最小变更**：在解决问题的同时，尽量减少对现有代码的影响
+
+## 相关文件
+
+- `packages/drawnix/src/data/image.ts` - 核心图片插入逻辑
+- `packages/drawnix/src/services/canvas-operations/canvas-insertion.ts` - 批量插入服务
+- `packages/drawnix/src/hooks/useWorkflowSubmission.ts` - 工作流提交钩子

--- a/packages/drawnix/src/data/image.ts
+++ b/packages/drawnix/src/data/image.ts
@@ -334,7 +334,9 @@ export const insertImageFromUrl = async (
   // 如果为 true 且提供了 referenceDimensions，则跳过图片加载直接使用提供的尺寸
   skipImageLoad?: boolean,
   // 如果为 true，图片加载后不再按真实比例改写尺寸
-  lockReferenceDimensions?: boolean
+  lockReferenceDimensions?: boolean,
+  // 如果为 true，插入图片后不自动选中（用于自动插入场景，避免覆盖用户当前选中状态）
+  skipSelect?: boolean
 ) => {
   // 外部 URL 和 data URL 先缓存到本地
   let resolvedUrl = normalizeImageDataUrl(imageUrl);
@@ -471,6 +473,15 @@ export const insertImageFromUrl = async (
     width: imageItem.width,
     height: imageItem.height,
   });
+
+  // 选中新插入的图片元素（如果没有跳过选中）
+  if (!skipSelect) {
+    const newElement = board.children[childrenCountBefore];
+    if (newElement) {
+      clearSelectedElement(board);
+      addSelectedElement(board, newElement);
+    }
+  }
 
   // 如果跳过了图片加载，异步加载图片并更新元素尺寸
   if (shouldUpdateSizeAfterLoad && referenceDimensions) {

--- a/packages/drawnix/src/hooks/useWorkflowSubmission.ts
+++ b/packages/drawnix/src/hooks/useWorkflowSubmission.ts
@@ -99,7 +99,8 @@ async function handleCanvasInsert(board: PlaitBoard, event: CanvasInsertEvent): 
       // Handle batch insert
       for (const item of params.items) {
         if (item.type === 'image' && item.url) {
-          await insertImageFromUrl(board, item.url, insertPoint);
+          // skipSelect: true - 工作流自动插入不选中新图片，避免覆盖用户当前选中状态
+          await insertImageFromUrl(board, item.url, insertPoint, false, undefined, undefined, undefined, undefined, true);
         } else if (item.type === 'video' && item.url) {
           await insertVideoFromUrl(board, item.url, insertPoint);
         } else if (item.type === 'audio' && item.url) {
@@ -107,7 +108,8 @@ async function handleCanvasInsert(board: PlaitBoard, event: CanvasInsertEvent): 
         }
       }
     } else if (operation === 'insert_image' && params.url) {
-      await insertImageFromUrl(board, params.url, insertPoint);
+      // skipSelect: true - 工作流自动插入不选中新图片，避免覆盖用户当前选中状态
+      await insertImageFromUrl(board, params.url, insertPoint, false, undefined, undefined, undefined, undefined, true);
     } else if (operation === 'insert_video' && params.url) {
       await insertVideoFromUrl(board, params.url, insertPoint);
     } else if ((operation as string) === 'insert_audio' && params.url) {

--- a/packages/drawnix/src/mcp/tools/canvas-insertion.ts
+++ b/packages/drawnix/src/mcp/tools/canvas-insertion.ts
@@ -220,8 +220,9 @@ async function insertImageToCanvas(
   // console.log(`[CanvasInsertion] insertImageToCanvas: url=${imageUrl.substring(0, 80)}, point=`, point, 'size=', size);
   // skipScroll: true - 由 executeCanvasInsertion 统一处理滚动
   // skipImageLoad: true - 使用传入的尺寸，不等待图片加载
+  // skipSelect=true: 自动插入时不选中新图片，避免覆盖用户当前选中状态
   try {
-    await insertImageFromUrl(board, imageUrl, point, false, size, true, true, true);
+    await insertImageFromUrl(board, imageUrl, point, false, size, true, true, true, true);
     // console.log(`[CanvasInsertion] insertImageFromUrl completed successfully`);
   } catch (error) {
     console.error(`[CanvasInsertion] insertImageFromUrl failed:`, error);

--- a/packages/drawnix/src/services/canvas-operations/canvas-insertion.ts
+++ b/packages/drawnix/src/services/canvas-operations/canvas-insertion.ts
@@ -222,7 +222,8 @@ async function insertImageToCanvas(
   });
   // 批量插入需要固定参考尺寸，避免图片加载后按原始比例回写导致间距抖动。
   // 传入 skipImageLoad=true 和尺寸，立即插入图片不等待下载
-  await insertImageFromUrl(board, imageUrl, point, false, size, true, true, true);
+  // skipSelect=true: 自动插入时不选中新图片，避免覆盖用户当前选中状态
+  await insertImageFromUrl(board, imageUrl, point, false, size, true, true, true, true);
   return size;
 }
 

--- a/packages/drawnix/src/services/canvas-operations/media-quick-insert.ts
+++ b/packages/drawnix/src/services/canvas-operations/media-quick-insert.ts
@@ -63,7 +63,8 @@ async function insertMedia(
     return size;
   }
 
-  await insertImageFromUrl(board, content, point, false, size, true, true);
+  // skipSelect: true - 快速插入通常用于自动插入场景，不选中新图片避免覆盖用户当前选中状态
+  await insertImageFromUrl(board, content, point, false, size, true, true, undefined, true);
   return size;
 }
 

--- a/packages/drawnix/src/services/sw-capabilities/handler.ts
+++ b/packages/drawnix/src/services/sw-capabilities/handler.ts
@@ -226,7 +226,8 @@ export class SWCapabilitiesHandler {
           }
 
           case 'image':
-            await insertImageFromUrl(board, content, currentPoint, false, { width: 400, height: 400 }, false, true);
+            // skipSelect: true - SW 自动插入不选中新图片，避免覆盖用户当前选中状态
+            await insertImageFromUrl(board, content, currentPoint, false, { width: 400, height: 400 }, false, true, undefined, true);
             currentPoint = [currentPoint[0], currentPoint[1] + 400 + verticalGap] as Point;
             insertedCount++;
             break;
@@ -304,7 +305,8 @@ export class SWCapabilitiesHandler {
         switch (type) {
           case 'image':
             // 使用默认尺寸立即插入，不等待图片下载完成
-            await insertImageFromUrl(board, content, currentPoint, false, { width: 400, height: 400 }, false, true);
+            // skipSelect: true - SW 自动插入不选中新图片，避免覆盖用户当前选中状态
+            await insertImageFromUrl(board, content, currentPoint, false, { width: 400, height: 400 }, false, true, undefined, true);
             currentPoint = [currentPoint[0], currentPoint[1] + 400 + verticalGap] as Point;
             insertedCount++;
             break;


### PR DESCRIPTION
## 画布图片选中状态锁定优化

### 问题描述
当用户在画布中选中一张图片并在对话框中编辑修改提示词时，如果此时有其他之前生成失败的图片刚好生成完成并自动插入画布，选中的图片会被意外切换为刚插入的图片。

### 解决方案
在 `insertImageFromUrl` 函数中添加 `skipSelect` 参数，控制插入后是否自动选中新图片：
- 自动插入场景传入 `skipSelect: true`，避免覆盖用户选中状态
- 用户主动操作场景保持原有行为（默认选中新图片）

### 修改的文件
- `packages/drawnix/src/data/image.ts` - 添加 `skipSelect` 参数
- `packages/drawnix/src/services/canvas-operations/canvas-insertion.ts` - 批量插入场景
- `packages/drawnix/src/mcp/tools/canvas-insertion.ts` - MCP 批量插入场景
- `packages/drawnix/src/services/canvas-operations/media-quick-insert.ts` - 快速插入场景
- `packages/drawnix/src/hooks/useWorkflowSubmission.ts` - 工作流自动插入场景
- `packages/drawnix/src/services/sw-capabilities/handler.ts` - Service Worker 自动插入场景
- `packages/drawnix/src/services/media-executor/fallback-executor.ts` - 修复参数不匹配问题
- `docs/IMAGE_SELECTION_LOCK_LESSONS.md` - 添加文档说明

### 验证
- ✅ `pnpm nx run drawnix:lint` 通过
- ✅ `pnpm build:web` 通过
- ✅ 与原仓库无代码冲突