### PR TITLE
修复供应商风控错误展示与恢复

### DIFF
--- a/docs/MULTI_IMAGE_PROVIDER_ERROR_RECOVERY_LESSONS.md
+++ b/docs/MULTI_IMAGE_PROVIDER_ERROR_RECOVERY_LESSONS.md
@@ -1,0 +1,215 @@
+# 多图生成与供应商错误恢复经验总结
+
+更新日期：2026-06-10
+
+## 背景
+
+本轮排查来自工具箱中的多图生成和任务队列失败提示。用户连续遇到两类表面相似、根因不同的问题：
+
+1. 多图生成规划任务失败，页面显示“响应中未找到有效 JSON”。
+2. 视频任务失败，任务列表直接显示 `status=403 403 Forbidden` 和一整段 Google reCAPTCHA JSON。
+
+这两类问题都发生在 AI 供应商响应进入任务队列后，但处理方式不同：
+
+- JSON 问题属于“模型输出/响应包裹不可解析”。
+- reCAPTCHA 403 属于“供应商风控拒绝”，前端无法绕过，只能识别、提示和保留排障信息。
+
+## 问题表现
+
+### 1. 规划任务 JSON 解析失败
+
+多图生成会先生成分镜/页面规划，再按页面生成图片。部分供应商返回内容时会套一层响应 envelope，例如：
+
+- Google `candidates[].content.parts[].text`
+- OpenAI-compatible `choices[].message.content[]`
+
+如果解析器只查普通字符串，就会误判为“没有 JSON”。
+
+### 2. 历史默认模型残留导致继续失败
+
+默认图片模型从旧的 `gpt-image-2-vip` 切到 `gpt-image-2` 后，历史本地设置和多图记录仍可能保存旧模型。仅修改静态默认值不能覆盖已经持久化的用户本地状态。
+
+### 3. 供应商原始错误污染任务列表
+
+`omni-flash` 视频提交被 Google 侧返回：
+
+```text
+reCAPTCHA evaluation failed
+PUBLIC_ERROR_UNUSUAL_ACTIVITY
+```
+
+旧逻辑把完整 HTTP 错误文本作为 `task.error.message` 展示，导致任务列表出现大段 JSON，用户无法判断该换模型、重试还是配置 API Key。
+
+## 修复思路
+
+### 1. 对规划任务主动要求 JSON
+
+创建多图规划 CHAT 任务时，为不同协议同时透传 JSON 输出约束：
+
+- Google: `response_mime_type: application/json`
+- OpenAI-compatible: `response_format: { type: 'json_object' }`
+
+这不能保证所有模型 100% 遵守，但能减少自然语言包裹和 markdown fence 的概率。
+
+### 2. JSON 解析器要理解供应商 envelope
+
+解析入口不能只看原始文本，还要从已知供应商结构中抽取文本字段：
+
+- `candidates[].content.parts[].text`
+- `choices[].message.content`
+- `choices[].message.content[].text`
+- `choices[].delta.content`
+
+解析失败时不要只抛“响应中未找到有效 JSON”，应带上响应预览，方便判断是空响应、截断、自然语言还是 envelope 未兼容。
+
+### 3. 历史默认值需要显式迁移
+
+默认值变更必须覆盖三层：
+
+- 静态默认：`DEFAULT_IMAGE_MODEL_ID`
+- 全局设置：`gemini.imageModelName` 和默认 invocation preset
+- 业务记录：多图历史记录中的 `imageModel`
+
+迁移只处理“旧默认且没有 profile 绑定”的场景。用户显式绑定到自定义 profile 的模型选择不能被覆盖。
+
+### 4. HTTP 错误要区分用户文案和原始详情
+
+供应商 403/500 的原始响应通常很长，不能直接塞进任务列表。更稳的结构是：
+
+- `message`: 面向用户的短提示
+- `code`: 可用于分类的错误码
+- `details.originalError`: 原始响应，供详情 tooltip 或排查使用
+
+对 reCAPTCHA/异常流量 403，统一成：
+
+```text
+供应商风控拦截：当前视频模型触发 reCAPTCHA/异常流量校验，请换用 Seedance/Veo 其他模型或稍后重试。
+```
+
+### 5. 流式截断读取错误响应
+
+高并发文件处理服务里，错误响应也可能很大。读取 provider error 时只读取前 1000 字预览，避免把完整响应读入内存。
+
+## 代码层面固化的规则
+
+### 多图生成
+
+- 多图规划任务必须带 JSON 输出约束。
+- `parseComicScriptResponse` 前必须通过共享 JSON 提取器处理供应商 envelope。
+- 解析失败的 UI 文案要包含“原因 + 响应预览”，不能只显示底层异常。
+- 多图记录写入前要归一化旧默认图片模型。
+
+### 模型默认值
+
+- 默认图片模型统一由 `getDefaultImageModel()` 提供。
+- 旧默认模型迁移要使用 migration flag，避免用户手动改回后被二次覆盖。
+- 旧 `gpt-image-2-vip` 只有在无 profile 绑定时才视作历史默认。
+
+### 供应商错误
+
+- HTTP 错误进入任务队列前要提取用户可读 message。
+- reCAPTCHA/`PUBLIC_ERROR_UNUSUAL_ACTIVITY` 要归类为 `PROVIDER_RECAPTCHA_BLOCKED`。
+- 这类风控错误允许重试，不应被批量视频逻辑当成参数错误永久失败。
+- 原始 provider JSON 放入 `details.originalError`，不要直接显示在列表主体。
+
+## 代码落点
+
+- `packages/drawnix/src/components/comic-creator/ComicCreator.tsx`
+
+  - 多图规划任务透传 JSON 输出参数。
+  - 默认文本/图片模型回退到稳定模型。
+  - 旧多图模型选择自动迁移到新默认。
+
+- `packages/drawnix/src/components/comic-creator/task-sync.ts`
+
+  - 规划响应解析失败时生成可诊断错误。
+
+- `packages/drawnix/src/components/comic-creator/storage.ts`
+
+  - 加载/保存多图记录时迁移旧默认图片模型。
+
+- `packages/drawnix/src/utils/llm-json-extractor.ts`
+
+  - 支持 Google 和 OpenAI-compatible 的响应 envelope。
+
+- `packages/drawnix/src/utils/settings-manager.ts`
+
+  - 全局设置和默认 preset 迁移旧图片模型。
+
+- `packages/drawnix/src/services/media-executor/fallback-executor.ts`
+
+  - 文本生成非 2xx 时流式读取错误预览。
+  - 透传 Google / OpenAI-compatible JSON 输出参数。
+
+- `packages/drawnix/src/services/media-api/video-api.ts`
+
+  - 识别 reCAPTCHA/异常流量 403，输出短中文错误和原始详情。
+
+- `packages/drawnix/src/services/task-queue-service.ts`
+
+  - 失败任务保留 `details.originalError`。
+
+- `packages/drawnix/src/utils/batch-video-generation.ts`
+  - reCAPTCHA 风控错误保持可重试。
+
+## 检查清单
+
+- 多图规划任务是否仍传递 JSON 输出约束。
+- JSON 提取器是否覆盖新增供应商 envelope，而不是在业务层临时解析。
+- 默认模型变更是否同时覆盖静态默认、全局设置和业务记录。
+- 旧默认迁移是否有 migration flag，且不会覆盖 profile 绑定的用户选择。
+- 任务列表是否只展示短错误，不直接展示 provider JSON。
+- 原始 provider 错误是否仍可通过详情查看。
+- 403 风控错误是否保持可重试。
+- 错误响应读取是否有长度上限。
+
+## 验证建议
+
+```bash
+pnpm --dir packages/drawnix exec vitest run \
+  src/components/comic-creator/storage.test.ts \
+  src/utils/__tests__/settings-manager.test.ts \
+  src/utils/llm-json-extractor.test.ts \
+  src/components/comic-creator/task-sync.test.ts \
+  src/components/comic-creator/utils.test.ts \
+  src/services/__tests__/media-api-routing.test.ts \
+  src/utils/batch-video-generation.test.ts \
+  --no-file-parallelism --maxWorkers=1
+
+pnpm --dir packages/drawnix exec tsc --noEmit --pretty false
+pnpm --dir packages/drawnix exec prettier --check \
+  src/components/comic-creator/storage.ts \
+  src/components/comic-creator/storage.test.ts \
+  src/components/comic-creator/task-sync.ts \
+  src/components/comic-creator/ComicCreator.tsx \
+  src/utils/settings-manager.ts \
+  src/utils/settings-types.ts \
+  src/utils/llm-json-extractor.ts \
+  src/utils/llm-json-extractor.test.ts \
+  src/services/media-executor/fallback-executor.ts \
+  src/services/media-api/video-api.ts \
+  src/services/task-queue-service.ts \
+  src/services/__tests__/media-api-routing.test.ts \
+  src/utils/batch-video-generation.ts \
+  src/utils/batch-video-generation.test.ts \
+  src/constants/model-config.ts
+git diff --check
+```
+
+## 提交备注模板
+
+```text
+问题描述:
+- 多图生成规划响应在部分供应商 envelope 下无法提取 JSON，历史默认模型残留会继续触发 403/500。
+- 视频任务遇到 Google reCAPTCHA 风控 403 时，任务列表直接展示大段原始 JSON。
+
+修复思路:
+- 多图规划请求透传 JSON 输出约束，增强共享 JSON 提取器。
+- 迁移旧默认图片模型到 gpt-image-2，并覆盖全局设置和多图记录。
+- 将供应商 HTTP 错误拆成用户短提示和 details.originalError，识别 reCAPTCHA 风控并保持可重试。
+
+更新代码架构:
+- 设置迁移使用 migration flag，避免二次覆盖用户选择。
+- 多图记录归一化收敛到 storage 层。
+- 视频提交错误归一化收敛到 media-api 层，任务队列只负责展示和持久化。
+```

