### PR TITLE
Feat/batch image group canvas insertion

### DIFF
--- a/docs/BATCH_IMAGE_GROUP_CANVAS_INSERTION_LESSONS.md
+++ b/docs/BATCH_IMAGE_GROUP_CANVAS_INSERTION_LESSONS.md
@@ -1,0 +1,41 @@
+# 批量出图按提交批次分组插入画布
+
+## 背景
+
+批量出图工具生成的图片插入画布后随机分布，用户无法直观区分不同批次提交的图片。需要让同一次提交产出的图片在画布上自动分组排列，不同批次之间有明显分隔。
+
+## 方案
+
+### 分组键传递
+
+在批量出图组件 `batch-image-generation.tsx` 的 `executeSubmit` 中，为每个任务添加 `batchGroupId` 参数，值为 `batch-submit-${globalBatchTimestamp}`。同一批次提交的所有任务共享相同的时间戳，因此共享相同的分组键。
+
+### 分组键识别
+
+在 `image-generation-anchor-task.ts` 的 `getImageGenerationTaskInsertGroupKey` 函数顶部新增判断：
+
+```typescript
+if (typeof task.params.batchGroupId === 'string') {
+  return `batch-row:${task.params.batchGroupId}`;
+}
+```
+
+该判断在所有其他分组逻辑之前执行，确保批量出图任务优先按批次分组。
+
+### 画布排列
+
+`executeCanvasInsertion` 已内置 `precalculateGroupedGridLayout` 逻辑：
+- 同 `groupId` 的图片在网格中水平排列，超出画布宽度自动换行
+- 不同 `groupId` 的图片组之间垂直分隔（默认 50px 间距）
+
+## 影响范围
+
+- **仅影响批量出图工具**：`batchGroupId` 只有该工具设置，其他功能（AI 对话出图、PPT 出图、单张出图等）完全不受影响
+- 所有现有测试用例（13 个）通过，无回归
+
+## 涉及文件
+
+| 文件 | 改动 |
+|------|------|
+| `packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx` | 任务参数新增 `batchGroupId` |
+| `packages/drawnix/src/utils/image-generation-anchor-task.ts` | `getImageGenerationTaskInsertGroupKey` 新增 `batchGroupId` 判断 |

