### PR TITLE
修复首帧生图窗口复用状态

### DIFF
--- a/packages/drawnix/src/components/mv-creator/pages/GeneratePage.tsx
+++ b/packages/drawnix/src/components/mv-creator/pages/GeneratePage.tsx
@@ -1000,6 +1000,7 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
     const characterReferenceImages = getShotCharacterReferenceImages(shot);
     const shotBatchId = `mv_${record.id}_shot${shot.id}_first`;
     openDialog(DialogType.aiImageGeneration, {
+      prefillId: shotBatchId,
       initialPrompt: draft?.prompt || prompt,
       initialKnowledgeContextRefs: knowledgeContextRefs,
       batchId: shotBatchId,

--- a/packages/drawnix/src/components/ttd-dialog/ttd-dialog.tsx
+++ b/packages/drawnix/src/components/ttd-dialog/ttd-dialog.tsx
@@ -62,6 +62,12 @@ const TTDDialogComponent = ({
     dialogInitialDataByType?.[DialogType.aiImageGeneration] ?? null;
   const videoDialogInitialData =
     dialogInitialDataByType?.[DialogType.aiVideoGeneration] ?? null;
+  const imageDialogSessionKey =
+    imageDialogInitialData?.prefillId ||
+    imageDialogInitialData?.batchId ||
+    'ai-image-dialog';
+  const [imageDialogManualModeKey, setImageDialogManualModeKey] =
+    useState<string | null>(null);
 
   // 移动端和平板端不显示批量出图
   const showBatchTab = !isMobile && !isTablet;
@@ -212,6 +218,32 @@ const TTDDialogComponent = ({
     initialImages: [],
     selectedElementIds: [],
   });
+  const resolvedAiImageData = imageDialogInitialData
+    ? {
+        initialPrompt:
+          imageDialogInitialData.initialPrompt ||
+          imageDialogInitialData.prompt ||
+          '',
+        initialImages:
+          imageDialogInitialData.initialImages ||
+          imageDialogInitialData.uploadedImages ||
+          [],
+        selectedElementIds: [],
+        initialKnowledgeContextRefs:
+          imageDialogInitialData.initialKnowledgeContextRefs ||
+          imageDialogInitialData.knowledgeContextRefs ||
+          [],
+        initialResultUrl:
+          imageDialogInitialData.initialResultUrl ||
+          imageDialogInitialData.resultUrl,
+        initialAspectRatio: imageDialogInitialData.initialAspectRatio,
+        targetFrameId: imageDialogInitialData.targetFrameId,
+        targetFrameDimensions: imageDialogInitialData.targetFrameDimensions,
+        pptSlideImage: imageDialogInitialData.pptSlideImage,
+        pptSlidePrompt: imageDialogInitialData.pptSlidePrompt,
+        pptReplaceElementId: imageDialogInitialData.pptReplaceElementId,
+      }
+    : aiImageData;
 
   // AI 视频生成的初始数据
   const [aiVideoData, setAiVideoData] = useState<{
@@ -240,6 +272,14 @@ const TTDDialogComponent = ({
         return 'single';
       }
     });
+  const shouldForceImageDialogSingleMode =
+    !!imageDialogInitialData && imageDialogManualModeKey !== imageDialogSessionKey;
+  const imageDialogRenderMode: ImageGenerationMode =
+    shouldForceImageDialogSingleMode ? 'single' : imageGenerationMode;
+
+  useEffect(() => {
+    setImageDialogManualModeKey(null);
+  }, [imageDialogInitialData]);
 
   // 移动端/平板端自动切换回单图模式
   useEffect(() => {
@@ -250,6 +290,7 @@ const TTDDialogComponent = ({
 
   // 处理图片生成模式变化
   const handleImageModeChange = useCallback((mode: ImageGenerationMode) => {
+    setImageDialogManualModeKey(imageDialogSessionKey);
     setImageGenerationMode(mode);
     // 切换到批量模式时触发一次性全屏，切回时不调整尺寸（保持当前状态）
     if (mode === 'batch') {
@@ -263,7 +304,7 @@ const TTDDialogComponent = ({
     } catch (e) {
       console.warn('Failed to save image mode:', e);
     }
-  }, []);
+  }, [imageDialogSessionKey]);
 
   // 当对话框将要打开时，预先计算是否需要自动放大
   // 这需要在 WinBox 组件渲染前确定，且逻辑需要与 AIImageGeneration 的模式判断一致
@@ -681,11 +722,11 @@ const TTDDialogComponent = ({
       </Dialog>
       {/* AI 图片生成窗口 - 使用 WinBox */}
       <WinBoxWindow
-        key={imageDialogInitialData?.prefillId || 'ai-image-window'}
+        key={imageDialogSessionKey}
         id="ai-image-dialog"
         visible={appState.openDialogTypes.has(DialogType.aiImageGeneration)}
         title={
-          imageGenerationMode === 'batch'
+          imageDialogRenderMode === 'batch'
             ? language === 'zh'
               ? '批量出图'
               : 'Batch Generation'
@@ -704,7 +745,7 @@ const TTDDialogComponent = ({
               <button
                 type="button"
                 className={`mode-tab ${
-                  imageGenerationMode === 'single' ? 'active' : ''
+                  imageDialogRenderMode === 'single' ? 'active' : ''
                 }`}
                 onClick={(e) => {
                   e.stopPropagation();
@@ -717,7 +758,7 @@ const TTDDialogComponent = ({
               <button
                 type="button"
                 className={`mode-tab ${
-                  imageGenerationMode === 'batch' ? 'active' : ''
+                  imageDialogRenderMode === 'batch' ? 'active' : ''
                 }`}
                 onClick={(e) => {
                   e.stopPropagation();
@@ -744,7 +785,7 @@ const TTDDialogComponent = ({
         autoMaximize={imageDialogAutoMaximize || isMobile}
       >
         {appState.openDialogTypes.has(DialogType.aiImageGeneration) &&
-          (imageGenerationMode === 'batch' ? (
+          (imageDialogRenderMode === 'batch' ? (
             <Suspense
               fallback={
                 <div className="loading-fallback">
@@ -762,20 +803,13 @@ const TTDDialogComponent = ({
             </Suspense>
           ) : (
             <AIImageGeneration
-              key={
-                imageDialogInitialData?.prefillId ||
-                imageDialogInitialData?.batchId ||
-                'ai-image-dialog'
-              }
-              initialPrompt={aiImageData.initialPrompt}
-              initialImages={aiImageData.initialImages}
+              key={imageDialogSessionKey}
+              initialPrompt={resolvedAiImageData.initialPrompt}
+              initialImages={resolvedAiImageData.initialImages}
               initialKnowledgeContextRefs={
-                aiImageData.initialKnowledgeContextRefs ||
-                imageDialogInitialData?.initialKnowledgeContextRefs ||
-                imageDialogInitialData?.knowledgeContextRefs ||
-                []
+                resolvedAiImageData.initialKnowledgeContextRefs || []
               }
-              selectedElementIds={aiImageData.selectedElementIds}
+              selectedElementIds={resolvedAiImageData.selectedElementIds}
               initialWidth={
                 imageDialogInitialData?.initialWidth ||
                 imageDialogInitialData?.width
@@ -784,13 +818,13 @@ const TTDDialogComponent = ({
                 imageDialogInitialData?.initialHeight ||
                 imageDialogInitialData?.height
               }
-              initialResultUrl={aiImageData.initialResultUrl}
-              initialAspectRatio={aiImageData.initialAspectRatio}
-              targetFrameId={aiImageData.targetFrameId}
-              targetFrameDimensions={aiImageData.targetFrameDimensions}
-              pptSlideImage={aiImageData.pptSlideImage}
-              pptSlidePrompt={aiImageData.pptSlidePrompt}
-              pptReplaceElementId={aiImageData.pptReplaceElementId}
+              initialResultUrl={resolvedAiImageData.initialResultUrl}
+              initialAspectRatio={resolvedAiImageData.initialAspectRatio}
+              targetFrameId={resolvedAiImageData.targetFrameId}
+              targetFrameDimensions={resolvedAiImageData.targetFrameDimensions}
+              pptSlideImage={resolvedAiImageData.pptSlideImage}
+              pptSlidePrompt={resolvedAiImageData.pptSlidePrompt}
+              pptReplaceElementId={resolvedAiImageData.pptReplaceElementId}
               selectedModel={selectedImageModel}
               selectedModelRef={selectedImageModelRef}
               onModelChange={handleImageModelChange}

--- a/packages/drawnix/src/components/video-analyzer/pages/GeneratePage.tsx
+++ b/packages/drawnix/src/components/video-analyzer/pages/GeneratePage.tsx
@@ -1040,6 +1040,7 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
     const characterReferenceImages = getShotCharacterReferenceImages(shot);
     const shotBatchId = `va_${record.id}_shot${shot.id}_first`;
     openDialog(DialogType.aiImageGeneration, {
+      prefillId: shotBatchId,
       initialPrompt: draft?.prompt || prompt,
       batchId: shotBatchId,
       initialAspectRatio: draft?.aspectRatio ?? selectedImageAspectRatio,


### PR DESCRIPTION
## 问题描述
爆款视频/爆款 MV 中连续点击不同镜头的「生成首帧」时，AI 图片生成窗口会复用上一次退出时的状态，可能停留在批量出图或旧首帧上下文。

## 修复思路
- 首帧入口传入按镜头唯一的 prefillId。
- AI 图片窗口使用 prefillId/batchId 作为当前会话 key，避免复用旧窗口实例。
- 有初始化数据时默认渲染 AI 图片生成页，同时保留「批量出图」tab，用户仍可手动切换。

## 更新代码架构
- 将 TTDDialog 图片窗口的持久偏好 imageGenerationMode 与当前会话渲染模式 imageDialogRenderMode 拆分。
- 外部初始化入口使用 resolvedAiImageData 直接渲染首屏，避免先读取上一轮 aiImageData。

## 验证
- git diff --check
- tsc -p packages/drawnix/tsconfig.lib.json --noEmit