--- a/packages/drawnix/src/services/__tests__/media-api-routing.test.ts
+++ b/packages/drawnix/src/services/__tests__/media-api-routing.test.ts
@@ -8,23 +8,27 @@ import {
 
 describe('media-api provider routing', () => {
   it('uses header auth and extra headers for sync image generation', async () => {
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe('https://api.example.com/v1/images/generations');
-      const headers = init?.headers as Record<string, string>;
-      expect(headers['Content-Type']).toBe('application/json');
-      expect(headers['X-API-Key']).toBe('secret');
-      expect(headers['X-Trace-Id']).toBe('trace-1');
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe(
+          'https://api.example.com/v1/images/generations'
+        );
+        const headers = init?.headers as Record<string, string>;
+        expect(headers['Content-Type']).toBe('application/json');
+        expect(headers['X-API-Key']).toBe('secret');
+        expect(headers['X-Trace-Id']).toBe('trace-1');
 
-      return new Response(
-        JSON.stringify({
-          data: [{ url: 'https://cdn.example.com/image.png' }],
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    });
+        return new Response(
+          JSON.stringify({
+            data: [{ url: 'https://cdn.example.com/image.png' }],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+    );
 
     const result = await generateImageSync(
       {
@@ -48,7 +52,9 @@ describe('media-api provider routing', () => {
 
   it('uses query auth for async image polling endpoints', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-      expect(String(input)).toBe('https://gateway.example.com/v1/videos/task-1?key=secret');
+      expect(String(input)).toBe(
+        'https://gateway.example.com/v1/videos/task-1?key=secret'
+      );
 
       return new Response(
         JSON.stringify({
@@ -77,31 +83,49 @@ describe('media-api provider routing', () => {
   });
 
   it('submits async image reference images and mask to /v1/videos form data', async () => {
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      if (String(input) === 'data:image/png;base64,abc123') {
-        return new Response(new Blob(['ref'], { type: 'image/png' }), {
-          status: 200,
-        });
-      }
-      if (String(input) === 'data:image/png;base64,mask123') {
-        return new Response(new Blob(['mask'], { type: 'image/png' }), {
-          status: 200,
-        });
-      }
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === 'data:image/png;base64,abc123') {
+          return new Response(new Blob(['ref'], { type: 'image/png' }), {
+            status: 200,
+          });
+        }
+        if (String(input) === 'data:image/png;base64,mask123') {
+          return new Response(new Blob(['mask'], { type: 'image/png' }), {
+            status: 200,
+          });
+        }
 
-      if (String(input) === 'https://gateway.example.com/v1/videos') {
-        expect(init?.body).toBeInstanceOf(FormData);
-        const formData = init?.body as FormData;
-        expect(formData.get('model')).toBe('gpt-image-2');
-        expect(formData.get('prompt')).toBe('edit with reference');
-        expect(formData.get('size')).toBe('1:1');
-        expect(formData.get('input_reference')).toBeInstanceOf(Blob);
-        expect(formData.get('mask')).toBeInstanceOf(Blob);
+        if (String(input) === 'https://gateway.example.com/v1/videos') {
+          expect(init?.body).toBeInstanceOf(FormData);
+          const formData = init?.body as FormData;
+          expect(formData.get('model')).toBe('gpt-image-2');
+          expect(formData.get('prompt')).toBe('edit with reference');
+          expect(formData.get('size')).toBe('1:1');
+          expect(formData.get('input_reference')).toBeInstanceOf(Blob);
+          expect(formData.get('mask')).toBeInstanceOf(Blob);
 
+          return new Response(
+            JSON.stringify({
+              id: 'task-1',
+              status: 'completed',
+              progress: 100,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          );
+        }
+
+        expect(String(input)).toBe(
+          'https://gateway.example.com/v1/videos/task-1'
+        );
         return new Response(
           JSON.stringify({
             id: 'task-1',
             status: 'completed',
+            url: 'https://cdn.example.com/final.png',
             progress: 100,
           }),
           {
@@ -110,21 +134,7 @@ describe('media-api provider routing', () => {
           }
         );
       }
-
-      expect(String(input)).toBe('https://gateway.example.com/v1/videos/task-1');
-      return new Response(
-        JSON.stringify({
-          id: 'task-1',
-          status: 'completed',
-          url: 'https://cdn.example.com/final.png',
-          progress: 100,
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    });
+    );
 
     const result = await generateImageAsync(
       {
@@ -151,24 +161,26 @@ describe('media-api provider routing', () => {
   });
 
   it('uses bearer auth for shared video submission', async () => {
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe('https://video.example.com/v1/videos');
-      const headers = init?.headers as Record<string, string>;
-      expect(headers.Authorization).toBe('Bearer video-secret');
-      expect(init?.method).toBe('POST');
-      expect(init?.body).toBeInstanceOf(FormData);
+    const fetchImpl = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe('https://video.example.com/v1/videos');
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBe('Bearer video-secret');
+        expect(init?.method).toBe('POST');
+        expect(init?.body).toBeInstanceOf(FormData);
 
-      return new Response(
-        JSON.stringify({
-          id: 'video-task-1',
-          status: 'queued',
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    });
+        return new Response(
+          JSON.stringify({
+            id: 'video-task-1',
+            status: 'queued',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+    );
 
     const remoteId = await submitVideoGeneration(
       {
@@ -185,5 +197,50 @@ describe('media-api provider routing', () => {
 
     expect(remoteId).toBe('video-task-1');
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('summarizes provider reCAPTCHA video submission failures', async () => {
+    const rawError = {
+      error: {
+        code: 403,
+        message: 'reCAPTCHA evaluation failed',
+        status: 'PERMISSION_DENIED',
+        details: [
+          {
+            '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+            reason: 'PUBLIC_ERROR_UNUSUAL_ACTIVITY',
+          },
+        ],
+      },
+    };
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify(rawError), {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+
+    await expect(
+      submitVideoGeneration(
+        {
+          prompt: 'make a video',
+          model: 'omni-flash',
+        },
+        {
+          apiKey: 'video-secret',
+          baseUrl: 'https://video.example.com/v1',
+          authType: 'bearer',
+          fetchImpl,
+        }
+      )
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_RECAPTCHA_BLOCKED',
+      message:
+        '供应商风控拦截：当前视频模型触发 reCAPTCHA/异常流量校验，请换用 Seedance/Veo 其他模型或稍后重试。',
+      rawResponse: JSON.stringify(rawError),
+      status: 403,
+    });
   });
 });

--- a/packages/drawnix/src/services/media-api/video-api.ts
+++ b/packages/drawnix/src/services/media-api/video-api.ts
@@ -28,6 +28,7 @@ import {
 import { prepareVideoReferenceImageBlob } from '../video-reference-image-utils';
 
 const DURATION_IN_MODEL_PREFIX = 'sora-2-';
+const PROVIDER_ERROR_PREVIEW_LIMIT = 1000;
 const durationEncodedInModel = (model?: string | null) =>
   Boolean(model && model.startsWith(DURATION_IN_MODEL_PREFIX));
 
@@ -40,6 +41,128 @@ export class VideoGenerationFailedError extends Error {
     super(message);
     this.name = 'VideoGenerationFailedError';
   }
+}
+
+export class ProviderHttpError extends Error {
+  public readonly status: number;
+  public readonly rawResponse: string;
+  public readonly code: string;
+
+  constructor(params: {
+    status: number;
+    message: string;
+    rawResponse: string;
+    code?: string;
+  }) {
+    super(params.message);
+    this.name = 'ProviderHttpError';
+    this.status = params.status;
+    this.rawResponse = params.rawResponse;
+    this.code = params.code || `HTTP_${params.status}`;
+  }
+}
+
+function extractProviderErrorMessage(rawText: string): string {
+  const trimmed = rawText.trim();
+  if (!trimmed) return '';
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: string;
+      detail?: string;
+      error?:
+        | string
+        | {
+            code?: unknown;
+            message?: unknown;
+            status?: unknown;
+            details?: Array<{
+              reason?: unknown;
+              metadata?: {
+                reason?: unknown;
+              };
+            }>;
+          };
+    };
+    if (typeof parsed.error === 'string') return parsed.error;
+
+    const error = parsed.error;
+    const reason =
+      error?.details?.find(
+        (item) =>
+          typeof item.reason === 'string' ||
+          typeof item.metadata?.reason === 'string'
+      )?.reason ||
+      error?.details?.find((item) => typeof item.metadata?.reason === 'string')
+        ?.metadata?.reason;
+    const message =
+      (typeof error?.message === 'string' ? error.message : '') ||
+      (typeof parsed.message === 'string' ? parsed.message : '') ||
+      (typeof parsed.detail === 'string' ? parsed.detail : '');
+    return [message, reason].filter(Boolean).join(' ').trim();
+  } catch {
+    return trimmed.replace(/\s+/g, ' ');
+  }
+}
+
+async function readResponseTextPreview(
+  response: Response,
+  limit = PROVIDER_ERROR_PREVIEW_LIMIT
+): Promise<string> {
+  if (!response.body) {
+    try {
+      return (await response.clone().text()).slice(0, limit);
+    } catch {
+      return '';
+    }
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+
+  try {
+    while (text.length < limit) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    if (text.length >= limit) {
+      await reader.cancel().catch(() => undefined);
+    }
+  } catch {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  return text.slice(0, limit);
+}
+
+function buildVideoSubmissionHttpError(
+  status: number,
+  rawResponse: string
+): ProviderHttpError {
+  const providerMessage = extractProviderErrorMessage(rawResponse);
+  const combined = `${providerMessage} ${rawResponse}`;
+  const isRecaptchaBlocked =
+    status === 403 &&
+    /recaptcha|PUBLIC_ERROR_UNUSUAL_ACTIVITY|unusual activity/i.test(combined);
+
+  if (isRecaptchaBlocked) {
+    return new ProviderHttpError({
+      status,
+      code: 'PROVIDER_RECAPTCHA_BLOCKED',
+      message:
+        '供应商风控拦截：当前视频模型触发 reCAPTCHA/异常流量校验，请换用 Seedance/Veo 其他模型或稍后重试。',
+      rawResponse,
+    });
+  }
+
+  return new ProviderHttpError({
+    status,
+    message: providerMessage || `视频提交失败：HTTP ${status}`,
+    rawResponse,
+  });
 }
 
 /**
@@ -73,10 +196,7 @@ export async function submitVideoGeneration(
   formData.append('model', submission.model);
   formData.append('prompt', params.prompt);
 
-  if (
-    submission.duration &&
-    !durationEncodedInModel(submission.model)
-  ) {
+  if (submission.duration && !durationEncodedInModel(submission.model)) {
     formData.append(submission.durationField, String(submission.duration));
   }
 
@@ -113,14 +233,16 @@ export async function submitVideoGeneration(
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Video submission failed: ${response.status} - ${errorText}`);
+    const errorText = await readResponseTextPreview(response);
+    throw buildVideoSubmissionHttpError(response.status, errorText);
   }
 
   const data = await response.json();
 
   if (data.status === 'failed') {
-    throw new VideoGenerationFailedError(parseErrorMessage(data.error) || '视频生成失败');
+    throw new VideoGenerationFailedError(
+      parseErrorMessage(data.error) || '视频生成失败'
+    );
   }
 
   if (!data.id) {
@@ -175,11 +297,7 @@ export async function pollVideoUntilComplete(
   config: VideoApiConfig,
   options: PollingOptions = {}
 ): Promise<VideoStatusResponse> {
-  const {
-    onProgress,
-    signal,
-    interval = 5000,
-  } = options;
+  const { onProgress, signal, interval = 5000 } = options;
   const fetchFn = config.fetchImpl || fetch;
   const baseUrl = normalizeApiBase(config.baseUrl);
   const providerContext = buildProviderContextFromApiConfig(config, baseUrl);
@@ -215,7 +333,10 @@ export async function pollVideoUntilComplete(
         }
 
         // 指数退避
-        const backoffInterval = Math.min(interval * Math.pow(1.5, consecutiveErrors), 60000);
+        const backoffInterval = Math.min(
+          interval * Math.pow(1.5, consecutiveErrors),
+          60000
+        );
         await sleep(backoffInterval, signal);
         attempts++;
         continue;
@@ -225,7 +346,8 @@ export async function pollVideoUntilComplete(
       consecutiveErrors = 0;
 
       const data: VideoStatusResponse = await response.json();
-      const status = data.status?.toLowerCase() as VideoStatusResponse['status'];
+      const status =
+        data.status?.toLowerCase() as VideoStatusResponse['status'];
 
       // 更新进度
       const progress = data.progress ?? Math.min(10 + attempts * 2, 90);
@@ -239,7 +361,9 @@ export async function pollVideoUntilComplete(
 
       // 检查失败状态 - 业务失败不应重试
       if (status === 'failed' || status === 'error') {
-        throw new VideoGenerationFailedError(parseErrorMessage(data.error) || '视频生成失败');
+        throw new VideoGenerationFailedError(
+          parseErrorMessage(data.error) || '视频生成失败'
+        );
       }
 
       // 等待下一次轮询
@@ -267,7 +391,10 @@ export async function pollVideoUntilComplete(
         throw err;
       }
 
-      const backoffInterval = Math.min(interval * Math.pow(1.5, consecutiveErrors), 60000);
+      const backoffInterval = Math.min(
+        interval * Math.pow(1.5, consecutiveErrors),
+        60000
+      );
       await sleep(backoffInterval, signal);
       attempts++;
     }

--- a/packages/drawnix/src/services/task-queue-service.ts
+++ b/packages/drawnix/src/services/task-queue-service.ts
@@ -132,12 +132,7 @@ function areStorageSyncValuesEqual(left: unknown, right: unknown): boolean {
     return true;
   }
 
-  if (
-    left &&
-    right &&
-    typeof left === 'object' &&
-    typeof right === 'object'
-  ) {
+  if (left && right && typeof left === 'object' && typeof right === 'object') {
     const leftJson = stableStringify(left);
     const rightJson = stableStringify(right);
     return leftJson !== undefined && leftJson === rightJson;
@@ -146,7 +141,10 @@ function areStorageSyncValuesEqual(left: unknown, right: unknown): boolean {
   return false;
 }
 
-function hasStorageTaskChanges(task: Task, storageTask: Partial<Task>): boolean {
+function hasStorageTaskChanges(
+  task: Task,
+  storageTask: Partial<Task>
+): boolean {
   return STORAGE_SYNC_FIELDS.some((field) => {
     if (!(field in storageTask)) {
       return false;
@@ -235,10 +233,7 @@ function trackTaskAnalytics(
 
 function isTrackedTerminalTaskStatus(
   status: TaskStatus
-): status is
-  | TaskStatus.COMPLETED
-  | TaskStatus.FAILED
-  | TaskStatus.CANCELLED {
+): status is TaskStatus.COMPLETED | TaskStatus.FAILED | TaskStatus.CANCELLED {
   return (
     status === TaskStatus.COMPLETED ||
     status === TaskStatus.FAILED ||
@@ -1159,12 +1154,20 @@ class TaskQueueService {
       const localTask = this.tasks.get(task.id);
       if (localTask) {
         const now = Date.now();
+        const originalError =
+          typeof error.rawResponse === 'string'
+            ? error.rawResponse
+            : error.message || String(error);
         const failedTask: Task = {
           ...localTask,
           status: TaskStatus.FAILED,
           error: {
-            code: 'EXECUTION_ERROR',
+            code: error.code || 'EXECUTION_ERROR',
             message: error.message || 'Task execution failed',
+            details: {
+              originalError,
+              timestamp: now,
+            },
           },
           updatedAt: now,
           completedAt: now,
@@ -2082,9 +2085,9 @@ class TaskQueueService {
   }
 
   async findImageTaskByResultUrl(imageUrl: string): Promise<Task | undefined> {
-    const memoryMatch = this
-      .getAllTasks()
-      .find((task) => imageTaskMatchesUrl(task, imageUrl));
+    const memoryMatch = this.getAllTasks().find((task) =>
+      imageTaskMatchesUrl(task, imageUrl)
+    );
     if (memoryMatch) {
       return this.getCompleteTask(memoryMatch.id);
     }
@@ -2157,10 +2160,7 @@ class TaskQueueService {
    *
    * @param taskId - The task ID to retry
    */
-  retryTask(
-    taskId: string,
-    options: { allowCompleted?: boolean } = {}
-  ): void {
+  retryTask(taskId: string, options: { allowCompleted?: boolean } = {}): void {
     const task = this.tasks.get(taskId);
     if (!task) {
       console.warn(`[TaskQueueService] Task ${taskId} not found`);

--- a/packages/drawnix/src/utils/batch-video-generation.test.ts
+++ b/packages/drawnix/src/utils/batch-video-generation.test.ts
@@ -69,6 +69,17 @@ describe('batch-video-generation retry classification', () => {
 
     expect(reason).toBeNull();
   });
+
+  it('keeps provider reCAPTCHA blocks retryable', () => {
+    const reason = getNonRetryableBatchVideoFailureReason(
+      buildFailedTask(
+        '供应商风控拦截：当前视频模型触发 reCAPTCHA/异常流量校验，请换用 Seedance/Veo 其他模型或稍后重试。',
+        'PROVIDER_RECAPTCHA_BLOCKED'
+      )
+    );
+
+    expect(reason).toBeNull();
+  });
 });
 
 describe('buildBatchVideoReferenceImages', () => {
@@ -99,8 +110,12 @@ describe('buildBatchVideoReferenceImages', () => {
 
     expect(result.referenceImages?.[0]).toBe('char-url');
     expect(result.referenceImageDescriptions?.[0]).toContain('角色参考图');
-    expect(result.referenceImageDescriptions?.[0]).toContain('不表示时间顺序、动作或剧情');
-    expect(result.referenceImageDescriptions?.[1]).toContain('优先于故事上下文');
+    expect(result.referenceImageDescriptions?.[0]).toContain(
+      '不表示时间顺序、动作或剧情'
+    );
+    expect(result.referenceImageDescriptions?.[1]).toContain(
+      '优先于故事上下文'
+    );
     expect(result.referenceImageDescriptions?.[2]).toContain('全局/补充参考图');
   });
 });

--- a/packages/drawnix/src/utils/batch-video-generation.ts
+++ b/packages/drawnix/src/utils/batch-video-generation.ts
@@ -55,8 +55,7 @@ function buildVideoFailureText(
 ): string {
   return [task?.error?.code, task?.error?.message, fallbackError]
     .filter(
-      (item): item is string =>
-        typeof item === 'string' && item.trim() !== ''
+      (item): item is string => typeof item === 'string' && item.trim() !== ''
     )
     .join(' ');
 }
@@ -67,6 +66,10 @@ export function getNonRetryableBatchVideoFailureReason(
 ): string | null {
   const failureText = buildVideoFailureText(task, fallbackError);
   if (!failureText) {
+    return null;
+  }
+
+  if (/\bPROVIDER_RECAPTCHA_BLOCKED\b/i.test(failureText)) {
     return null;
   }
 
@@ -102,7 +105,13 @@ export function getNonRetryableBatchVideoFailureReason(
 export function buildBatchVideoReferenceImages(
   params: BuildBatchVideoReferenceImagesParams
 ): BatchVideoReferenceResult {
-  const { model, firstFrameUrl, lastFrameUrl, extraReferenceUrls = [], characterReferenceUrls = [] } = params;
+  const {
+    model,
+    firstFrameUrl,
+    lastFrameUrl,
+    extraReferenceUrls = [],
+    characterReferenceUrls = [],
+  } = params;
   const config = getVideoModelConfig(model);
   const urls: string[] = [];
   const descriptions: string[] = [];
@@ -115,31 +124,53 @@ export function buildBatchVideoReferenceImages(
   };
 
   if (config.imageUpload.mode === 'frames') {
-    append(firstFrameUrl, '首帧图：只表示视频起始画面状态，视频必须从这张图开始，优先于故事上下文。');
-    append(lastFrameUrl, '尾帧图：只表示视频结束画面状态，视频应自然过渡到这张图，优先于故事上下文。');
-    const referenceImages = urls.length > 0 ? urls.slice(0, config.imageUpload.maxCount) : undefined;
+    append(
+      firstFrameUrl,
+      '首帧图：只表示视频起始画面状态，视频必须从这张图开始，优先于故事上下文。'
+    );
+    append(
+      lastFrameUrl,
+      '尾帧图：只表示视频结束画面状态，视频应自然过渡到这张图，优先于故事上下文。'
+    );
+    const referenceImages =
+      urls.length > 0 ? urls.slice(0, config.imageUpload.maxCount) : undefined;
     const referenceImageDescriptions = referenceImages
       ? descriptions.slice(0, referenceImages.length)
       : undefined;
     // frames 模式槽位被首尾帧占满，角色参考图只能通过 prompt 注入
-    const unusedCharacterReferenceUrls = characterReferenceUrls.length > 0 ? characterReferenceUrls : undefined;
-    return { referenceImages, referenceImageDescriptions, unusedCharacterReferenceUrls };
+    const unusedCharacterReferenceUrls =
+      characterReferenceUrls.length > 0 ? characterReferenceUrls : undefined;
+    return {
+      referenceImages,
+      referenceImageDescriptions,
+      unusedCharacterReferenceUrls,
+    };
   }
 
   // 非 frames 模式：角色参考图优先，然后是首帧，再是额外参考图
   for (const url of characterReferenceUrls) {
-    append(url, '角色参考图：仅用于锁定人物身份、脸型、发型、服装、材质和气质，不表示时间顺序、动作或剧情。');
+    append(
+      url,
+      '角色参考图：仅用于锁定人物身份、脸型、发型、服装、材质和气质，不表示时间顺序、动作或剧情。'
+    );
     if (urls.length >= config.imageUpload.maxCount) break;
   }
-  append(firstFrameUrl, '首帧图：只表示视频起始画面状态，视频必须从这张图开始，优先于故事上下文。');
+  append(
+    firstFrameUrl,
+    '首帧图：只表示视频起始画面状态，视频必须从这张图开始，优先于故事上下文。'
+  );
   for (const url of extraReferenceUrls) {
-    append(url, '全局/补充参考图：仅用于主体、产品、场景、风格或色彩一致性，不表示时间顺序、动作或剧情。');
+    append(
+      url,
+      '全局/补充参考图：仅用于主体、产品、场景、风格或色彩一致性，不表示时间顺序、动作或剧情。'
+    );
     if (urls.length >= config.imageUpload.maxCount) break;
   }
 
   return {
     referenceImages: urls.length > 0 ? urls : undefined,
-    referenceImageDescriptions: descriptions.length > 0 ? descriptions : undefined,
+    referenceImageDescriptions:
+      descriptions.length > 0 ? descriptions : undefined,
   };
 }
 

--- a/qa/2026-06-10-多图生成供应商错误恢复测试/2026-06-10-多图生成供应商错误恢复测试.md
+++ b/qa/2026-06-10-多图生成供应商错误恢复测试/2026-06-10-多图生成供应商错误恢复测试.md
@@ -1,0 +1,184 @@
+# 多图生成与供应商错误恢复网页版测试清单
+
+**目的**: 验证多图生成 JSON 解析、旧默认模型迁移、供应商 reCAPTCHA 403 错误展示和重试行为。
+**创建日期**: 2026-06-10
+**功能**: 工具箱多图生成、AI 图片/视频任务队列、供应商错误恢复
+**关联经验文档**: [docs/MULTI_IMAGE_PROVIDER_ERROR_RECOVERY_LESSONS.md](../../docs/MULTI_IMAGE_PROVIDER_ERROR_RECOVERY_LESSONS.md)
+
+## 测试入口
+
+优先使用本次 PR 对应的网页版预览地址；如无独立预览环境，使用线上站点：
+
+- 正式站点: `https://opentu.ai`
+- 预览站点: `https://pr.opentu.ai`
+
+## 网页版快速验证步骤
+
+### 方法 1: 多图生成规划成功
+
+1. 打开网页版测试地址。
+2. 进入画布页，打开工具箱。
+3. 进入“多图生成”。
+4. 使用默认文本模型和默认图片模型，输入 3-6 页多图需求。
+5. 点击生成规划，等待规划任务完成。
+
+**结果判断**:
+
+- ✅ 页面生成分镜/页面规划。
+- ✅ 不出现“响应中未找到有效 JSON”。
+- ✅ 如果失败，错误文案包含“提示词规划未返回可解析 JSON”和响应预览。
+
+### 方法 2: 旧默认图片模型迁移
+
+1. 使用已有账号或浏览器环境打开网页版测试地址。
+2. 进入图片生成或多图生成模型选择。
+3. 查看默认图片模型。
+4. 如账号/浏览器曾使用旧默认模型 `gpt-image-2-vip`，刷新页面后再次查看默认图片模型。
+
+**结果判断**:
+
+- ✅ 默认图片模型显示为 `gpt-image-2`。
+- ✅ 不再自动回到 `gpt-image-2-vip`。
+- ✅ 如果用户手动选择 profile 绑定的 `gpt-image-2-vip`，刷新后不被强制覆盖。
+
+### 方法 3: 视频 reCAPTCHA 403 错误展示
+
+1. 选择视频生成。
+2. 选择容易触发该问题的 `Gemini Omni Flash / omni-flash`。
+3. 提交一个视频任务。
+4. 如果供应商返回 reCAPTCHA 403，查看任务列表。
+
+**结果判断**:
+
+- ✅ 任务列表只显示短错误：
+  `供应商风控拦截：当前视频模型触发 reCAPTCHA/异常流量校验，请换用 Seedance/Veo 其他模型或稍后重试。`
+- ✅ 列表主体不直接显示整段 JSON。
+- ✅ 点击 `[详情]` 可查看原始 provider 响应。
+- ✅ 任务仍显示“重试”，不被当成永久参数错误。
+
+## 开发回归参考
+
+以下命令仅供开发回归使用，网页版 QA 主流程不要求在本地启动服务：
+
+```bash
+pnpm --dir packages/drawnix exec vitest run \
+  src/components/comic-creator/storage.test.ts \
+  src/utils/__tests__/settings-manager.test.ts \
+  src/utils/llm-json-extractor.test.ts \
+  src/components/comic-creator/task-sync.test.ts \
+  src/components/comic-creator/utils.test.ts \
+  src/services/__tests__/media-api-routing.test.ts \
+  src/utils/batch-video-generation.test.ts \
+  --no-file-parallelism --maxWorkers=1
+
+pnpm --dir packages/drawnix exec tsc --noEmit --pretty false
+pnpm --dir packages/drawnix exec prettier --check \
+  src/components/comic-creator/storage.ts \
+  src/components/comic-creator/storage.test.ts \
+  src/components/comic-creator/task-sync.ts \
+  src/components/comic-creator/ComicCreator.tsx \
+  src/utils/settings-manager.ts \
+  src/utils/settings-types.ts \
+  src/utils/llm-json-extractor.ts \
+  src/utils/llm-json-extractor.test.ts \
+  src/services/media-executor/fallback-executor.ts \
+  src/services/media-api/video-api.ts \
+  src/services/task-queue-service.ts \
+  src/services/__tests__/media-api-routing.test.ts \
+  src/utils/batch-video-generation.ts \
+  src/utils/batch-video-generation.test.ts \
+  src/constants/model-config.ts
+git diff --check
+```
+
+**开发回归通过标准**:
+
+- `vitest` 全部通过。
+- `tsc` 无类型错误。
+- `prettier --check` 通过。
+- `git diff --check` 无尾随空白或冲突标记。
+
+## 手动回归测试清单
+
+### 多图生成
+
+- [ ] 新建多图生成规划，能正常产出页面规划。
+- [ ] Google-style `candidates[].content.parts[].text` 响应能被解析。
+- [ ] OpenAI-style `message.content[]` 响应能被解析。
+- [ ] 解析失败时展示可诊断预览，而不是裸异常。
+- [ ] 多图生成默认图片模型为 `gpt-image-2`。
+- [ ] 旧多图记录中的无 profile 旧默认模型会迁移到 `gpt-image-2`。
+- [ ] profile 绑定的旧模型选择不会被迁移覆盖。
+
+### 任务队列
+
+- [ ] 图片任务 403/500 错误不会导致页面卡死。
+- [ ] 文本任务非 2xx 错误显示 provider 摘要，不显示泛化 `Text generation failed`。
+- [ ] 错误详情中保留原始响应。
+- [ ] 清除失败任务、重试失败任务、插入成功任务仍可用。
+
+### 视频生成
+
+- [ ] `omni-flash` reCAPTCHA 403 显示中文短提示。
+- [ ] `omni-flash` reCAPTCHA 403 原始 JSON 只出现在详情里。
+- [ ] reCAPTCHA 403 任务可重试。
+- [ ] 参数错误类 400/422 仍按不可重试错误处理。
+- [ ] 换用 `seedance-1.5-pro` 或其他可用视频模型后能重新提交。
+
+### 性能与安全
+
+- [ ] 错误响应读取有长度上限，不读取完整大响应。
+- [ ] 多图记录只保存 URL、模型 ID 和轻量参数，不保存 base64 大对象。
+- [ ] 刷新页面后任务恢复不丢失 `invocationRoute`。
+- [ ] 不把 API Key 写入任务详情或错误详情。
+
+## 常见问题排查
+
+### 问题 1: 旧任务仍显示大段 JSON
+
+**原因**: 旧失败任务已经把原始错误写入了 storage。
+
+**处理**:
+
+- 点击“重试”让任务重新经过新错误归一化。
+- 或清除旧失败任务后重新提交。
+
+### 问题 2: `omni-flash` 仍然 403
+
+**原因**: 这是供应商 reCAPTCHA/异常流量风控，前端不能绕过。
+
+**处理**:
+
+- 换用 `seedance-1.5-pro`、Veo 或其它视频模型。
+- 稍后重试。
+- 检查供应商账号、IP、代理和调用频率。
+
+### 问题 3: 多图规划仍提示 JSON 解析失败
+
+**排查步骤**:
+
+1. 打开失败任务详情。
+2. 查看响应预览是否为空、截断或是自然语言。
+3. 如果是新的供应商 envelope，在 `llm-json-extractor.ts` 中补共享提取规则。
+4. 补充对应单测，不在业务组件里临时字符串切割。
+
+## 验证成功标准
+
+所有以下条件满足，说明本次修复通过：
+
+1. ✅ 多图规划不再因常见 Google/OpenAI envelope 报“响应中未找到有效 JSON”。
+2. ✅ 默认图片模型和旧记录迁移到 `gpt-image-2`。
+3. ✅ reCAPTCHA 403 显示中文短提示，不污染任务列表。
+4. ✅ 原始错误仍能通过详情查看。
+5. ✅ 风控 403 可重试，参数错误仍能被识别为不可重试。
+6. ✅ 自动化测试、类型检查、格式检查和 diff 检查全部通过。
+
+## 报告问题
+
+如果验证失败，请提供：
+
+1. 失败任务的模型 ID 和任务类型。
+2. 任务列表错误文案截图。
+3. `[详情]` 中的原始错误，注意不要包含 API Key。
+4. 浏览器控制台错误。
+5. 测试环境地址、浏览器版本和账号是否绑定自定义模型 profile。


### PR DESCRIPTION
## 问题描述\n- 视频任务遇到 Google reCAPTCHA/异常流量 403 时，任务列表会直接展示大段 provider JSON。\n- 批量视频逻辑可能把风控拦截误判为不可重试错误，导致用户无法通过重试恢复。\n- 本次也补充了多图生成/供应商错误恢复的经验文档和网页版 QA 测试目录。\n\n## 修复思路\n- 在 `media-api/video-api.ts` 识别 reCAPTCHA 与 `PUBLIC_ERROR_UNUSUAL_ACTIVITY`，转换为短中文提示和 `PROVIDER_RECAPTCHA_BLOCKED` 错误码。\n- 错误响应限长读取，任务队列展示短 message，并将原始响应保留到 `details.originalError`。\n- 批量视频对风控错误保持可重试。\n\n## 更新代码架构\n- 供应商 HTTP 错误归一化收敛到 media-api 层。\n- task queue 只负责失败态持久化和详情保留。\n- 新增 docs 经验沉淀与 qa 网页版测试目录。\n\n## 验证\n- pnpm --dir packages/drawnix exec vitest run src/services/__tests__/media-api-routing.test.ts src/utils/batch-video-generation.test.ts --no-file-parallelism --maxWorkers=1\n- /Users/shuidiyu/opentu/node_modules/.bin/tsc --noEmit --pretty false（在 PR worktree 的 packages/drawnix 下执行）\n- prettier --check 目标文件\n- git diff --check HEAD~1..HEAD\n\n备注：`origin` 无写权限，已通过 fork `selwen-0102/opentu` 提交 PR。