--- a/docs/BATCH_IMAGE_GROUP_CANVAS_INSERTION_LESSONS.md
+++ b/docs/BATCH_IMAGE_GROUP_CANVAS_INSERTION_LESSONS.md
@@ -33,9 +33,20 @@ if (typeof task.params.batchGroupId === 'string') {
 - **仅影响批量出图工具**：`batchGroupId` 只有该工具设置，其他功能（AI 对话出图、PPT 出图、单张出图等）完全不受影响
 - 所有现有测试用例（13 个）通过，无回归
 
+### 用户提示
+
+在"生成选中行"按钮上添加 `HoverTip`，鼠标悬停时展示分组说明：
+- 中文: "同批次生成的图片将在画布上自动分组排列，不同批次间垂直分隔"
+- 英文: "Images from the same batch will be grouped together on the canvas"
+
+## 影响范围
+
+- **仅影响批量出图工具**：`batchGroupId` 只有该工具设置，其他功能（AI 对话出图、PPT 出图、单张出图等）完全不受影响
+- 所有现有测试用例（13 个）通过，无回归
+
 ## 涉及文件
 
 | 文件 | 改动 |
 |------|------|
-| `packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx` | 任务参数新增 `batchGroupId` |
+| `packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx` | 任务参数新增 `batchGroupId`；生成按钮添加 HoverTip 分组提示 |
 | `packages/drawnix/src/utils/image-generation-anchor-task.ts` | `getImageGenerationTaskInsertGroupKey` 新增 `batchGroupId` 判断 |

--- a/packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx
+++ b/packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx
@@ -3314,26 +3314,35 @@ const BatchImageGeneration: React.FC<BatchImageGenerationProps> = ({
               />
             </div>
 
-            <Button
-              theme="primary"
-              onClick={submitToQueue}
-              loading={isSubmitting}
-              disabled={isSubmitting}
-              className="batch-generate-btn"
-              data-track="batch_generate_click"
-              data-track-params={JSON.stringify({
-                selectedRows: selectedRows.size,
-                model: selectedModel,
-              })}
+            <HoverTip
+              content={
+                language === 'zh'
+                  ? '同批次生成的图片将在画布上自动分组排列，不同批次间垂直分隔'
+                  : 'Images from the same batch will be grouped together on the canvas'
+              }
+              theme="light"
             >
-              {isSubmitting
-                ? language === 'zh'
-                  ? '提交中...'
-                  : 'Submitting...'
-                : language === 'zh'
-                ? '生成选中行'
-                : 'Generate Selected'}
-            </Button>
+              <Button
+                theme="primary"
+                onClick={submitToQueue}
+                loading={isSubmitting}
+                disabled={isSubmitting}
+                className="batch-generate-btn"
+                data-track="batch_generate_click"
+                data-track-params={JSON.stringify({
+                  selectedRows: selectedRows.size,
+                  model: selectedModel,
+                })}
+              >
+                {isSubmitting
+                  ? language === 'zh'
+                    ? '提交中...'
+                    : 'Submitting...'
+                  : language === 'zh'
+                  ? '生成选中行'
+                  : 'Generate Selected'}
+              </Button>
+            </HoverTip>
 
             <span className="toolbar-divider"></span>
 

--- a/packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx
+++ b/packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx
@@ -2168,6 +2168,7 @@ const BatchImageGeneration: React.FC<BatchImageGenerationProps> = ({
               batchTotal: generateCount,
               globalIndex: subTaskCounter,
               autoInsertToCanvas: true,
+              batchGroupId: `batch-submit-${globalBatchTimestamp}`,
               ...(adapterParams ? { params: adapterParams } : {}),
             };
 

--- a/packages/drawnix/src/utils/image-generation-anchor-task.ts
+++ b/packages/drawnix/src/utils/image-generation-anchor-task.ts
@@ -58,6 +58,11 @@ export function getImageGenerationTaskInsertGroupKey(
   const batchIndex = getImageGenerationAnchorTaskBatchIndex(task);
   const fallbackGroupKey = workflowId || task.params.prompt || `task:${task.id}`;
 
+  // 批量出图工具：同一行（同一 batchId）的图片分组排列
+  if (typeof task.params.batchGroupId === 'string') {
+    return `batch-row:${task.params.batchGroupId}`;
+  }
+
   if (task.type !== TaskType.IMAGE) {
     const taskGroupType =
       task.type === TaskType.AUDIO && isLyricsTask(task) ? 'lyrics' : task.type;


### PR DESCRIPTION
## 背景

批量出图工具生成的图片插入画布后随机分布，用户无法直观区分不同批次提交的图片。本次改动让同一次提交产出的图片在画布上自动分组网格排列，不同批次之间有明显分隔。

## 改动内容

### 1. 传递分组键 (`batch-image-generation.tsx`)
在 `executeSubmit` 中为每个任务添加 `batchGroupId` 参数，值为 `batch-submit-${globalBatchTimestamp}`。同一批次提交的所有任务共享相同的时间戳。

### 2. 识别分组键 (`image-generation-anchor-task.ts`)
在 `getImageGenerationTaskInsertGroupKey` 中新增 `batchGroupId` 判断，优先按批次分组。

### 3. 画布排列
复用已有的 `precalculateGroupedGridLayout` 逻辑：
- 同组图片水平网格排列，超出画布宽度自动换行
- 不同组之间垂直分隔（默认 50px 间距）

### 4. 用户提示
在"生成选中行"按钮上添加 `HoverTip`，悬停时显示分组说明。

## 影响范围

- **仅影响批量出图工具**，其他功能（AI 对话出图、PPT 出图、单张出图等）完全不受影响
- 所有现有测试用例通过，无回归

## 涉及文件

| 文件 | 改动 |
|------|------|
| `packages/drawnix/src/components/ttd-dialog/batch-image-generation.tsx` | 任务参数新增 `batchGroupId`；生成按钮添加 HoverTip |
| `packages/drawnix/src/utils/image-generation-anchor-task.ts` | 新增 `batchGroupId` 分组判断 |
| `docs/BATCH_IMAGE_GROUP_CANVAS_INSERTION_LESSONS.md` | 新增功能总结文档 |