### PR TITLE
修复多图生成 JSON 解析和默认模型迁移

### DIFF
--- a/packages/drawnix/src/components/comic-creator/ComicCreator.tsx
+++ b/packages/drawnix/src/components/comic-creator/ComicCreator.tsx
@@ -25,8 +25,6 @@ import { MediaLibraryIcon } from '../icons';
 import { ModelDropdown } from '../ai-input-bar/ModelDropdown';
 import { ParametersDropdown } from '../ai-input-bar/ParametersDropdown';
 import {
-  DEFAULT_IMAGE_MODEL_ID,
-  DEFAULT_TEXT_MODEL_ID,
   ModelVendor,
   getCompatibleParams,
   type ModelConfig,
@@ -40,7 +38,11 @@ import {
   type ModelRef,
 } from '../../utils/settings-manager';
 import { promptForApiKey } from '../../utils/gemini-api';
-import { getSelectionKey } from '../../utils/model-selection';
+import {
+  findMatchingSelectableModel,
+  getModelRefFromConfig,
+  getSelectionKey,
+} from '../../utils/model-selection';
 import { generateUUID } from '../../utils/runtime-helpers';
 import { taskQueueService } from '../../services/task-queue';
 import { unifiedCacheService } from '../../services/unified-cache-service';
@@ -144,6 +146,10 @@ const COMIC_ANALYTICS_UV_EVENT = 'multi_image_generation_unique_view';
 const COMIC_ANALYTICS_DAILY_UV_KEY =
   'comic-creator:analytics:daily-unique-view';
 const COMIC_IMAGE_COUNT_OPTIONS = [1, 2, 3, 4];
+const COMIC_DEFAULT_TEXT_MODEL_ID = 'gemini-2.5-pro-all';
+const COMIC_DEFAULT_IMAGE_MODEL_ID = 'gpt-image-2';
+const LEGACY_COMIC_DEFAULT_TEXT_MODEL_ID = 'gpt-5.5';
+const LEGACY_COMIC_DEFAULT_IMAGE_MODEL_ID = 'gpt-image-2-vip';
 
 interface ComicPdfAttachment {
   cacheUrl: string;
@@ -311,15 +317,56 @@ function getModelRefForOption(model: ModelConfig): ModelRef | null {
     : null;
 }
 
+function getModelRefForSelection(model: ModelConfig): ModelRef | null {
+  return getModelRefFromConfig(model);
+}
+
+function selectFallbackModel(
+  models: ModelConfig[],
+  fallbackModelId: string
+): ModelConfig | undefined {
+  return (
+    findMatchingSelectableModel(models, fallbackModelId, null) ||
+    models.find((model) => !model.isVip) ||
+    models[0]
+  );
+}
+
+function readComicModelSelection(
+  storageKey: string,
+  models: ModelConfig[],
+  fallbackModelId: string,
+  legacyFallbackModelId: string
+): { modelId: string; modelRef: ModelRef | null } {
+  const stored = readStoredModelSelection(storageKey, fallbackModelId);
+  const isLegacyFallback =
+    stored.modelId === legacyFallbackModelId && !stored.modelRef?.profileId;
+  const matchedStored = findMatchingSelectableModel(
+    models,
+    stored.modelId,
+    stored.modelRef
+  );
+
+  if (matchedStored && !isLegacyFallback) {
+    return {
+      modelId: matchedStored.id,
+      modelRef: getModelRefForSelection(matchedStored),
+    };
+  }
+
+  const fallback = selectFallbackModel(models, fallbackModelId);
+  return {
+    modelId: fallback?.id || fallbackModelId,
+    modelRef: fallback ? getModelRefForSelection(fallback) : null,
+  };
+}
+
 function isSelectedModelInList(
   models: ModelConfig[],
   modelId: string,
   modelRef?: ModelRef | null
 ): boolean {
-  const selectedKey = getSelectionKey(modelId, modelRef);
-  return models.some(
-    (model) => (model.selectionKey || model.id) === selectedKey
-  );
+  return Boolean(findMatchingSelectableModel(models, modelId, modelRef));
 }
 
 function formatFileSize(size: number): string {
@@ -584,13 +631,23 @@ const ComicCreator: React.FC = () => {
   );
   const initialTextSelection = useMemo(
     () =>
-      readStoredModelSelection(STORAGE_KEY_TEXT_MODEL, DEFAULT_TEXT_MODEL_ID),
-    []
+      readComicModelSelection(
+        STORAGE_KEY_TEXT_MODEL,
+        textModels,
+        COMIC_DEFAULT_TEXT_MODEL_ID,
+        LEGACY_COMIC_DEFAULT_TEXT_MODEL_ID
+      ),
+    [textModels]
   );
   const initialImageSelection = useMemo(
     () =>
-      readStoredModelSelection(STORAGE_KEY_IMAGE_MODEL, DEFAULT_IMAGE_MODEL_ID),
-    []
+      readComicModelSelection(
+        STORAGE_KEY_IMAGE_MODEL,
+        imageModels,
+        COMIC_DEFAULT_IMAGE_MODEL_ID,
+        LEGACY_COMIC_DEFAULT_IMAGE_MODEL_ID
+      ),
+    [imageModels]
   );
   const initialPromptMode = useMemo(
     () => currentRecord?.sourcePromptMode || readSessionPromptMode(),
@@ -848,6 +905,60 @@ const ComicCreator: React.FC = () => {
     },
     [imageModel]
   );
+
+  useEffect(() => {
+    if (selectableTextModels.length === 0) return;
+    const isLegacyFallback =
+      textModel === LEGACY_COMIC_DEFAULT_TEXT_MODEL_ID &&
+      !textModelRef?.profileId;
+    const matchedModel = findMatchingSelectableModel(
+      selectableTextModels,
+      textModel,
+      textModelRef
+    );
+    if (matchedModel && !isLegacyFallback) return;
+
+    const fallback = selectFallbackModel(
+      selectableTextModels,
+      COMIC_DEFAULT_TEXT_MODEL_ID
+    );
+    if (!fallback) return;
+
+    const nextRef = getModelRefForSelection(fallback);
+    if (
+      getSelectionKey(textModel, textModelRef) !==
+      getSelectionKey(fallback.id, nextRef)
+    ) {
+      setTextModel(fallback.id, nextRef);
+    }
+  }, [selectableTextModels, setTextModel, textModel, textModelRef]);
+
+  useEffect(() => {
+    if (imageModels.length === 0) return;
+    const isLegacyFallback =
+      imageModel === LEGACY_COMIC_DEFAULT_IMAGE_MODEL_ID &&
+      !imageModelRef?.profileId;
+    const matchedModel = findMatchingSelectableModel(
+      imageModels,
+      imageModel,
+      imageModelRef
+    );
+    if (matchedModel && !isLegacyFallback) return;
+
+    const fallback = selectFallbackModel(
+      imageModels,
+      COMIC_DEFAULT_IMAGE_MODEL_ID
+    );
+    if (!fallback) return;
+
+    const nextRef = getModelRefForSelection(fallback);
+    if (
+      getSelectionKey(imageModel, imageModelRef) !==
+      getSelectionKey(fallback.id, nextRef)
+    ) {
+      setImageModel(fallback.id, nextRef);
+    }
+  }, [imageModel, imageModelRef, imageModels, setImageModel]);
 
   const handleImageParamChange = useCallback(
     (paramId: string, value: string) => {
@@ -1180,6 +1291,10 @@ const ComicCreator: React.FC = () => {
           knowledgeContextRefs,
           model: textModel,
           modelRef: textModelRef,
+          params: {
+            response_mime_type: 'application/json',
+            response_format: { type: 'json_object' },
+          },
           comicCreatorAction: 'outline',
           comicCreatorRecordId: record.id,
           comicCreatorScenarioId: scenarioId,

--- a/packages/drawnix/src/components/comic-creator/storage.test.ts
+++ b/packages/drawnix/src/components/comic-creator/storage.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadRecords } from './storage';
+
+const { getMock, setMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  setMock: vi.fn(),
+}));
+
+vi.mock('../../services/kv-storage-service', () => ({
+  kvStorageService: {
+    get: getMock,
+    isAvailable: () => true,
+    set: setMock,
+  },
+}));
+
+vi.mock('./utils', () => ({
+  stripLargeImageDataFromComicPage: (page: unknown) => page,
+}));
+
+describe('comic-creator storage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    setMock.mockReset();
+  });
+
+  it('migrates legacy default image model on load', async () => {
+    getMock.mockResolvedValue([
+      {
+        id: 'record-1',
+        starred: false,
+        title: '旧记录',
+        sourcePrompt: '故事',
+        commonPrompt: '',
+        pageCount: 1,
+        pages: [],
+        imageModel: 'gpt-image-2-vip',
+        imageModelRef: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+
+    const records = await loadRecords();
+
+    expect(records[0]).toMatchObject({
+      imageModel: 'gpt-image-2',
+      imageModelRef: null,
+    });
+  });
+
+  it('preserves explicit profile-bound legacy image model', async () => {
+    getMock.mockResolvedValue([
+      {
+        id: 'record-1',
+        starred: false,
+        title: '自定义记录',
+        sourcePrompt: '故事',
+        commonPrompt: '',
+        pageCount: 1,
+        pages: [],
+        imageModel: 'gpt-image-2-vip',
+        imageModelRef: {
+          profileId: 'custom-profile',
+          modelId: 'gpt-image-2-vip',
+        },
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+
+    const records = await loadRecords();
+
+    expect(records[0]).toMatchObject({
+      imageModel: 'gpt-image-2-vip',
+      imageModelRef: {
+        profileId: 'custom-profile',
+        modelId: 'gpt-image-2-vip',
+      },
+    });
+  });
+});

--- a/packages/drawnix/src/components/comic-creator/storage.ts
+++ b/packages/drawnix/src/components/comic-creator/storage.ts
@@ -4,19 +4,37 @@ import {
   loadRecordsByKey,
   saveRecordsByKey,
   updateRecordById,
-} from '../shared/workflow';
+} from '../shared/workflow/record-storage';
 import type { ComicRecord } from './types';
 import { stripLargeImageDataFromComicPage } from './utils';
 
 const STORAGE_KEY = 'comic-creator:records';
 const MAX_RECORDS = 50;
+const LEGACY_DEFAULT_IMAGE_MODEL_ID = 'gpt-image-2-vip';
+const DEFAULT_IMAGE_MODEL_ID = 'gpt-image-2';
 
-function sanitizeRecord(record: ComicRecord): ComicRecord {
+function normalizeLegacyImageModel(record: ComicRecord): ComicRecord {
+  if (
+    record.imageModel !== LEGACY_DEFAULT_IMAGE_MODEL_ID ||
+    record.imageModelRef?.profileId
+  ) {
+    return record;
+  }
+
   return {
     ...record,
-    starred: !!record.starred,
-    pages: Array.isArray(record.pages)
-      ? record.pages.map(stripLargeImageDataFromComicPage)
+    imageModel: DEFAULT_IMAGE_MODEL_ID,
+    imageModelRef: null,
+  };
+}
+
+function sanitizeRecord(record: ComicRecord): ComicRecord {
+  const normalizedRecord = normalizeLegacyImageModel(record);
+  return {
+    ...normalizedRecord,
+    starred: !!normalizedRecord.starred,
+    pages: Array.isArray(normalizedRecord.pages)
+      ? normalizedRecord.pages.map(stripLargeImageDataFromComicPage)
       : [],
   };
 }

--- a/packages/drawnix/src/components/comic-creator/task-sync.ts
+++ b/packages/drawnix/src/components/comic-creator/task-sync.ts
@@ -34,6 +34,17 @@ function getTaskErrorMessage(task: Task): string {
   );
 }
 
+function buildOutlineParseErrorMessage(
+  error: unknown,
+  responseText: string
+): string {
+  const reason = error instanceof Error ? error.message : '返回格式错误';
+  const preview = responseText.trim().replace(/\s+/g, ' ').slice(0, 200);
+  return preview
+    ? `提示词规划未返回可解析 JSON：${reason}。响应预览：${preview}`
+    : `提示词规划未返回可解析 JSON：${reason}`;
+}
+
 export function isComicCreatorTerminalTask(task: Task): task is Task {
   return (
     isComicCreatorTask(task) &&
@@ -84,8 +95,9 @@ export async function syncComicOutlineTask(task: Task): Promise<{
   }
 
   try {
+    const chatResponse = readTaskChatResponse(task);
     const payload = parseComicScriptResponse(
-      readTaskChatResponse(task),
+      chatResponse,
       (task.params as { comicCreatorPageCount?: unknown })
         .comicCreatorPageCount || target.pageCount
     );
@@ -112,10 +124,10 @@ export async function syncComicOutlineTask(task: Task): Promise<{
       target,
       {
         pendingOutlineTaskId: null,
-        outlineError:
-          error instanceof Error
-            ? error.message
-            : '提示词规划返回格式错误，请重试',
+        outlineError: buildOutlineParseErrorMessage(
+          error,
+          readTaskChatResponse(task)
+        ),
         updatedAt: Date.now(),
       },
       updateRecord

--- a/packages/drawnix/src/constants/model-config.ts
+++ b/packages/drawnix/src/constants/model-config.ts
@@ -796,7 +796,8 @@ const BUILT_IN_VIDEO_MODELS: ModelConfig[] = [
     id: 'happyhorse-1.0-video-edit',
     label: 'HappyHorse 1.0 Video Edit',
     shortCode: 'h10v',
-    description: 'HappyHorse 视频参考生成视频，时长跟随输入视频，支持保留原音频',
+    description:
+      'HappyHorse 视频参考生成视频，时长跟随输入视频，支持保留原音频',
     type: 'video',
     vendor: ModelVendor.HAPPYHORSE,
     supportsTools: true,
@@ -1537,7 +1538,7 @@ export const AUDIO_MODEL_SELECT_OPTIONS = AUDIO_MODELS.map((model) => ({
 /**
  * 默认图片模型 ID
  */
-export const DEFAULT_IMAGE_MODEL_ID = 'gpt-image-2-vip';
+export const DEFAULT_IMAGE_MODEL_ID = 'gpt-image-2';
 
 /**
  * 获取默认图片模型 ID（优先使用环境变量）
@@ -1848,7 +1849,8 @@ export const VIDEO_PARAMS: ParamConfig[] = [
     id: 'duration',
     label: '视频时长',
     shortLabel: '时长',
-    description: 'HappyHorse 视频时长（3-15 秒整数；Video Edit 跟随输入视频，不支持此参数）',
+    description:
+      'HappyHorse 视频时长（3-15 秒整数；Video Edit 跟随输入视频，不支持此参数）',
     valueType: 'enum',
     options: [
       { value: '3', label: '3秒' },

--- a/packages/drawnix/src/services/media-executor/fallback-executor.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-executor.ts
@@ -101,6 +101,67 @@ function buildProviderContext(config: {
   );
 }
 
+async function readResponseTextPreview(
+  response: Response,
+  limit = 1000
+): Promise<string> {
+  if (!response.body) {
+    try {
+      return (await response.clone().text()).slice(0, limit);
+    } catch {
+      return '';
+    }
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+
+  try {
+    while (text.length < limit) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    if (text.length >= limit) {
+      await reader.cancel().catch(() => undefined);
+    }
+  } catch {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  return text.slice(0, limit);
+}
+
+function extractProviderErrorMessage(rawText: string): string {
+  const trimmed = rawText.trim();
+  if (!trimmed) return '';
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: string;
+      detail?: string;
+      error?:
+        | string
+        | {
+            message?: string;
+            details?: string;
+          };
+    };
+    if (typeof parsed.error === 'string') return parsed.error;
+    return (
+      parsed.error?.message ||
+      parsed.error?.details ||
+      parsed.message ||
+      parsed.detail ||
+      ''
+    ).trim();
+  } catch {
+    return trimmed.replace(/\s+/g, ' ');
+  }
+}
+
 /** 从 uploadedImages 提取 URL 列表，与 SW ImageHandler 逻辑一致 */
 function extractUrlsFromUploadedImages(
   uploadedImages: unknown
@@ -461,10 +522,7 @@ export class FallbackMediaExecutor implements IMediaExecutor {
         const maskData = await unifiedCacheService.getImageForAI(
           params.maskImage
         );
-        processedMaskImage = await ensureBase64ForAI(
-          maskData,
-          options?.signal
-        );
+        processedMaskImage = await ensureBase64ForAI(maskData, options?.signal);
       }
 
       // 调用异步图片生成
@@ -1016,6 +1074,12 @@ export class FallbackMediaExecutor implements IMediaExecutor {
                 ...(toNumber(extraParams?.max_tokens) !== undefined
                   ? { maxOutputTokens: toNumber(extraParams?.max_tokens) }
                   : {}),
+                ...(typeof extraParams?.response_mime_type === 'string' &&
+                extraParams.response_mime_type.trim()
+                  ? {
+                      responseMimeType: extraParams.response_mime_type.trim(),
+                    }
+                  : {}),
               },
             })
           : await providerTransport
@@ -1038,14 +1102,21 @@ export class FallbackMediaExecutor implements IMediaExecutor {
                   ...(toNumber(extraParams?.max_tokens) !== undefined
                     ? { max_tokens: toNumber(extraParams?.max_tokens) }
                     : {}),
+                  ...(typeof extraParams?.response_format === 'object'
+                    ? { response_format: extraParams.response_format }
+                    : {}),
                 }),
                 signal: options?.signal,
               })
               .then(async (response) => {
                 if (!response.ok) {
+                  const rawError = await readResponseTextPreview(response);
+                  const providerMessage = extractProviderErrorMessage(rawError);
                   throw new Error(
                     `HTTP ${response.status}: ${
-                      response.statusText || 'Text generation failed'
+                      providerMessage ||
+                      response.statusText ||
+                      'Text generation failed'
                     }`
                   );
                 }

--- a/packages/drawnix/src/utils/__tests__/settings-manager.test.ts
+++ b/packages/drawnix/src/utils/__tests__/settings-manager.test.ts
@@ -330,6 +330,86 @@ describe('settings-manager', () => {
     });
   });
 
+  it('migrates legacy default image model only once', async () => {
+    mockSettingsManagerDeps();
+
+    localStorage.setItem(
+      DRAWNIX_SETTINGS_KEY,
+      JSON.stringify({
+        gemini: {
+          apiKey: 'legacy-key',
+          baseUrl: 'https://api.tu-zi.com/v1',
+          imageModelName: 'gpt-image-2-vip',
+        },
+        invocationPresets: [
+          {
+            id: 'default',
+            name: '默认方案',
+            isDefault: true,
+            text: {
+              defaultModelRef: {
+                profileId: 'legacy-default',
+                modelId: 'gemini-2.5-pro-all',
+              },
+            },
+            audio: {
+              defaultModelRef: {
+                profileId: 'legacy-default',
+                modelId: 'suno_music',
+              },
+            },
+            image: {
+              defaultModelRef: {
+                profileId: 'legacy-default',
+                modelId: 'gpt-image-2-vip',
+              },
+            },
+            video: {
+              defaultModelRef: {
+                profileId: 'legacy-default',
+                modelId: 'seedance-1.5-pro',
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    const { settingsManager } = await import('../settings-manager');
+    const settings = settingsManager.getSettings();
+
+    expect(settings.gemini.imageModelName).toBe('gpt-image-2');
+    expect(settings.invocationPresets[0]?.image.defaultModelRef).toMatchObject({
+      profileId: 'legacy-default',
+      modelId: 'gpt-image-2',
+    });
+    expect(settings.migrations).toMatchObject({
+      legacyDefaultImageModelV1: true,
+    });
+
+    await settingsManager.updateActiveInvocationRouteModel('image', {
+      profileId: 'legacy-default',
+      modelId: 'gpt-image-2-vip',
+    });
+
+    vi.resetModules();
+    mockSettingsManagerDeps();
+
+    const reloaded = await import('../settings-manager');
+    const reloadedSettings = reloaded.settingsManager.getSettings();
+
+    expect(reloadedSettings.gemini.imageModelName).toBe('gpt-image-2-vip');
+    expect(
+      reloadedSettings.invocationPresets[0]?.image.defaultModelRef
+    ).toMatchObject({
+      profileId: 'legacy-default',
+      modelId: 'gpt-image-2-vip',
+    });
+    expect(reloadedSettings.migrations).toMatchObject({
+      legacyDefaultImageModelV1: true,
+    });
+  });
+
   it('does not migrate legacy default compatibility when the default baseUrl is not Tuzi', async () => {
     mockSettingsManagerDeps();
 

--- a/packages/drawnix/src/utils/llm-json-extractor.test.ts
+++ b/packages/drawnix/src/utils/llm-json-extractor.test.ts
@@ -66,6 +66,52 @@ describe('llm-json-extractor', () => {
     expect(result.shots).toEqual([{ id: 'shot_1' }]);
   });
 
+  it('extracts JSON from google generateContent candidate envelopes', () => {
+    const result = extractJsonObject<{ pages: unknown[] }>(
+      JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    title: '深圳文旅',
+                    pages: [{ title: '封面' }],
+                  }),
+                },
+              ],
+            },
+          },
+        ],
+      }),
+      (value) => Array.isArray((value as { pages?: unknown }).pages)
+    );
+
+    expect(result.pages).toEqual([{ title: '封面' }]);
+  });
+
+  it('extracts JSON from array message content envelopes', () => {
+    const result = extractJsonObject<{ pages: unknown[] }>(
+      JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: [
+                {
+                  type: 'text',
+                  text: '{"title":"深圳文旅","pages":[{"title":"封面"}]}',
+                },
+              ],
+            },
+          },
+        ],
+      }),
+      (value) => Array.isArray((value as { pages?: unknown }).pages)
+    );
+
+    expect(result.pages).toEqual([{ title: '封面' }]);
+  });
+
   it('keeps brackets inside JSON strings from breaking balance', () => {
     const result = extractJsonObject<{ text: string }>(
       'prefix {"text":"literal { brace } and [ bracket ]"} suffix'
@@ -99,8 +145,10 @@ describe('llm-json-extractor', () => {
   });
 
   it('keeps truncated JSON as a failure', () => {
-    expect(() => extractJsonValue('前缀 {"title":"未完成"', {
-      kinds: ['object'],
-    })).toThrow('响应中未找到有效 JSON');
+    expect(() =>
+      extractJsonValue('前缀 {"title":"未完成"', {
+        kinds: ['object'],
+      })
+    ).toThrow('响应中未找到有效 JSON');
   });
 });

--- a/packages/drawnix/src/utils/llm-json-extractor.ts
+++ b/packages/drawnix/src/utils/llm-json-extractor.ts
@@ -50,9 +50,30 @@ function collectString(value: unknown, output: string[]): void {
   }
 }
 
+function collectTextFromContentParts(value: unknown, output: string[]): void {
+  if (typeof value === 'string') {
+    collectString(value, output);
+    return;
+  }
+
+  if (!Array.isArray(value)) return;
+
+  for (const part of value) {
+    if (typeof part === 'string') {
+      collectString(part, output);
+      continue;
+    }
+
+    const item = part as { text?: unknown; type?: unknown } | null;
+    if (!item || typeof item !== 'object') continue;
+    collectString(item.text, output);
+  }
+}
+
 function collectKnownLlmPayloads(value: unknown): string[] {
   const output: string[] = [];
   const root = value as {
+    candidates?: unknown;
     choices?: unknown;
     output_text?: unknown;
     text?: unknown;
@@ -64,6 +85,16 @@ function collectKnownLlmPayloads(value: unknown): string[] {
   collectString(root.output_text, output);
   collectString(root.text, output);
   collectString(root.content, output);
+  collectTextFromContentParts(root.content, output);
+
+  if (Array.isArray(root.candidates)) {
+    for (const candidate of root.candidates) {
+      const item = candidate as {
+        content?: { parts?: unknown };
+      } | null;
+      collectTextFromContentParts(item?.content?.parts, output);
+    }
+  }
 
   if (Array.isArray(root.choices)) {
     for (const choice of root.choices) {
@@ -76,6 +107,8 @@ function collectKnownLlmPayloads(value: unknown): string[] {
       collectString(item.message?.content, output);
       collectString(item.delta?.content, output);
       collectString(item.text, output);
+      collectTextFromContentParts(item.message?.content, output);
+      collectTextFromContentParts(item.delta?.content, output);
     }
   }
 
@@ -121,7 +154,7 @@ function buildJsonSearchSources(text: string): string[] {
   const envelopePayloads = collectEnvelopePayloadSources(directSources);
 
   return uniqueSources([
-    ...envelopePayloads.flatMap(payload => [
+    ...envelopePayloads.flatMap((payload) => [
       ...getFenceContents(payload),
       payload,
     ]),

--- a/packages/drawnix/src/utils/settings-manager.ts
+++ b/packages/drawnix/src/utils/settings-manager.ts
@@ -74,6 +74,7 @@ export const TUZI_ORIGINAL_PROVIDER_NAME = '原价分组';
 export const TUZI_MIX_PROVIDER_NAME = 'gemini-mix 分组';
 export const TUZI_CODEX_PROVIDER_NAME = 'codex 分组';
 export const TUZI_BUSINESS_PROVIDER_NAME = 'Business';
+const LEGACY_DEFAULT_IMAGE_MODEL_ID = 'gpt-image-2-vip';
 
 const DEFAULT_PROVIDER_CAPABILITIES: ProviderCapabilities = {
   supportsModelsEndpoint: true,
@@ -91,7 +92,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     baseUrl: TUZI_PROVIDER_DEFAULT_BASE_URL,
     chatModel: getDefaultTextModel(),
     audioModelName: 'suno_music',
-    imageModelName: 'gpt-image-2-vip',
+    imageModelName: getDefaultImageModel(),
     videoModelName: 'seedance-1.5-pro',
     textModelName: getDefaultTextModel(),
   },
@@ -390,6 +391,7 @@ class SettingsManager {
     return {
       legacyDefaultImageApiCompatibilityV1:
         migrations.legacyDefaultImageApiCompatibilityV1 === true,
+      legacyDefaultImageModelV1: migrations.legacyDefaultImageModelV1 === true,
     };
   }
 
@@ -452,6 +454,19 @@ class SettingsManager {
     return this.isTuziProviderBaseUrl(baseUrl)
       ? LEGACY_DEFAULT_PROVIDER_IMAGE_API_COMPATIBILITY
       : DEFAULT_PROVIDER_IMAGE_API_COMPATIBILITY;
+  }
+
+  private migrateLegacyDefaultImageModel(
+    gemini: GeminiSettings
+  ): GeminiSettings {
+    if (gemini.imageModelName !== LEGACY_DEFAULT_IMAGE_MODEL_ID) {
+      return gemini;
+    }
+
+    return {
+      ...gemini,
+      imageModelName: getDefaultImageModel(),
+    };
   }
 
   private normalizeCapabilities(value: unknown): ProviderCapabilities {
@@ -948,8 +963,12 @@ class SettingsManager {
     const migrations: SettingsMigrations = { ...settings.migrations };
     const shouldRunLegacyDefaultImageMigration =
       migrations.legacyDefaultImageApiCompatibilityV1 !== true;
-    const legacyBaseUrl =
-      settings.gemini.baseUrl || DEFAULT_SETTINGS.gemini.baseUrl;
+    const shouldRunLegacyDefaultImageModelMigration =
+      migrations.legacyDefaultImageModelV1 !== true;
+    const gemini = shouldRunLegacyDefaultImageModelMigration
+      ? this.migrateLegacyDefaultImageModel(settings.gemini)
+      : settings.gemini;
+    const legacyBaseUrl = gemini.baseUrl || DEFAULT_SETTINGS.gemini.baseUrl;
     const legacyProfileForBuild =
       shouldRunLegacyDefaultImageMigration &&
       this.shouldMigrateLegacyDefaultImageApiCompatibility(
@@ -967,9 +986,15 @@ class SettingsManager {
       migrations.legacyDefaultImageApiCompatibilityV1 = true;
       this.shouldPersistSettingsAfterInitialization = true;
     }
+    if (shouldRunLegacyDefaultImageModelMigration) {
+      migrations.legacyDefaultImageModelV1 = true;
+      if (gemini !== settings.gemini) {
+        this.shouldPersistSettingsAfterInitialization = true;
+      }
+    }
 
     const legacyProfile = {
-      ...this.buildLegacyDefaultProfile(settings.gemini, legacyProfileForBuild),
+      ...this.buildLegacyDefaultProfile(gemini, legacyProfileForBuild),
       extraHeaders: this.normalizeStringRecord(
         existingLegacyProfile?.extraHeaders
       ),
@@ -987,7 +1012,7 @@ class SettingsManager {
     const tuziBusinessProfile = this.buildTuziBusinessProfile(
       existingTuziBusinessProfile
     );
-    const legacyPreset = this.buildLegacyDefaultPreset(settings.gemini);
+    const legacyPreset = this.buildLegacyDefaultPreset(gemini);
 
     const providerProfiles = [
       legacyProfile,
@@ -1153,6 +1178,7 @@ class SettingsManager {
 
     return {
       ...settings,
+      gemini,
       migrations,
       providerProfiles,
       providerCatalogs,

--- a/packages/drawnix/src/utils/settings-types.ts
+++ b/packages/drawnix/src/utils/settings-types.ts
@@ -82,6 +82,7 @@ export interface InvocationPreset {
 
 export interface SettingsMigrations {
   legacyDefaultImageApiCompatibilityV1?: boolean;
+  legacyDefaultImageModelV1?: boolean;
 }
 
 export interface TtsSettings {


### PR DESCRIPTION
## 问题描述
- 多图生成规划任务在部分供应商响应包裹下无法提取 JSON，页面显示“响应中未找到有效 JSON”。
- 旧默认图片模型 `gpt-image-2-vip` 会在本地设置和历史记录中残留，可能继续触发 403/500。

## 修复思路
- 规划请求透传 JSON 输出参数，兼容 Google `responseMimeType` 与 OpenAI-like `response_format`。
- 增强 LLM JSON 提取，支持 Google candidates envelope 与 OpenAI content array envelope。
- 非 2xx 文本响应使用流式读取前 1000 字错误摘要，避免大响应占用内存，并展示真实 provider 错误。
- 默认图片模型迁移到 `gpt-image-2`，并迁移旧全局设置和旧多图记录；用户绑定 profile 的显式选择保留。

## 更新代码架构
- 复用模型选择匹配工具，避免手写 selectionKey 比对。
- 新增 settings migration 标记与 comic storage 归一化测试。
- 收窄 comic storage 对 shared workflow 的导入，减少测试/运行时副作用。

## 验证
- `pnpm --dir packages/drawnix exec vitest run src/components/comic-creator/storage.test.ts src/utils/__tests__/settings-manager.test.ts src/utils/llm-json-extractor.test.ts src/components/comic-creator/task-sync.test.ts src/components/comic-creator/utils.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir packages/drawnix exec tsc --noEmit --pretty false`
- `pnpm --dir packages/drawnix exec prettier --check ...`
- `git diff --check`
