### PR TITLE
feat: 完善图片请求 ID 找回与失败重试体验

### DIFF
--- a/apps/web/src/sw/task-queue/llm-api-logger.ts
+++ b/apps/web/src/sw/task-queue/llm-api-logger.ts
@@ -24,6 +24,7 @@ export interface LLMApiLog {
   endpoint: string; // API endpoint (e.g., /images/generations, /chat/completions)
   model: string; // 使用的模型
   taskType: 'image' | 'video' | 'audio' | 'chat' | 'character' | 'other';
+  requestId?: string; // 请求头 X-Request-Id，用于超时/失败时通过 /log/get-request 找回结果
 
   // 请求参数（脱敏后）
   prompt?: string; // 提示词
@@ -493,6 +494,7 @@ export function startLLMApiLog(params: {
   endpoint: string;
   model: string;
   taskType: LLMApiLog['taskType'];
+  requestId?: string;
   prompt?: string;
   requestBody?: string; // 完整请求体（JSON 格式，用于调试）
   hasReferenceImages?: boolean;
@@ -509,6 +511,7 @@ export function startLLMApiLog(params: {
     endpoint: params.endpoint,
     model: params.model,
     taskType: params.taskType,
+    requestId: params.requestId,
     prompt: params.prompt ? truncatePrompt(params.prompt) : undefined,
     // 对请求体进行脱敏处理，过滤 API Key 等敏感信息
     requestBody: params.requestBody
@@ -604,6 +607,28 @@ export function updateLLMApiLogMetadata(
     updateLogInDB(log);
 
     // 广播
+    if (broadcastCallback) {
+      broadcastCallback({ ...log });
+    }
+  }
+}
+
+/**
+ * 补写 LLM API 日志的 requestId 字段
+ * 用于 adapter 路径：sendAdapterRequest 内部生成 requestId 后，
+ * caller 再通过此接口回填到已创建的日志上。
+ */
+export function updateLLMApiLogRequestId(
+  logId: string,
+  requestId: string
+): void {
+  if (!requestId) return;
+  const log = memoryLogs.find((l) => l.id === logId);
+  if (log) {
+    log.requestId = requestId;
+
+    updateLogInDB(log);
+
     if (broadcastCallback) {
       broadcastCallback({ ...log });
     }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1185,6 +1185,20 @@ export default defineConfig({
       'Content-Security-Policy':
         "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' http: https: ws: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
     },
+    // dev 代理：让 API 请求走同源，规避浏览器 CORS 拦截自定义头（如 X-Request-Id）
+    // 使用方式：把 Provider 的 baseUrl 从 https://api.tu-zi.com/v1 改为 /v1
+    proxy: {
+      '/v1': {
+        target: 'https://api.tu-zi.com',
+        changeOrigin: true,
+        secure: true,
+      },
+      '/log': {
+        target: 'https://api.tu-zi.com',
+        changeOrigin: true,
+        secure: true,
+      },
+    },
   },
 
   preview: {

--- a/docs/APIFOX_TEST_CASES.md
+++ b/docs/APIFOX_TEST_CASES.md
@@ -1,0 +1,400 @@
+# X-Request-Id 找回机制 - Apifox 测试用例
+
+> 用于在 Apifox 中手动测试 X-Request-Id 注入 + `/log/get-request` 找回接口。
+
+## 环境变量
+
+在 Apifox 中设置以下环境变量：
+
+| 变量名 | 值 | 说明 |
+|--------|-----|------|
+| `baseUrl` | `https://api.tu-zi.com` | API 站地址 |
+| `apiKey` | `sk-xxxx` | 你的 API Key |
+| `requestId` | （自动生成或手动填） | UUID 格式 |
+
+---
+
+## 用例 1：正常生图 + X-Request-Id 注入
+
+**目的**：验证生图接口能正确接受 `X-Request-Id` 请求头。
+
+### 请求
+
+```
+POST {{baseUrl}}/v1/images/generations
+```
+
+**Headers:**
+
+| Key | Value |
+|-----|-------|
+| Authorization | Bearer {{apiKey}} |
+| Content-Type | application/json |
+| X-Request-Id | {{requestId}} |
+
+> `requestId` 可以在 Apifox 的"前置脚本"中自动生成：
+> ```js
+> pm.environment.set("requestId", pm.variables.replaceIn("{{$guid}}"));
+> ```
+
+**Body (JSON):**
+
+```json
+{
+  "prompt": "一只橘猫坐在窗台上，窗外是下雨天",
+  "model": "gpt-image-1",
+  "size": "1024x1024"
+}
+```
+
+### 期望响应
+
+**Status:** 200
+
+```json
+{
+  "data": [
+    {
+      "url": "https://xxx.com/generated-image.png"
+    }
+  ]
+}
+```
+
+### 后置脚本（断言）
+
+```js
+pm.test("状态码 200", function () {
+  pm.response.to.have.status(200);
+});
+
+pm.test("返回 data 数组且有 url", function () {
+  const json = pm.response.json();
+  pm.expect(json.data).to.be.an("array");
+  pm.expect(json.data.length).to.be.greaterThan(0);
+  pm.expect(json.data[0].url).to.be.a("string");
+});
+
+// 保存 requestId 以供用例 2 使用
+console.log("X-Request-Id:", pm.environment.get("requestId"));
+```
+
+---
+
+## 用例 2：通过 X-Request-Id 找回图片
+
+**目的**：验证 `/log/get-request` 能通过 requestId 找回已生成的图片。
+
+### 前置条件
+
+先执行用例 1（正常生图），记录下该次的 `requestId`。
+
+### 请求
+
+```
+GET {{baseUrl}}/log/get-request?id={{requestId}}
+```
+
+**Headers:**
+
+| Key | Value |
+|-----|-------|
+| Authorization | Bearer {{apiKey}} |
+
+### 期望响应（成功找回）
+
+**Status:** 200
+
+```json
+{
+  "status": "succeeded",
+  "data": [
+    {
+      "url": "https://xxx.com/generated-image.png"
+    }
+  ]
+}
+```
+
+### 后置脚本（断言）
+
+```js
+pm.test("状态码 200", function () {
+  pm.response.to.have.status(200);
+});
+
+pm.test("status 为 succeeded 或 success", function () {
+  const json = pm.response.json();
+  pm.expect(["succeeded", "success"]).to.include(json.status);
+});
+
+pm.test("data 数组包含 url", function () {
+  const json = pm.response.json();
+  pm.expect(json.data).to.be.an("array");
+  pm.expect(json.data.length).to.be.greaterThan(0);
+  pm.expect(json.data[0].url).to.be.a("string");
+  pm.expect(json.data[0].url).to.match(/^https?:\/\//);
+});
+```
+
+---
+
+## 用例 3：无效 requestId 找回（应失败）
+
+**目的**：验证不存在的 requestId 找回接口返回合理的错误。
+
+### 请求
+
+```
+GET {{baseUrl}}/log/get-request?id=non-existent-id-12345
+```
+
+**Headers:**
+
+| Key | Value |
+|-----|-------|
+| Authorization | Bearer {{apiKey}} |
+
+### 期望响应
+
+**Status:** 200 或 404（取决于 API 站实现）
+
+可能的返回：
+
+```json
+{
+  "status": "not_found"
+}
+```
+
+或：
+
+```json
+{
+  "status": "failed",
+  "error": "请求不存在"
+}
+```
+
+### 后置脚本（断言）
+
+```js
+pm.test("状态码为 200 或 404", function () {
+  pm.expect([200, 404]).to.include(pm.response.code);
+});
+
+pm.test("status 非 succeeded/success（找回应失败）", function () {
+  if (pm.response.code === 200) {
+    const json = pm.response.json();
+    if (json.status) {
+      pm.expect(["succeeded", "success"]).to.not.include(json.status);
+    }
+  }
+});
+```
+
+---
+
+## 用例 4：缺少 id 参数
+
+**目的**：验证找回接口对缺少参数的容错。
+
+### 请求
+
+```
+GET {{baseUrl}}/log/get-request
+```
+
+**Headers:**
+
+| Key | Value |
+|-----|-------|
+| Authorization | Bearer {{apiKey}} |
+
+### 期望响应
+
+**Status:** 400 或 422
+
+### 后置脚本
+
+```js
+pm.test("缺少 id 应返回 4xx", function () {
+  pm.expect(pm.response.code).to.be.within(400, 499);
+});
+```
+
+---
+
+## 用例 5：端到端超时模拟（完整链路）
+
+**目的**：模拟客户端实际的超时找回流程。
+
+### 步骤
+
+这是一个**流程测试**，在 Apifox 中设为"测试套件"按顺序执行：
+
+#### Step 1 - 生图（带 X-Request-Id）
+
+同用例 1，前置脚本生成 UUID：
+
+```js
+const uuid = pm.variables.replaceIn("{{$guid}}");
+pm.environment.set("requestId", uuid);
+console.log("生成的 X-Request-Id:", uuid);
+```
+
+#### Step 2 - 等待 3 秒
+
+在 Apifox 测试套件中加一个延时步骤（3000ms），模拟"生图已完成但客户端超时"的间隔。
+
+#### Step 3 - 用相同 requestId 找回
+
+同用例 2，直接读 `{{requestId}}`。
+
+#### 断言
+
+```js
+pm.test("找回的 URL 与原始生图的 URL 一致", function () {
+  const json = pm.response.json();
+  const recoveredUrl = json.data?.[0]?.url;
+  // 如果用例1把 url 存下来了可以对比
+  const originalUrl = pm.environment.get("originalImageUrl");
+  if (originalUrl) {
+    pm.expect(recoveredUrl).to.equal(originalUrl);
+  } else {
+    pm.expect(recoveredUrl).to.be.a("string");
+  }
+});
+```
+
+> 用例 1 的后置脚本加一行保存 URL：
+> ```js
+> const url = pm.response.json()?.data?.[0]?.url;
+> if (url) pm.environment.set("originalImageUrl", url);
+> ```
+
+---
+
+## 用例 6：X-Request-Id 不影响无该头的正常请求
+
+**目的**：验证不带 X-Request-Id 时，生图接口行为完全不变。
+
+### 请求
+
+```
+POST {{baseUrl}}/v1/images/generations
+```
+
+**Headers:**
+
+| Key | Value |
+|-----|-------|
+| Authorization | Bearer {{apiKey}} |
+| Content-Type | application/json |
+
+> 注意：故意**不带** X-Request-Id
+
+**Body:**
+
+```json
+{
+  "prompt": "一片星空下的海边",
+  "model": "gpt-image-1",
+  "size": "1024x1024"
+}
+```
+
+### 期望响应
+
+**Status:** 200，正常返回图片（与带 X-Request-Id 无区别）
+
+### 后置脚本
+
+```js
+pm.test("不带 X-Request-Id 也能正常生图", function () {
+  pm.response.to.have.status(200);
+  const json = pm.response.json();
+  pm.expect(json.data[0].url).to.be.a("string");
+});
+```
+
+---
+
+## 用例 7：验证 CORS 预检（浏览器场景专用）
+
+**目的**：确认 API 站的 CORS 配置是否允许 `X-Request-Id`。
+
+> 此测试在 Apifox 中模拟 OPTIONS 预检请求。
+
+### 请求
+
+```
+OPTIONS {{baseUrl}}/v1/images/generations
+```
+
+**Headers:**
+
+| Key | Value |
+|-----|-------|
+| Origin | http://localhost:7200 |
+| Access-Control-Request-Method | POST |
+| Access-Control-Request-Headers | authorization, content-type, x-request-id |
+
+### 期望响应
+
+**Status:** 200 或 204
+
+### 后置脚本
+
+```js
+pm.test("CORS 允许 X-Request-Id", function () {
+  const allowedHeaders = pm.response.headers.get("Access-Control-Allow-Headers");
+  pm.expect(allowedHeaders?.toLowerCase()).to.include("x-request-id");
+});
+
+// 如果这个断言失败，说明 API 站 CORS 还没加 X-Request-Id
+// 本地开发需要走 vite proxy 绕过
+pm.test("打印 CORS 响应头（调试用）", function () {
+  console.log("Allow-Headers:", pm.response.headers.get("Access-Control-Allow-Headers"));
+  console.log("Allow-Origin:", pm.response.headers.get("Access-Control-Allow-Origin"));
+  console.log("Allow-Methods:", pm.response.headers.get("Access-Control-Allow-Methods"));
+});
+```
+
+---
+
+## 测试套件运行顺序
+
+在 Apifox 中创建**自动化测试**，按以下顺序编排：
+
+| 序号 | 用例 | 说明 |
+|------|------|------|
+| 1 | 用例 7 | CORS 检查（可选，了解现状） |
+| 2 | 用例 6 | 无 X-Request-Id 基线验证 |
+| 3 | 用例 1 | 正常生图 + X-Request-Id |
+| 4 | 用例 2 | 找回（用上一步的 requestId） |
+| 5 | 用例 3 | 无效 ID 找回 |
+| 6 | 用例 4 | 缺少参数 |
+| 7 | 用例 5 | 端到端流程 |
+
+---
+
+## 快速手动测试（cURL）
+
+如果不想开 Apifox，直接在终端跑：
+
+```bash
+# 1. 生图（带 X-Request-Id）
+REQUEST_ID=$(uuidgen)
+echo "X-Request-Id: $REQUEST_ID"
+
+curl -X POST "https://api.tu-zi.com/v1/images/generations" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "X-Request-Id: $REQUEST_ID" \
+  -d '{"prompt":"一只橘猫","model":"gpt-image-1","size":"1024x1024"}'
+
+# 2. 找回
+curl "https://api.tu-zi.com/log/get-request?id=$REQUEST_ID" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```

--- a/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
+++ b/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
@@ -1,0 +1,256 @@
+# 生图超时兜底：X-Request-Id 找回机制
+
+> 版本：v1.0 · 日期：2026-07-09
+
+## 一、背景
+
+**问题场景**：使用 `api.tu-zi.com` 等 API 站生图时，偶发以下情况：
+
+- 图片实际生成成功，账户已扣费
+- 但客户端因请求超时/网络中断没拿到响应
+- 用户端显示"生图失败"，等于白白花费了 API 调用
+
+**API 站提供的能力**：
+- **生图时**：在请求头带上自定义 `X-Request-Id`
+- **超时后**：调用 `GET /log/get-request?id={requestId}` 可以找回真实的生成结果
+
+**改造目标**：让客户端在同步生图接口超时时自动走 `/log/get-request` 兜底找回，把"失败"透明地转为"成功"。
+
+## 二、总体设计
+
+### 2.1 传输层统一注入 X-Request-Id
+
+- `ProviderTransport.send()` 是所有 provider 请求的最终出口
+- 新增 `ProviderTransportRequest.requestId` 可选字段
+- 若传入 → 自动写入 `X-Request-Id` 请求头
+- 超时抛出的 `TimeoutError` 上会挂载 `.requestId`（便于上层直接兜底）
+- **向后兼容**：不传 `requestId` 时行为完全不变
+
+### 2.2 图片适配器自动生成 requestId
+
+- `sendAdapterRequest()`（`model-adapters/context.ts`）
+- 当 `context.operation === 'image'` 且 caller 未显式传入 `requestId` → **自动生成 UUID**
+- 通过 `AdapterContext.onRequestSent({ requestId })` 回调回传给 caller，便于日志/兜底
+
+### 2.3 找回接口封装
+
+- `recoverImageByRequestId(requestId, config, signal)` 位于 `media-api/image-api.ts`
+- `GET /log/get-request?id={requestId}`，使用 `baseUrlStrategy: 'trim-v1'`（此接口不带 /v1 前缀）
+- **短超时 15s**，避免兜底本身长时间挂起
+- 响应结构与生图接口一致（`{ data: [{ url }] }`），复用 `parseImageResponse` 解析
+- 若返回 `status` 非 `succeeded/success` → 抛出「找回接口返回状态非成功」
+
+### 2.4 三处调用点覆盖超时兜底
+
+| 路径 | 触发时机 | 文件 |
+|---|---|---|
+| **主线程 SW 模式 - Adapter** | tuzi/gpt-image/seedream 适配器生图超时 | `services/media-executor/fallback-adapter-routes.ts` |
+| **主线程降级模式 - 直连** | `?sw=0` 降级路径下 `/images/generations` 直连超时 | `services/media-executor/fallback-executor.ts` |
+| **同步 API 门面** | `generateImageSync()`（目前仅测试直用） | `services/media-api/image-api.ts` |
+
+三处逻辑一致：
+1. 生成 / 捕获 requestId
+2. `providerTransport.send()` catch 到 `TimeoutError`
+3. 调用 `recoverImageByRequestId()` 尝试找回
+4. **成功**：把找回的图当正常结果，走 completeLLMApiLog + 缓存 URL + 完成任务
+5. **失败**：抛出**原始超时错误**，日志的 `errorMessage` 保持"生图超时"，用户端展示保持原样
+
+### 2.5 日志字段同步
+
+- `LLMApiLog.requestId?: string`（双端 interface 同步）
+- `startLLMApiLog({ requestId })` 支持初始化时写入
+- 新增 `updateLLMApiLogRequestId(logId, requestId)` 用于 adapter 路径的后置补写（因 requestId 由 sendAdapterRequest 生成，先 log 后拿到 id）
+- IDB schema 无需迁移（`requestId` 是可选字段）
+
+## 三、代码改动清单
+
+### 3.1 类型层
+
+| 文件 | 改动 |
+|---|---|
+| `packages/drawnix/src/services/provider-routing/types.ts` | `ProviderTransportRequest` 新增 `requestId?: string` |
+| `packages/drawnix/src/services/model-adapters/types.ts` | `AdapterContext` 新增 `onRequestSent?: (info: { requestId: string }) => void` |
+
+### 3.2 传输层
+
+`packages/drawnix/src/services/provider-routing/provider-transport.ts`
+
+- 新增 `applyRequestIdHeader(headers, requestId)` 工具函数
+- `prepareRequest()` 中调用 → 写入 `X-Request-Id`
+- `send()` 中的 TimeoutError 挂上 `.requestId`
+
+### 3.3 适配器上下文
+
+`packages/drawnix/src/services/model-adapters/context.ts`
+
+- `sendAdapterRequest()` 中：
+  - 若 `context.operation === 'image'` 且 `request.requestId` 未设 → 生成 UUID
+  - 若有 requestId + `onRequestSent` → 触发回调（try/catch 保护）
+- 新增 `generateRequestId()` 兜底（`crypto.randomUUID` 优先，无则 `req-{ts}-{rand}`）
+
+### 3.4 找回接口封装
+
+`packages/drawnix/src/services/media-api/image-api.ts`
+
+- 新增常量 `RECOVER_REQUEST_TIMEOUT_MS = 15_000`
+- 新增函数 `generateRequestId()` / `isTimeoutError()` 工具
+- **新增 `recoverImageByRequestId(requestId, config, signal)`**
+- `generateImageSync()` 加超时兜底 try/catch
+
+`packages/drawnix/src/services/media-api/index.ts`
+- 导出 `recoverImageByRequestId`
+
+### 3.5 图片直连路径兜底
+
+`packages/drawnix/src/services/media-executor/fallback-executor.ts`
+
+- 顶部新增 `generateRequestIdForImage()` / `isTimeoutErrorForRecover()`
+- import `recoverImageByRequestId`
+- `generateImage()` 图片直连分支：
+  - 生成 requestId，写入 `startLLMApiLog` + `providerTransport.send`
+  - 内层 try/catch 捕获 TimeoutError → 调 `recoverImageByRequestId` → 成功走 complete，失败 throw
+
+### 3.6 Adapter 路径兜底 + 日志补写
+
+`packages/drawnix/src/services/media-executor/fallback-adapter-routes.ts`
+
+- 新增 `isTimeoutErrorForAdapterRecover()`
+- import `recoverImageByRequestId` / `updateLLMApiLogRequestId` / 类型 `ImageApiConfig`
+- `executeImageViaAdapter()` 中：
+  - 显式创建 `adapterContext`，注入 `onRequestSent` 回调（首次触发时缓存 requestId + 补写日志）
+  - 内层 try/catch 捕获 adapter 错误：若是超时 + 有 requestId → 构造 `recoverConfig`（从 `context.provider` 提取）→ 调找回
+
+### 3.7 日志器双端同步
+
+`apps/web/src/sw/task-queue/llm-api-logger.ts`（SW 模式）
+`packages/drawnix/src/services/media-executor/llm-api-logger.ts`（主线程降级）
+
+两处**结构对齐**：
+- `LLMApiLog` interface 加 `requestId?: string`
+- `startLLMApiLog` 参数加 `requestId?`
+- 新增导出函数 `updateLLMApiLogRequestId(logId, requestId)`
+
+## 四、执行步骤
+
+### 4.1 顺序
+
+1. **types 层**：`provider-routing/types.ts` / `model-adapters/types.ts`
+2. **传输层**：`provider-transport.ts`
+3. **适配器上下文**：`model-adapters/context.ts`
+4. **日志器双端**：`sw/task-queue/llm-api-logger.ts` / `media-executor/llm-api-logger.ts`
+5. **找回接口封装**：`media-api/image-api.ts` + `index.ts` 导出
+6. **generateImageSync 兜底**：`media-api/image-api.ts`
+7. **fallback-executor 兜底**：`media-executor/fallback-executor.ts`
+8. **fallback-adapter-routes 兜底**：`media-executor/fallback-adapter-routes.ts`
+9. **编译校验**：`pnpm exec nx run-many -t typecheck`
+
+### 4.2 提交拆分建议
+
+按上面的分组分 5-6 个 commit，方便 code review 与回滚。
+
+## 五、验证方案
+
+### 5.1 编译验证
+
+```bash
+pnpm exec nx run-many -t typecheck   # 5 个包全部通过 ✓
+```
+
+### 5.2 手动验证（浏览器）
+
+**场景 A - 正常路径**：
+1. 打开应用，用 `api.tu-zi.com` provider 正常生图
+2. F12 > Application > IndexedDB > `llm-api-logs` > `logs`
+3. 找到最新一条记录，字段 `requestId` 应为 UUID（如 `8c41eb26-a2d0-fcb1-01a6-f697e7d4e2ff`）
+4. F12 > Network 面板中找到 `/images/generations` 请求，Request Headers 应包含 `X-Request-Id: <UUID>`
+
+**场景 B - 超时找回成功**：
+1. 临时把 `IMAGE_GENERATION_TIMEOUT_MS`（`constants/TASK_CONSTANTS.ts`）改到 100ms
+2. 触发一次生图
+3. 观察 Console 应出现：
+   - `[FallbackMediaExecutor/FallbackAdapterRoutes] 生图请求超时，尝试通过 X-Request-Id 找回: xxx`
+   - `[...] ✅ 通过 X-Request-Id 找回结果成功: xxx`
+4. 画布上应正常出现图片，任务状态为 completed（**不显示失败**）
+5. 恢复超时常量
+
+**场景 C - 找回失败**：
+1. 同 B 步骤 1，触发超时
+2. 但用 devtools 的 request block 屏蔽 `/log/get-request`
+3. Console 应出现：
+   - `[...] ❌ 通过 X-Request-Id 找回结果失败: xxx`
+4. 用户端看到"生图超时"错误（**保持原有失败展示**）
+
+### 5.3 日志查看
+
+- IndexedDB `llm-api-logs` > `logs` 表
+- 或访问 `sw-debug.html`（若项目有该调试页面）查看 requestId 字段
+
+## 六、影响面 & 兼容性
+
+| 项 | 说明 |
+|---|---|
+| **老日志记录** | `requestId` 为可选字段，读旧数据 = undefined，无影响 |
+| **未覆盖的适配器**（如 Midjourney/Flux/Kling 视频） | 走 submit+poll 异步流，自身有 remoteId 机制，本次**不改** |
+| **`?sw=0` 降级模式** | 已覆盖（fallback-executor 直连 + fallback-adapter-routes 两条分支）|
+| **`crypto.randomUUID`** | Chrome 92+ / 现代 SW 全部支持，含极端兜底 fallback |
+| **`baseUrlStrategy: 'trim-v1'`** | 已有能力，不新增基础设施 |
+| **`X-Request-Id` 与 `Authorization`** | 在 `applyAuthHeaders` 之后追加，不影响鉴权 |
+| **找回接口自身超时** | 15s 短超时，兜底不拖累主流程 |
+
+## 七、注意事项
+
+### 7.1 只作用于同步生图
+
+- **不覆盖**：`generateImageAsync`（走 `/v1/videos` 通道，自身有 remoteId + poll 机制）
+- **不覆盖**：Midjourney / Flux / Kling / Seedance / 视频 API 等异步流程
+- **不覆盖**：`AdapterContext.operation !== 'image'` 的场景（如聊天/视频/音频）
+
+### 7.2 找回接口返回格式
+
+- 已按 `{ data: [{ url }], status?: 'succeeded' }` 结构处理
+- 若实际 API 返回结构不同（比如带 `data.state` 而非 `status`），需要调整 `recoverImageByRequestId` 内的 status 检测
+
+### 7.3 缓存与 URL 有效期
+
+- 找回来的 URL 会走原有 `cacheRemoteUrls` 流程缓存到本地 `/__aitu_cache__/`
+- 用户看到的最终图片是缓存副本，不受签名 URL 过期影响
+
+### 7.4 CLAUDE.md 规范符合性
+
+- **规则 26（外部输入校验）**：`error.requestId` 使用前用 `typeof === 'string'` 检查
+- **规则 22（降级路径功能一致性）**：SW 模式与降级模式都覆盖了兜底逻辑
+- **断舍离原则**：仅新增必要字段和函数，不引入 Repository/Strategy 等抽象层
+- **规则 27（SW 与主线程日志器双端同步）**：`LLMApiLog` interface 两处保持字段一致
+
+## 八、后续拓展方向（不在本次范围内）
+
+1. **失败原因分类**：`LLMApiLog` 新增 `recoveryAttempted?: boolean` / `recoveryFailReason?: string`，便于统计"多少次通过兜底救回"（用户当前选择只加 `requestId`）
+2. **UI 展示**：在 `sw-debug.html` 增加 `requestId` 列，方便手动排查
+3. **视频接口兜底**：Kling/Sora2 视频超时也可能失败但已扣费，未来可扩展到视频路径
+4. **手动重试按钮**：给失败任务加"通过 requestId 重新找回"按钮
+
+## 九、相关文件速查表
+
+```
+packages/drawnix/src/
+├── services/
+│   ├── provider-routing/
+│   │   ├── types.ts                          [+] requestId 字段
+│   │   └── provider-transport.ts             [+] applyRequestIdHeader + 挂 TimeoutError.requestId
+│   ├── model-adapters/
+│   │   ├── types.ts                          [+] AdapterContext.onRequestSent
+│   │   └── context.ts                        [+] sendAdapterRequest 自动生成 requestId
+│   ├── media-api/
+│   │   ├── image-api.ts                      [+] recoverImageByRequestId + generateImageSync 兜底
+│   │   └── index.ts                          [+] 导出 recoverImageByRequestId
+│   └── media-executor/
+│       ├── fallback-executor.ts              [+] 图片直连路径超时兜底
+│       ├── fallback-adapter-routes.ts        [+] adapter 路径超时兜底 + 日志 requestId 补写
+│       └── llm-api-logger.ts                 [+] LLMApiLog.requestId + updateLLMApiLogRequestId
+└── ...
+
+apps/web/src/sw/task-queue/
+└── llm-api-logger.ts                          [+] LLMApiLog.requestId + updateLLMApiLogRequestId
+```
+
+`[+]` = 本次改动 / 新增

--- a/packages/drawnix/src/components/ai-input-bar/RequestIdRecoveryPanel.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/RequestIdRecoveryPanel.tsx
@@ -1,0 +1,256 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Search, RefreshCw, X } from 'lucide-react';
+import { MessagePlugin } from 'tdesign-react';
+import {
+  recoverImageByRequestId,
+  extractRequestId,
+} from '../../services/media-api/image-api';
+import {
+  IMAGE_REQUEST_ID_EVENT,
+  getLatestImageRequestId,
+  setLatestImageRequestId,
+} from '../../services/media-api/request-id-debug';
+import { getAdapterContextFromSettings } from '../../services/model-adapters/context';
+import type { ModelRef } from '../../utils/settings-manager';
+import { RetryImage } from '../retry-image';
+import './request-id-recovery-panel.scss';
+
+interface RequestIdRecoveryPanelProps {
+  selectedModel?: string;
+  selectedModelRef?: ModelRef | null;
+  language?: 'zh' | 'en';
+  className?: string;
+}
+
+function getRecoverErrorMessage(
+  error: unknown,
+  language: 'zh' | 'en'
+): string {
+  const fallback =
+    language === 'zh' ? '图片找回失败，请稍后再试' : 'Image recovery failed';
+
+  if (!(error instanceof Error)) {
+    return fallback;
+  }
+
+  const message = error.message || fallback;
+
+  if (
+    /找回接口返回状态非成功/.test(message) ||
+    /processing_or_not_found/.test(message) ||
+    /\bfailed\b/i.test(message)
+  ) {
+    return language === 'zh'
+      ? '查找图片失败，没有成功生成图片'
+      : 'Image lookup failed. The image was not generated successfully.';
+  }
+
+  return message;
+}
+
+export const RequestIdRecoveryPanel: React.FC<RequestIdRecoveryPanelProps> = ({
+  selectedModel = '',
+  selectedModelRef,
+  language = 'zh',
+  className,
+}) => {
+  const [requestId, setRequestId] = useState('');
+  const [isRecovering, setIsRecovering] = useState(false);
+  const [recoveredUrl, setRecoveredUrl] = useState('');
+  const [recoveredError, setRecoveredError] = useState('');
+  const [latestRequestId, setLatestRequestIdState] = useState(() =>
+    getLatestImageRequestId()
+  );
+
+  useEffect(() => {
+    const syncLatestRequestId = (event: Event) => {
+      const nextRequestId =
+        (event as CustomEvent<{ requestId?: string }>).detail?.requestId ||
+        getLatestImageRequestId();
+      setLatestRequestIdState(nextRequestId);
+    };
+
+    window.addEventListener(IMAGE_REQUEST_ID_EVENT, syncLatestRequestId);
+    return () =>
+      window.removeEventListener(IMAGE_REQUEST_ID_EVENT, syncLatestRequestId);
+  }, []);
+
+  const recoverConfig = useMemo(() => {
+    const context = getAdapterContextFromSettings(
+      'image',
+      selectedModelRef || selectedModel || null
+    );
+
+    return {
+      apiKey: context.provider?.apiKey || context.apiKey || '',
+      baseUrl: context.provider?.baseUrl || context.baseUrl,
+      authType: context.provider?.authType || context.authType,
+      providerType: context.provider?.providerType,
+      extraHeaders: context.provider?.extraHeaders || context.extraHeaders,
+      provider: context.provider || null,
+      binding: context.binding || null,
+    };
+  }, [selectedModel, selectedModelRef]);
+
+  const handleUseLatest = () => {
+    if (!latestRequestId) {
+      MessagePlugin.warning(
+        language === 'zh'
+          ? '还没有最近一次 X-Request-Id，请先发起一次图片生成'
+          : 'No recent X-Request-Id yet. Generate an image first.'
+      );
+      return;
+    }
+
+    setRequestId(extractRequestId(latestRequestId));
+  };
+
+  const handleRecover = async () => {
+    const normalizedRequestId = extractRequestId(requestId);
+    if (!normalizedRequestId) {
+      MessagePlugin.warning(
+        language === 'zh'
+          ? '请输入 X-Request-Id'
+          : 'Please enter an X-Request-Id'
+      );
+      return;
+    }
+
+    if (normalizedRequestId !== requestId) {
+      setRequestId(normalizedRequestId);
+    }
+
+    setIsRecovering(true);
+    setRecoveredError('');
+
+    try {
+      const recovered = await recoverImageByRequestId(
+        normalizedRequestId,
+        recoverConfig
+      );
+      setLatestImageRequestId(normalizedRequestId);
+      setRecoveredUrl(recovered.url);
+      MessagePlugin.success(
+        language === 'zh' ? '图片找回成功' : 'Image recovered successfully'
+      );
+    } catch (error) {
+      const message = getRecoverErrorMessage(error, language);
+      setRecoveredUrl('');
+      setRecoveredError(message);
+      console.error(`[X-Request-Id][recover] ${normalizedRequestId} ${message}`);
+      MessagePlugin.error(message);
+    } finally {
+      setIsRecovering(false);
+    }
+  };
+
+  const handleCloseRecovered = () => {
+    setRecoveredUrl('');
+    setRecoveredError('');
+  };
+
+  return (
+    <div className={`request-id-recovery ${className || ''}`.trim()}>
+        <div className="request-id-recovery__header">
+          <span className="request-id-recovery__title">X-Request-Id</span>
+          <button
+            type="button"
+            className="request-id-recovery__chip"
+            onClick={handleUseLatest}
+          >
+            <RefreshCw size={12} />
+            <span>{language === 'zh' ? '填入最近一次' : 'Use latest'}</span>
+          </button>
+        </div>
+
+        <div className="request-id-recovery__controls">
+          <input
+            className="request-id-recovery__input"
+            value={requestId}
+            onChange={(event) => {
+              setRequestId(event.target.value);
+              if (recoveredError) {
+                setRecoveredError('');
+              }
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !isRecovering) {
+                event.preventDefault();
+                handleRecover();
+              }
+            }}
+            placeholder={
+              language === 'zh'
+                ? '输入生成后输出到控制台的 X-Request-Id'
+                : 'Paste the X-Request-Id printed in the console'
+            }
+          />
+          <button
+            type="button"
+            className="request-id-recovery__action"
+            onClick={handleRecover}
+            disabled={isRecovering}
+          >
+            <Search size={14} />
+            <span>{language === 'zh' ? '查询' : 'Recover'}</span>
+          </button>
+        </div>
+
+        {latestRequestId ? (
+          <div className="request-id-recovery__status">
+            {language === 'zh' ? '最近一次' : 'Latest'}: {latestRequestId}
+          </div>
+        ) : null}
+
+        {recoveredUrl ? (
+          <div className="request-id-recovery__result">
+            <div className="request-id-recovery__preview-shell">
+              <RetryImage
+                src={recoveredUrl}
+                alt="Recovered image"
+                className="request-id-recovery__preview"
+                wrapperClassName="request-id-recovery__preview-wrap"
+                showSkeleton={false}
+              />
+              <button
+                type="button"
+                className="request-id-recovery__close"
+                onClick={handleCloseRecovered}
+                aria-label={
+                  language === 'zh' ? '关闭找回图片' : 'Close recovered image'
+                }
+              >
+                <X size={12} />
+              </button>
+            </div>
+            <div className="request-id-recovery__meta">
+              <span className="request-id-recovery__status request-id-recovery__status--success">
+                {language === 'zh' ? '找回成功' : 'Recovered'}
+              </span>
+              <span className="request-id-recovery__caption">
+                {language === 'zh'
+                  ? '图片已找回，可在这里临时查看'
+                  : 'Recovered image preview is available here'}
+              </span>
+              <a
+                className="request-id-recovery__link"
+                href={recoveredUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {language === 'zh' ? '打开原图' : 'Open image'}
+              </a>
+            </div>
+          </div>
+        ) : null}
+
+        {!recoveredUrl && recoveredError ? (
+          <div className="request-id-recovery__status request-id-recovery__status--error">
+            {recoveredError}
+          </div>
+        ) : null}
+    </div>
+  );
+};
+
+export default RequestIdRecoveryPanel;

--- a/packages/drawnix/src/components/ai-input-bar/request-id-recovery-panel.scss
+++ b/packages/drawnix/src/components/ai-input-bar/request-id-recovery-panel.scss
@@ -1,0 +1,175 @@
+.request-id-recovery {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  color: #111827;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  &__title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #111827;
+  }
+
+  &__chip,
+  &__action,
+  &__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border: 1px solid rgba(209, 213, 219, 0.9);
+    background: rgba(255, 255, 255, 0.92);
+    color: #374151;
+    cursor: pointer;
+    transition: background-color 160ms ease, border-color 160ms ease,
+      color 160ms ease, box-shadow 160ms ease;
+
+    &:hover:not(:disabled) {
+      border-color: rgba(245, 158, 11, 0.45);
+      background: #fff8eb;
+      color: #b45309;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+  }
+
+  &__chip {
+    height: 28px;
+    padding: 0 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    flex-shrink: 0;
+  }
+
+  &__controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__input {
+    flex: 1;
+    min-width: 0;
+    height: 36px;
+    padding: 0 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(209, 213, 219, 0.9);
+    background: rgba(255, 255, 255, 0.96);
+    color: #111827;
+    font-size: 13px;
+    outline: none;
+    transition: border-color 160ms ease, box-shadow 160ms ease;
+
+    &:focus {
+      border-color: rgba(245, 158, 11, 0.7);
+      box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.14);
+    }
+
+    &::placeholder {
+      color: #9ca3af;
+    }
+  }
+
+  &__action {
+    height: 36px;
+    padding: 0 12px;
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+
+  &__status {
+    font-size: 12px;
+    line-height: 1.5;
+    color: #6b7280;
+    word-break: break-all;
+
+    &--success {
+      color: #047857;
+      font-weight: 600;
+    }
+
+    &--error {
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(254, 242, 242, 0.95);
+      color: #b91c1c;
+      border: 1px solid rgba(248, 113, 113, 0.22);
+    }
+  }
+
+  &__result {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.82);
+    border: 1px solid rgba(229, 231, 235, 0.92);
+  }
+
+  &__preview-shell {
+    position: relative;
+    overflow: hidden;
+    border-radius: 12px;
+    background: rgba(243, 244, 246, 0.85);
+  }
+
+  &__preview-wrap {
+    display: block;
+    width: 100%;
+  }
+
+  &__preview {
+    display: block;
+    width: 100%;
+    max-height: 220px;
+    object-fit: cover;
+  }
+
+  &__close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 24px;
+    height: 24px;
+    border-radius: 999px;
+    padding: 0;
+    backdrop-filter: blur(8px);
+  }
+
+  &__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__caption {
+    font-size: 12px;
+    line-height: 1.5;
+    color: #6b7280;
+  }
+
+  &__link {
+    font-size: 12px;
+    font-weight: 600;
+    color: #b45309;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/packages/drawnix/src/components/image-generation-anchor/ImageGenerationAnchorContent.tsx
+++ b/packages/drawnix/src/components/image-generation-anchor/ImageGenerationAnchorContent.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import type { PlaitBoard } from '@plait/core';
+import { Copy } from 'lucide-react';
+import { MessagePlugin } from 'tdesign-react';
 import { useImageGenerationAnchorController } from '../../hooks/useImageGenerationAnchorController';
 import { taskQueueService } from '../../services/task-queue';
 import { workflowCompletionService } from '../../services/workflow-completion-service';
@@ -52,6 +54,14 @@ export const ImageGenerationAnchorContent: React.FC<
 > = ({ board, element, selected }) => {
   const { viewModel } = useImageGenerationAnchorController({ anchor: element });
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const relatedTasks = useMemo(
+    () => getTasksForImageGenerationAnchor(element, taskQueueService.getAllTasks()),
+    [element]
+  );
+  const resolvedTask = useMemo(
+    () => selectPrimaryImageGenerationAnchorTask(element, relatedTasks),
+    [element, relatedTasks]
+  );
   const isGhost = viewModel.anchorType === 'ghost';
   const batchPreview = viewModel.batchPreview;
   const isStack = Boolean(batchPreview);
@@ -81,17 +91,28 @@ export const ImageGenerationAnchorContent: React.FC<
       : 'default';
   const detailItems = useMemo(
     () => [
+      {
+        label: '编号',
+        value:
+          resolvedTask?.id ||
+          element.primaryTaskId ||
+          element.taskIds[0] ||
+          element.workflowId,
+        copyable: true,
+      },
       { label: '阶段', value: viewModel.phaseLabel },
       { label: '形态', value: viewModel.anchorType },
       { label: '过渡', value: viewModel.transitionMode },
       {
         label: '任务',
         value: element.primaryTaskId || (element.taskIds[0] ?? '待绑定'),
+        copyable: true,
       },
-      { label: '工作流', value: element.workflowId },
+      { label: '工作流', value: element.workflowId, copyable: true },
       { label: '错误', value: viewModel.error || '无' },
     ],
     [
+      resolvedTask?.id,
       element.primaryTaskId,
       element.taskIds,
       element.workflowId,
@@ -108,12 +129,44 @@ export const ImageGenerationAnchorContent: React.FC<
     },
     []
   );
+  const stopInteractionStart = useCallback(
+    (event: React.PointerEvent | React.MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+    },
+    []
+  );
+  const failureIdentifier =
+    resolvedTask?.id ||
+    element.primaryTaskId ||
+    element.taskIds[0] ||
+    element.workflowId;
   const stopPointer = useCallback(
     (event: React.PointerEvent | React.MouseEvent) => {
       event.stopPropagation();
       event.preventDefault();
     },
     []
+  );
+  const copyText = useCallback(
+    async (
+      event: React.PointerEvent | React.MouseEvent,
+      value?: string | null
+    ) => {
+      stopPointer(event);
+      if (!value) {
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(value);
+        MessagePlugin.success('已复制 ID');
+      } catch (error) {
+        console.error('[ImageGenerationAnchor] Failed to copy text:', error);
+        MessagePlugin.error('复制失败');
+      }
+    },
+    [stopPointer]
   );
 
   const handleAction = useCallback(
@@ -128,10 +181,6 @@ export const ImageGenerationAnchorContent: React.FC<
       }
 
       if (actionType === 'retry') {
-        const relatedTasks = getTasksForImageGenerationAnchor(
-          element,
-          taskQueueService.getAllTasks()
-        );
         const retryableTask =
           relatedTasks.find(
             (task) =>
@@ -157,12 +206,35 @@ export const ImageGenerationAnchorContent: React.FC<
           return;
         }
 
+        const retryablePostProcessingStatus = retryableTask
+          ? workflowCompletionService.getPostProcessingStatus(retryableTask.id)
+              ?.status
+          : undefined;
+
         if (retryableTask) {
           ImageGenerationAnchorTransforms.updateAnchor(
             board,
             element.id,
             buildImageGenerationAnchorPresentationPatch('retrying')
           );
+
+          if (
+            retryableTask.status === TaskStatus.FAILED ||
+            retryableTask.status === TaskStatus.CANCELLED
+          ) {
+            taskQueueService.retryTask(retryableTask.id);
+            return;
+          }
+
+          if (
+            retryableTask.status === TaskStatus.COMPLETED &&
+            retryablePostProcessingStatus === 'failed'
+          ) {
+            taskQueueService.retryTask(retryableTask.id, {
+              allowCompleted: true,
+            });
+            return;
+          }
         }
 
         window.dispatchEvent(
@@ -177,7 +249,15 @@ export const ImageGenerationAnchorContent: React.FC<
         board.deleteFragment([element]);
       }
     },
-    [board, element]
+    [board, element, relatedTasks]
+  );
+  const runDeferredAction = useCallback(
+    (actionType: ImageGenerationAnchorActionType) => {
+      window.setTimeout(() => {
+        handleAction(actionType);
+      }, 0);
+    },
+    [handleAction]
   );
 
   const renderCore = () => {
@@ -199,14 +279,38 @@ export const ImageGenerationAnchorContent: React.FC<
             <span className="image-generation-anchor__error-raw">
               {viewModel.error}
             </span>
+            {failureIdentifier ? (
+              <span className="image-generation-anchor__error-id">
+                <span className="image-generation-anchor__error-id-text">
+                  ID: {failureIdentifier}
+                </span>
+                <button
+                  type="button"
+                  className="image-generation-anchor__copy-button"
+                  onPointerDown={stopInteractionStart}
+                  onMouseDown={stopInteractionStart}
+                  onPointerUp={stopEventPropagation}
+                  onMouseUp={stopEventPropagation}
+                  onClick={(event) => {
+                    void copyText(event, failureIdentifier);
+                  }}
+                  aria-label="复制 ID"
+                  title="复制 ID"
+                >
+                  <Copy size={12} />
+                </button>
+              </span>
+            ) : null}
             <button
               type="button"
               className="image-generation-anchor__error-link"
-              onPointerDown={stopEventPropagation}
-              onMouseDown={stopEventPropagation}
+              onPointerDown={stopInteractionStart}
+              onMouseDown={stopInteractionStart}
+              onPointerUp={stopEventPropagation}
+              onMouseUp={stopEventPropagation}
               onClick={(event) => {
                 stopPointer(event);
-                handleAction('details');
+                runDeferredAction('details');
               }}
             >
               {detailsOpen ? '收起详情' : '查看详情'}
@@ -378,7 +482,26 @@ export const ImageGenerationAnchorContent: React.FC<
                 {item.label}
               </span>
               <span className="image-generation-anchor__detail-value">
-                {item.value}
+                <span className="image-generation-anchor__detail-value-text">
+                  {item.value}
+                </span>
+                {item.copyable && item.value ? (
+                  <button
+                    type="button"
+                    className="image-generation-anchor__copy-button image-generation-anchor__copy-button--detail"
+                    onPointerDown={stopInteractionStart}
+                    onMouseDown={stopInteractionStart}
+                    onPointerUp={stopEventPropagation}
+                    onMouseUp={stopEventPropagation}
+                    onClick={(event) => {
+                      void copyText(event, item.value);
+                    }}
+                    aria-label={`复制${item.label}`}
+                    title={`复制${item.label}`}
+                  >
+                    <Copy size={12} />
+                  </button>
+                ) : null}
               </span>
             </div>
           ))}
@@ -390,11 +513,13 @@ export const ImageGenerationAnchorContent: React.FC<
           <button
             type="button"
             className="image-generation-anchor__action"
-            onPointerDown={stopEventPropagation}
-            onMouseDown={stopEventPropagation}
+            onPointerDown={stopInteractionStart}
+            onMouseDown={stopInteractionStart}
+            onPointerUp={stopEventPropagation}
+            onMouseUp={stopEventPropagation}
             onClick={(event) => {
               stopPointer(event);
-              handleAction(viewModel.primaryAction.type);
+              runDeferredAction(viewModel.primaryAction.type);
             }}
           >
             {primaryActionLabel}
@@ -403,12 +528,14 @@ export const ImageGenerationAnchorContent: React.FC<
             <button
               type="button"
               className="image-generation-anchor__action image-generation-anchor__action--secondary"
-              onPointerDown={stopEventPropagation}
-              onMouseDown={stopEventPropagation}
+              onPointerDown={stopInteractionStart}
+              onMouseDown={stopInteractionStart}
+              onPointerUp={stopEventPropagation}
+              onMouseUp={stopEventPropagation}
               onClick={(event) => {
                 stopPointer(event);
                 if (secondaryActionType) {
-                  handleAction(secondaryActionType);
+                  runDeferredAction(secondaryActionType);
                 }
               }}
             >

--- a/packages/drawnix/src/components/image-generation-anchor/image-generation-anchor.scss
+++ b/packages/drawnix/src/components/image-generation-anchor/image-generation-anchor.scss
@@ -510,6 +510,56 @@
   white-space: nowrap;
 }
 
+.image-generation-anchor__error-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(280px, 100%);
+  font-size: 11px;
+  line-height: 1.45;
+  color: rgba(71, 85, 105, 0.92);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-generation-anchor__error-id-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-generation-anchor__copy-button {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  border: 1px solid rgba(226, 232, 240, 0.96);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: rgba(100, 116, 139, 0.88);
+  cursor: pointer;
+  transition: background-color 160ms ease, border-color 160ms ease,
+    color 160ms ease, transform 120ms ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    border-color: rgba(245, 158, 11, 0.36);
+    background: rgba(255, 251, 235, 0.98);
+    color: rgba(180, 83, 9, 0.92);
+  }
+}
+
+.image-generation-anchor__copy-button--detail {
+  width: 20px;
+  height: 20px;
+}
+
 .image-generation-anchor__error-link {
   appearance: none;
   padding: 0;
@@ -576,11 +626,21 @@
 }
 
 .image-generation-anchor__detail-value {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 6px;
   font-size: 11px;
   line-height: 1.45;
   color: rgba(51, 65, 85, 0.84);
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.image-generation-anchor__detail-value-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
 }
 
 .image-generation-anchor__actions {

--- a/packages/drawnix/src/components/toolbar/bottom-actions-section.scss
+++ b/packages/drawnix/src/components/toolbar/bottom-actions-section.scss
@@ -11,6 +11,66 @@
   gap: 4px;
   width: 100%;
 
+  &__request-id-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__request-id-panel-shell {
+    position: absolute;
+    left: calc(100% + 16px);
+    bottom: -4px;
+    width: min(340px, calc(100vw - 120px));
+    max-height: min(70vh, 640px);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 14px;
+    border-radius: 18px;
+    border: 1px solid rgba(229, 231, 235, 0.95);
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 18px 48px rgba(15, 23, 42, 0.16);
+    backdrop-filter: blur(14px);
+    z-index: 10;
+  }
+
+  &__request-id-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  &__request-id-panel-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #111827;
+  }
+
+  &__request-id-panel-close {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid rgba(229, 231, 235, 0.95);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.96);
+    color: #6b7280;
+    cursor: pointer;
+    transition: background-color 160ms ease, color 160ms ease,
+      border-color 160ms ease;
+
+    &:hover {
+      background: #fff7ed;
+      border-color: rgba(245, 158, 11, 0.42);
+      color: #b45309;
+    }
+  }
+
   // 任务按钮包装器 - 添加相对定位以支持状态点
   &__task-wrapper {
     position: relative;
@@ -71,6 +131,13 @@
     &--failed {
       background: var(--td-error-color, #e34d59);
     }
+  }
+}
+
+:root.aitu-toolbar-dock-right {
+  .bottom-actions-section__request-id-panel-shell {
+    left: auto;
+    right: calc(100% + 16px);
   }
 }
 

--- a/packages/drawnix/src/components/toolbar/bottom-actions-section.tsx
+++ b/packages/drawnix/src/components/toolbar/bottom-actions-section.tsx
@@ -6,12 +6,15 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { Search, X } from 'lucide-react';
 import { Badge } from 'tdesign-react';
 import { ToolButton } from '../tool-button';
 import { useTaskQueue } from '../../hooks/useTaskQueue';
 import type { Task } from '../../types/task.types';
 import { FeedbackButton } from '../feedback-button/feedback-button';
+import { RequestIdRecoveryPanel } from '../ai-input-bar/RequestIdRecoveryPanel';
 import { FolderIcon, ToolboxIcon, TaskIcon } from '../icons';
+import { useI18n } from '../../i18n';
 import './bottom-actions-section.scss';
 
 const FAILED_TASK_ACK_STORAGE_KEY = 'aitu-task-queue-failed-ack-at';
@@ -67,9 +70,11 @@ export const BottomActionsSection: React.FC<BottomActionsSectionProps> = ({
   onTaskPanelToggle,
 }) => {
   const { activeTasks, completedTasks, failedTasks } = useTaskQueue();
+  const { language } = useI18n();
   const [acknowledgedFailedAt, setAcknowledgedFailedAt] = useState(
     readFailedTaskAckAt
   );
+  const [requestIdPanelOpen, setRequestIdPanelOpen] = useState(false);
 
   const latestFailedAt = useMemo(
     () =>
@@ -140,6 +145,57 @@ export const BottomActionsSection: React.FC<BottomActionsSectionProps> = ({
           onClick={onToolboxDrawerToggle}
         />
       )}
+
+      <div className="bottom-actions-section__request-id-wrapper">
+        <ToolButton
+          type="icon"
+          icon={<Search size={18} />}
+          aria-label={
+            requestIdPanelOpen
+              ? language === 'zh'
+                ? '关闭 X-Request-Id 查询'
+                : 'Close X-Request-Id recovery'
+              : language === 'zh'
+              ? '打开 X-Request-Id 查询'
+              : 'Open X-Request-Id recovery'
+          }
+          tooltip={
+            language === 'zh' ? 'X-Request-Id 查询' : 'X-Request-Id recovery'
+          }
+          tooltipPlacement="right"
+          selected={requestIdPanelOpen}
+          visible={true}
+          data-track="toolbar_click_request_id_recovery"
+          data-testid="toolbar-request-id-recovery"
+          onPointerDown={(e) => {
+            e.event.stopPropagation();
+          }}
+          onClick={() => {
+            setRequestIdPanelOpen((value) => !value);
+          }}
+        />
+
+        {requestIdPanelOpen ? (
+          <div className="bottom-actions-section__request-id-panel-shell">
+            <div className="bottom-actions-section__request-id-panel-header">
+              <div className="bottom-actions-section__request-id-panel-title">
+                X-Request-Id
+              </div>
+              <button
+                type="button"
+                className="bottom-actions-section__request-id-panel-close"
+                onClick={() => {
+                  setRequestIdPanelOpen(false);
+                }}
+                aria-label={language === 'zh' ? '关闭查询面板' : 'Close recovery panel'}
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <RequestIdRecoveryPanel language={language} />
+          </div>
+        ) : null}
+      </div>
 
       {/* 任务队列按钮 - 使用 ToolButton + Badge */}
       <div className="bottom-actions-section__task-wrapper">

--- a/packages/drawnix/src/data/image.ts
+++ b/packages/drawnix/src/data/image.ts
@@ -351,7 +351,7 @@ export const insertImageFromUrl = async (
       'image',
       'png',
       undefined,
-      { forceRemoteCache: true }
+      { forceRemoteCache: true, returnLocalCacheUrl: true }
     );
     if (cachedUrl !== resolvedUrl) {
       resolvedUrl = cachedUrl;
@@ -542,7 +542,7 @@ function updateImageSizeAfterLoad(
         naturalWidth,
         naturalHeight
       );
-      
+
       let newWidth = displayDimensions.width;
       let newHeight = displayDimensions.height;
 

--- a/packages/drawnix/src/data/image.ts
+++ b/packages/drawnix/src/data/image.ts
@@ -349,7 +349,9 @@ export const insertImageFromUrl = async (
       resolvedUrl,
       `insert-${Date.now()}`,
       'image',
-      'png'
+      'png',
+      undefined,
+      { forceRemoteCache: true }
     );
     if (cachedUrl !== resolvedUrl) {
       resolvedUrl = cachedUrl;

--- a/packages/drawnix/src/services/media-api/image-api.ts
+++ b/packages/drawnix/src/services/media-api/image-api.ts
@@ -24,12 +24,129 @@ import {
 } from './utils';
 import { providerTransport } from '../provider-routing/provider-transport';
 import { IMAGE_GENERATION_TIMEOUT_MS } from '../../constants/TASK_CONSTANTS';
+import { emitImageRequestIdDebugLog } from './request-id-debug';
 
 // 重新导出工具函数，方便外部使用
 export { isAsyncImageModel, aspectRatioToSize };
 
+/** /log/get-request 找回接口的短超时，避免兜底本身长时间挂起 */
+const RECOVER_REQUEST_TIMEOUT_MS = 15_000;
+const RECOVER_RETRYABLE_STATUS = new Set(['processing', 'processing_or_not_found']);
+const RECOVER_MAX_ATTEMPTS = 3;
+const RECOVER_RETRY_DELAY_MS = 1200;
+
 function getDefaultImagePollingMaxAttempts(interval: number): number {
   return Math.ceil(IMAGE_GENERATION_TIMEOUT_MS / Math.max(interval, 1));
+}
+
+function generateRequestId(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (typeof g.crypto?.randomUUID === 'function') {
+    return g.crypto.randomUUID();
+  }
+  return `req-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'TimeoutError' ||
+      /Request timeout|请求超时/.test(error.message))
+  );
+}
+
+export function extractRequestId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const uuidMatch = trimmed.match(
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i
+  );
+  if (uuidMatch) {
+    return uuidMatch[0];
+  }
+
+  const reqMatch = trimmed.match(/\breq-[a-z0-9-]{8,}\b/i);
+  if (reqMatch) {
+    return reqMatch[0];
+  }
+
+  return trimmed;
+}
+
+function getRecoverStatus(
+  data: Record<string, unknown>
+): string | undefined {
+  return typeof data.status === 'string' ? data.status : undefined;
+}
+
+function isRecoverStatusRetryable(status: string | undefined): boolean {
+  return !!status && RECOVER_RETRYABLE_STATUS.has(status);
+}
+
+/**
+ * 通过 X-Request-Id 找回已经生成成功的图片。
+ * 用于生图接口超时但服务端实际已扣费/生成成功的兜底场景。
+ *
+ * 接口：`GET /log/get-request?id={requestId}`
+ * 响应结构与 `POST /images/generations` 一致（`{ data: [{ url }] }`），可复用 parseImageResponse。
+ */
+export async function recoverImageByRequestId(
+  requestId: string,
+  config: ImageApiConfig,
+  signal?: AbortSignal
+): Promise<ImageGenerationResult> {
+  const normalizedRequestId =
+    typeof requestId === 'string' ? extractRequestId(requestId) : '';
+
+  if (!normalizedRequestId) {
+    throw new Error('recoverImageByRequestId: 缺少 requestId');
+  }
+
+  const fetchFn = config.fetchImpl || fetch;
+  for (let attempt = 1; attempt <= RECOVER_MAX_ATTEMPTS; attempt += 1) {
+    const response = await providerTransport.send(
+      buildProviderContextFromApiConfig(config),
+      {
+        path: '/log/get-request',
+        method: 'GET',
+        query: { id: normalizedRequestId },
+        // /log/get-request 是根路径级 API，不带 /v1 前缀
+        baseUrlStrategy: 'trim-v1',
+        signal,
+        timeoutMs: RECOVER_REQUEST_TIMEOUT_MS,
+        fetcher: fetchFn,
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      throw new Error(
+        `找回接口调用失败: ${response.status} - ${errorText.substring(0, 200)}`
+      );
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+    const status = getRecoverStatus(data);
+
+    if (!status || status === 'succeeded' || status === 'success') {
+      return parseImageResponse(data);
+    }
+
+    if (isRecoverStatusRetryable(status) && attempt < RECOVER_MAX_ATTEMPTS) {
+      console.info(
+        `[X-Request-Id][recover] ${normalizedRequestId} ${status} retry ${attempt}`
+      );
+      await sleep(RECOVER_RETRY_DELAY_MS);
+      continue;
+    }
+
+    throw new Error(`找回接口返回状态非成功：${status}`);
+  }
+
+  throw new Error('找回接口重试结束但未返回成功结果');
 }
 
 function normalizeImageResultUrl(
@@ -152,30 +269,66 @@ export async function generateImageSync(
     model,
   });
 
-  const response = await providerTransport.send(
-    buildProviderContextFromApiConfig(config),
-    {
-      path: '/images/generations',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(requestBody),
-      signal,
-      timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
-      fetcher: fetchFn,
-    }
-  );
+  const requestId = generateRequestId();
+  emitImageRequestIdDebugLog(requestId, {
+    model,
+    endpoint: '/images/generations',
+    source: 'generateImageSync',
+  });
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(
-      `Image generation failed: ${response.status} - ${errorText}`
+  try {
+    const response = await providerTransport.send(
+      buildProviderContextFromApiConfig(config),
+      {
+        path: '/images/generations',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+        signal,
+        timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
+        fetcher: fetchFn,
+        requestId,
+      }
     );
-  }
 
-  const data = await response.json();
-  return parseImageResponse(data);
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Image generation failed: ${response.status} - ${errorText}`
+      );
+    }
+
+    const data = await response.json();
+    return parseImageResponse(data);
+  } catch (error) {
+    // 超时兜底：尝试通过 /log/get-request 找回已经生成成功的结果
+    if (isTimeoutError(error)) {
+      console.warn(
+        `[ImageAPI] 生图请求超时，尝试通过 X-Request-Id 找回结果: ${requestId}`
+      );
+      try {
+        const recovered = await recoverImageByRequestId(
+          requestId,
+          config,
+          signal
+        );
+        console.info(
+          `[ImageAPI] ✅ 通过 X-Request-Id 找回结果成功: ${requestId}`
+        );
+        return recovered;
+      } catch (recoverError) {
+        console.error(
+          `[ImageAPI] ❌ 通过 X-Request-Id 找回结果失败: ${requestId}`,
+          recoverError
+        );
+        // 找回失败，抛出原始超时错误
+        throw error;
+      }
+    }
+    throw error;
+  }
 }
 
 /**

--- a/packages/drawnix/src/services/media-api/index.ts
+++ b/packages/drawnix/src/services/media-api/index.ts
@@ -45,6 +45,7 @@ export {
   generateImageSync,
   generateImageAsync,
   resumeAsyncImagePolling,
+  recoverImageByRequestId,
 } from './image-api';
 
 // 视频 API 导出

--- a/packages/drawnix/src/services/media-api/request-id-debug.test.ts
+++ b/packages/drawnix/src/services/media-api/request-id-debug.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  emitImageRequestIdDebugLog,
+  getLatestImageRequestId,
+  setLatestImageRequestId,
+} from './request-id-debug';
+import { extractRequestId } from './image-api';
+
+describe('request-id-debug', () => {
+  it('stores and exposes latest image request id', () => {
+    setLatestImageRequestId('req-test-1');
+    expect(getLatestImageRequestId()).toBe('req-test-1');
+  });
+
+  it('logs and stores request id when emitted', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    emitImageRequestIdDebugLog('req-test-2', {
+      model: 'gpt-image-1',
+      source: 'unit-test',
+    });
+
+    expect(getLatestImageRequestId()).toBe('req-test-2');
+    expect(infoSpy).toHaveBeenCalledWith('[X-Request-Id] req-test-2');
+
+    infoSpy.mockRestore();
+  });
+
+  it('extracts uuid request id from noisy console text', () => {
+    expect(
+      extractRequestId(
+        "[X-Request-Id][image] {requestId: 'd4ee33d0-2104-4175-89b0-ece755265a8e', model: null}"
+      )
+    ).toBe('d4ee33d0-2104-4175-89b0-ece755265a8e');
+  });
+});

--- a/packages/drawnix/src/services/media-api/request-id-debug.ts
+++ b/packages/drawnix/src/services/media-api/request-id-debug.ts
@@ -1,0 +1,48 @@
+const LAST_IMAGE_REQUEST_ID_KEY = '__OPENTU_LAST_IMAGE_REQUEST_ID__';
+export const IMAGE_REQUEST_ID_EVENT = 'opentu:image-request-id';
+
+type ImageRequestIdDebugGlobal = typeof globalThis & {
+  [LAST_IMAGE_REQUEST_ID_KEY]?: string;
+};
+
+export interface ImageRequestIdDebugMeta {
+  model?: string;
+  endpoint?: string;
+  source?: string;
+}
+
+export function setLatestImageRequestId(requestId: string): void {
+  if (!requestId) {
+    return;
+  }
+  const globalScope = globalThis as ImageRequestIdDebugGlobal;
+  globalScope[LAST_IMAGE_REQUEST_ID_KEY] = requestId;
+
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(
+      new CustomEvent(IMAGE_REQUEST_ID_EVENT, {
+        detail: { requestId },
+      })
+    );
+  }
+}
+
+export function getLatestImageRequestId(): string {
+  return (
+    (globalThis as ImageRequestIdDebugGlobal)[LAST_IMAGE_REQUEST_ID_KEY] || ''
+  );
+}
+
+export function emitImageRequestIdDebugLog(
+  requestId: string,
+  meta: ImageRequestIdDebugMeta = {}
+): void {
+  if (!requestId) {
+    return;
+  }
+
+  setLatestImageRequestId(requestId);
+
+  void meta;
+  console.info(`[X-Request-Id] ${requestId}`);
+}

--- a/packages/drawnix/src/services/media-executor/fallback-adapter-routes.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-adapter-routes.ts
@@ -32,6 +32,17 @@ import {
   cacheRemoteUrl,
   cacheRemoteUrls,
 } from './fallback-utils';
+import { recoverImageByRequestId } from '../media-api';
+import { updateLLMApiLogRequestId } from './llm-api-logger';
+import type { ImageApiConfig } from '../media-api';
+
+function isTimeoutErrorForAdapterRecover(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'TimeoutError' ||
+      /Request timeout|请求超时/.test(error.message))
+  );
+}
 
 type ImageGenerationMode = 'text_to_image' | 'image_to_image' | 'image_edit';
 type ImageInputFidelity = 'high' | 'low';
@@ -125,6 +136,21 @@ export async function executeImageViaAdapter(
     taskId,
   });
 
+  // 由 sendAdapterRequest 生成的 X-Request-Id 通过 onRequestSent 回传，用于超时兜底找回
+  let capturedRequestId: string | undefined;
+  const adapterContext = getAdapterContextFromSettings(
+    'image',
+    params.modelRef || params.model,
+    { preferredRequestSchema }
+  );
+  adapterContext.onRequestSent = ({ requestId }) => {
+    if (!capturedRequestId && requestId) {
+      capturedRequestId = requestId;
+      // 补写日志的 requestId 字段
+      updateLLMApiLogRequestId(logId, requestId);
+    }
+  };
+
   try {
     let processedImages: string[] | undefined;
     if (params.referenceImages && params.referenceImages.length > 0) {
@@ -138,11 +164,9 @@ export async function executeImageViaAdapter(
 
     options?.onProgress?.({ progress: 10, phase: 'submitting' });
 
-    const result = await adapter.generateImage(
-      getAdapterContextFromSettings('image', params.modelRef || params.model, {
-        preferredRequestSchema,
-      }),
-      {
+    let result;
+    try {
+      result = await adapter.generateImage(adapterContext, {
         prompt: params.prompt,
         model: params.model,
         modelRef: params.modelRef || null,
@@ -164,8 +188,54 @@ export async function executeImageViaAdapter(
           n: params.count,
           ...params.params,
         },
+      });
+    } catch (adapterError) {
+      // 超时兜底：通过 /log/get-request 找回已经生成成功的结果
+      const recoverRequestId =
+        capturedRequestId ||
+        (typeof (adapterError as { requestId?: unknown })?.requestId ===
+        'string'
+          ? ((adapterError as { requestId?: string }).requestId as string)
+          : undefined);
+
+      if (
+        isTimeoutErrorForAdapterRecover(adapterError) &&
+        recoverRequestId &&
+        adapterContext.provider
+      ) {
+        console.warn(
+          `[FallbackAdapterRoutes] 生图请求超时，尝试通过 X-Request-Id 找回: ${recoverRequestId}`
+        );
+        try {
+          // 构造 ImageApiConfig：从 provider 上下文取字段
+          const recoverConfig: ImageApiConfig = {
+            apiKey: adapterContext.provider.apiKey || '',
+            baseUrl: adapterContext.provider.baseUrl,
+            authType: adapterContext.provider.authType,
+            providerType: adapterContext.provider.providerType,
+            extraHeaders: adapterContext.provider.extraHeaders,
+            provider: adapterContext.provider,
+            binding: adapterContext.binding || null,
+          };
+          result = await recoverImageByRequestId(
+            recoverRequestId,
+            recoverConfig,
+            options?.signal
+          );
+          console.info(
+            `[FallbackAdapterRoutes] ✅ 通过 X-Request-Id 找回结果成功: ${recoverRequestId}`
+          );
+        } catch (recoverError) {
+          console.error(
+            `[FallbackAdapterRoutes] ❌ 通过 X-Request-Id 找回失败: ${recoverRequestId}`,
+            recoverError
+          );
+          throw adapterError;
+        }
+      } else {
+        throw adapterError;
       }
-    );
+    }
 
     const duration = Date.now() - logStartTime;
 

--- a/packages/drawnix/src/services/media-executor/fallback-executor.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-executor.ts
@@ -48,7 +48,11 @@ import {
 } from '../../utils/api-auth-error-event';
 import { extractTextContent, parseToolCalls } from '../agent/tool-parser';
 import { unifiedCacheService } from '../unified-cache-service';
-import { submitVideoGeneration } from '../media-api';
+import {
+  submitVideoGeneration,
+  recoverImageByRequestId,
+} from '../media-api';
+import { emitImageRequestIdDebugLog } from '../media-api/request-id-debug';
 import {
   extractPromptFromMessages,
   buildImageRequestBody,
@@ -98,6 +102,22 @@ function buildProviderContext(config: {
       authType: config.authType || 'bearer',
       extraHeaders: config.extraHeaders,
     }
+  );
+}
+
+function generateRequestIdForImage(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (typeof g.crypto?.randomUUID === 'function') {
+    return g.crypto.randomUUID();
+  }
+  return `req-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isTimeoutErrorForRecover(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'TimeoutError' ||
+      /Request timeout|请求超时/.test(error.message))
   );
 }
 
@@ -336,11 +356,20 @@ export class FallbackMediaExecutor implements IMediaExecutor {
       );
     }
 
+    // 为本次请求生成 X-Request-Id，用于超时时通过 /log/get-request 找回结果
+    const requestId = generateRequestIdForImage();
+    emitImageRequestIdDebugLog(requestId, {
+      model: modelName,
+      endpoint: '/images/generations',
+      source: 'fallbackExecutor',
+    });
+
     // 开始记录 LLM API 调用
     const logId = startLLMApiLog({
       endpoint: '/images/generations',
       model: modelName,
       taskType: 'image',
+      requestId,
       prompt,
       hasReferenceImages: !!referenceImages && referenceImages.length > 0,
       referenceImageCount: referenceImages?.length,
@@ -375,49 +404,82 @@ export class FallbackMediaExecutor implements IMediaExecutor {
 
       options?.onProgress?.({ progress: 10, phase: 'submitting' });
 
-      // 直接调用 API
-      const response = await providerTransport.send(
-        buildProviderContext(config.imageConfig),
-        {
-          path: '/images/generations',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(requestBody),
-          signal: options?.signal,
-          timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
-        }
-      );
-
-      if (!response.ok) {
-        const duration = Date.now() - startTime;
-        const errorBody = await response
-          .text()
-          .catch(
-            () => `HTTP ${response.status} ${response.statusText || 'Error'}`
-          );
-        failLLMApiLog(logId, {
-          httpStatus: response.status,
-          duration,
-          errorMessage: errorBody.substring(0, 500),
-        });
-        throw new Error(
-          `Image generation failed: ${response.status} - ${errorBody.substring(
-            0,
-            200
-          )}`
+      let result;
+      let httpStatus = 200;
+      try {
+        // 直接调用 API
+        const response = await providerTransport.send(
+          buildProviderContext(config.imageConfig),
+          {
+            path: '/images/generations',
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(requestBody),
+            signal: options?.signal,
+            timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
+            requestId,
+          }
         );
+
+        if (!response.ok) {
+          const duration = Date.now() - startTime;
+          const errorBody = await response
+            .text()
+            .catch(
+              () => `HTTP ${response.status} ${response.statusText || 'Error'}`
+            );
+          failLLMApiLog(logId, {
+            httpStatus: response.status,
+            duration,
+            errorMessage: errorBody.substring(0, 500),
+          });
+          throw new Error(
+            `Image generation failed: ${response.status} - ${errorBody.substring(
+              0,
+              200
+            )}`
+          );
+        }
+
+        options?.onProgress?.({ progress: 80, phase: 'downloading' });
+
+        const data = await response.json();
+        result = parseImageResponse(data);
+        httpStatus = response.status;
+      } catch (sendError) {
+        // 超时兜底：尝试通过 /log/get-request 找回已经生成成功的结果
+        if (isTimeoutErrorForRecover(sendError)) {
+          console.warn(
+            `[FallbackMediaExecutor] 生图请求超时，尝试通过 X-Request-Id 找回: ${requestId}`
+          );
+          try {
+            result = await recoverImageByRequestId(
+              requestId,
+              config.imageConfig,
+              options?.signal
+            );
+            console.info(
+              `[FallbackMediaExecutor] ✅ 通过 X-Request-Id 找回结果成功: ${requestId}`
+            );
+          } catch (recoverError) {
+            console.error(
+              `[FallbackMediaExecutor] ❌ 通过 X-Request-Id 找回结果失败: ${requestId}`,
+              recoverError
+            );
+            // 找回失败，抛出原始超时错误交给外层 catch 处理
+            throw sendError;
+          }
+        } else {
+          throw sendError;
+        }
       }
 
-      options?.onProgress?.({ progress: 80, phase: 'downloading' });
-
-      const data = await response.json();
-      const result = parseImageResponse(data);
       const duration = Date.now() - startTime;
-      // 记录成功
+      // 记录成功（找回场景也走这里）
       completeLLMApiLog(logId, {
-        httpStatus: response.status,
+        httpStatus,
         duration,
         resultType: 'image',
         resultCount: 1,

--- a/packages/drawnix/src/services/media-executor/fallback-utils.test.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-utils.test.ts
@@ -250,6 +250,40 @@ describe('cacheRemoteUrl', () => {
     vi.unstubAllGlobals();
   });
 
+  it('returns a stable local URL only when explicitly requested', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(new Blob(['image-binary'], { type: 'image/png' }), {
+        status: 200,
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { cacheRemoteUrl } = await import('./fallback-utils');
+    const remoteUrl = 'https://cdn.example.com/generated/image.png';
+
+    const result = await cacheRemoteUrl(
+      remoteUrl,
+      'insert-123',
+      'image',
+      'png',
+      undefined,
+      { forceRemoteCache: true, returnLocalCacheUrl: true }
+    );
+
+    expect(result).toBe('/__aitu_cache__/image/insert-123.png');
+    expect(cacheMediaFromBlob).toHaveBeenCalledWith(
+      '/__aitu_cache__/image/insert-123.png',
+      expect.any(Blob),
+      'image',
+      {
+        taskId: 'insert-123',
+        source: 'AI_GENERATED',
+      }
+    );
+
+    vi.unstubAllGlobals();
+  });
+
   it('keeps remote http urls unchanged as well', async () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/drawnix/src/services/media-executor/fallback-utils.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-utils.ts
@@ -285,6 +285,7 @@ export async function cacheRemoteUrl(
   options?: {
     source?: 'AI_GENERATED' | 'PLAYBACK_CACHE';
     forceRemoteCache?: boolean;
+    returnLocalCacheUrl?: boolean;
     extraMetadata?: Record<string, unknown>;
   }
 ): Promise<string> {
@@ -325,13 +326,12 @@ export async function cacheRemoteUrl(
       }
 
       const suffix = index !== undefined ? `_${index}` : '';
-      const localCacheUrl =
-        mediaType === 'audio'
-          ? normalizedUrl
-          : `/__aitu_cache__/${mediaType}/${taskId}${suffix}.${format}`;
+      const cacheTargetUrl = options?.returnLocalCacheUrl
+        ? `/__aitu_cache__/${mediaType}/${taskId}${suffix}.${format}`
+        : normalizedUrl;
 
       const cacheUrl = await unifiedCacheService.cacheMediaFromBlob(
-        localCacheUrl,
+        cacheTargetUrl,
         blob,
         mediaType,
         {
@@ -340,7 +340,9 @@ export async function cacheRemoteUrl(
           ...options?.extraMetadata,
         }
       );
-      return cacheUrl || normalizedUrl;
+      return options?.returnLocalCacheUrl && cacheUrl
+        ? cacheUrl
+        : normalizedUrl;
     } catch (error) {
       console.warn(
         '[cacheRemoteUrl] Remote media cache failed, using original URL:',

--- a/packages/drawnix/src/services/media-executor/fallback-utils.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-utils.ts
@@ -324,8 +324,14 @@ export async function cacheRemoteUrl(
         return normalizedUrl;
       }
 
-      await unifiedCacheService.cacheMediaFromBlob(
-        normalizedUrl,
+      const suffix = index !== undefined ? `_${index}` : '';
+      const localCacheUrl =
+        mediaType === 'audio'
+          ? normalizedUrl
+          : `/__aitu_cache__/${mediaType}/${taskId}${suffix}.${format}`;
+
+      const cacheUrl = await unifiedCacheService.cacheMediaFromBlob(
+        localCacheUrl,
         blob,
         mediaType,
         {
@@ -334,7 +340,7 @@ export async function cacheRemoteUrl(
           ...options?.extraMetadata,
         }
       );
-      return normalizedUrl;
+      return cacheUrl || normalizedUrl;
     } catch (error) {
       console.warn(
         '[cacheRemoteUrl] Remote media cache failed, using original URL:',

--- a/packages/drawnix/src/services/media-executor/llm-api-logger.ts
+++ b/packages/drawnix/src/services/media-executor/llm-api-logger.ts
@@ -34,6 +34,7 @@ export interface LLMApiLog {
   endpoint: string;
   model: string;
   taskType: 'image' | 'video' | 'audio' | 'chat' | 'character' | 'other';
+  requestId?: string;
   prompt?: string;
   requestBody?: string;
   hasReferenceImages?: boolean;
@@ -145,6 +146,7 @@ export function startLLMApiLog(params: {
   endpoint: string;
   model: string;
   taskType: LLMApiLog['taskType'];
+  requestId?: string;
   prompt?: string;
   requestBody?: string;
   hasReferenceImages?: boolean;
@@ -161,6 +163,7 @@ export function startLLMApiLog(params: {
     endpoint: params.endpoint,
     model: params.model,
     taskType: params.taskType,
+    requestId: params.requestId,
     prompt: params.prompt ? truncate(params.prompt, 2000) : undefined,
     requestBody: params.requestBody ? sanitizeRequestBody(params.requestBody) : undefined,
     hasReferenceImages: params.hasReferenceImages,
@@ -234,6 +237,23 @@ export function updateLLMApiLogMetadata(
     if (params.httpStatus) log.httpStatus = params.httpStatus;
 
     // 更新 IndexedDB
+    saveLogToDB(log);
+  }
+}
+
+/**
+ * 补写 LLM API 日志的 requestId 字段（Fallback 版本）
+ * 用于 adapter 路径：sendAdapterRequest 内部生成 requestId 后，
+ * caller 再通过此接口回填到已创建的日志上。
+ */
+export function updateLLMApiLogRequestId(
+  logId: string,
+  requestId: string
+): void {
+  if (!requestId) return;
+  const log = memoryLogs.find((l) => l.id === logId);
+  if (log) {
+    log.requestId = requestId;
     saveLogToDB(log);
   }
 }

--- a/packages/drawnix/src/services/model-adapters/context.ts
+++ b/packages/drawnix/src/services/model-adapters/context.ts
@@ -12,6 +12,7 @@ import type { ModelType } from '../../constants/model-config';
 import { IMAGE_GENERATION_TIMEOUT_MS } from '../../constants/TASK_CONSTANTS';
 import { resolveInvocationPlanFromRoute } from '../provider-routing';
 import type { AdapterContext } from './types';
+import { emitImageRequestIdDebugLog } from '../media-api/request-id-debug';
 
 interface AdapterContextRouteOptions {
   bindingId?: string | null;
@@ -81,12 +82,45 @@ export function sendAdapterRequest(
     request.timeoutMs ??
     (context.operation === 'image' ? IMAGE_GENERATION_TIMEOUT_MS : undefined);
 
+  // 图片操作自动附带 X-Request-Id，用于超时时通过 /log/get-request 找回结果。
+  // 若 caller 已显式传入 requestId 则复用，避免重复生成。
+  let requestId = request.requestId;
+  if (!requestId && context.operation === 'image') {
+    requestId = generateRequestId();
+  }
+
+  if (requestId && context.operation === 'image') {
+    emitImageRequestIdDebugLog(requestId, {
+      endpoint: request.path,
+      source: 'sendAdapterRequest',
+    });
+  }
+
+  if (requestId && context.onRequestSent) {
+    try {
+      context.onRequestSent({ requestId });
+    } catch (err) {
+      // 回调异常不影响主流程
+      console.debug('[sendAdapterRequest] onRequestSent callback error:', err);
+    }
+  }
+
   return providerTransport.send(
     buildProviderContextFromAdapterContext(context, baseUrlOverride),
     {
       ...request,
+      requestId,
       timeoutMs,
       fetcher: context.fetcher || request.fetcher,
     }
   );
+}
+
+function generateRequestId(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (typeof g.crypto?.randomUUID === 'function') {
+    return g.crypto.randomUUID();
+  }
+  // 极端兜底（老环境）：时间戳 + 随机
+  return `req-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }

--- a/packages/drawnix/src/services/model-adapters/types.ts
+++ b/packages/drawnix/src/services/model-adapters/types.ts
@@ -22,6 +22,11 @@ export interface AdapterContext {
   provider?: ResolvedProviderContext | null;
   binding?: ProviderModelBinding | null;
   fetcher?: typeof fetch;
+  /**
+   * sendAdapterRequest 发起图片类请求时会自动生成 requestId 并通过此回调回传。
+   * 用于 caller（如 runImageAdapter）在超时时通过 /log/get-request 找回结果。
+   */
+  onRequestSent?: (info: { requestId: string }) => void;
 }
 
 export interface AdapterMetadata {

--- a/packages/drawnix/src/services/provider-routing/provider-transport.ts
+++ b/packages/drawnix/src/services/provider-routing/provider-transport.ts
@@ -9,11 +9,37 @@ function trimTrailingSlashes(value: string): string {
   return value.replace(/\/+$/, '');
 }
 
+/**
+ * DEV-ONLY: 把匹配的 API 站绝对 URL 改写为同源相对路径，
+ * 让请求走 vite dev proxy，规避浏览器对自定义头（如 X-Request-Id）的 CORS 拦截。
+ *
+ * 生产环境（import.meta.env.PROD）该逻辑不生效。
+ * 需与 apps/web/vite.config.ts 中的 server.proxy 配置配套使用。
+ */
+const DEV_PROXY_HOSTS: readonly string[] = ['api.tu-zi.com'];
+
+function rewriteBaseUrlForDevProxy(baseUrl: string): string {
+  try {
+    const isDev =
+      typeof import.meta !== 'undefined' && (import.meta as { env?: { DEV?: boolean } }).env?.DEV;
+    if (!isDev) return baseUrl;
+    if (!/^https?:\/\//i.test(baseUrl)) return baseUrl;
+
+    const parsed = new URL(baseUrl);
+    if (!DEV_PROXY_HOSTS.includes(parsed.host)) return baseUrl;
+    // 只保留 pathname（如 /v1），改写为同源相对路径
+    return parsed.pathname.replace(/\/+$/, '');
+  } catch {
+    return baseUrl;
+  }
+}
+
 function applyBaseUrlStrategy(
   baseUrl: string,
   strategy: ProviderBaseUrlStrategy = 'preserve'
 ): string {
-  const normalizedBaseUrl = trimTrailingSlashes(baseUrl);
+  const rewritten = rewriteBaseUrlForDevProxy(baseUrl);
+  const normalizedBaseUrl = trimTrailingSlashes(rewritten);
 
   switch (strategy) {
     case 'trim-v1':
@@ -155,6 +181,16 @@ function createTimeoutSignal(
   };
 }
 
+function applyRequestIdHeader(
+  headers: Record<string, string>,
+  requestId: string | undefined
+): Record<string, string> {
+  if (!requestId) {
+    return headers;
+  }
+  return { ...headers, 'X-Request-Id': requestId };
+}
+
 export class ProviderTransport {
   prepareRequest(
     context: ResolvedProviderContext,
@@ -162,6 +198,10 @@ export class ProviderTransport {
   ): PreparedProviderTransportRequest {
     const mergedHeaders = mergeHeaders(context.extraHeaders, request.headers);
     const authenticatedHeaders = applyAuthHeaders(context, mergedHeaders);
+    const finalHeaders = applyRequestIdHeader(
+      authenticatedHeaders,
+      request.requestId
+    );
     const query = applyAuthQuery(context, request.query || {});
     const resolvedBaseUrl = applyBaseUrlStrategy(
       context.baseUrl,
@@ -173,10 +213,10 @@ export class ProviderTransport {
 
     return {
       url,
-      headers: authenticatedHeaders,
+      headers: finalHeaders,
       init: {
         method: request.method || 'GET',
-        headers: authenticatedHeaders,
+        headers: finalHeaders,
         body: request.body,
         signal: request.signal,
         credentials: request.credentials,
@@ -203,10 +243,13 @@ export class ProviderTransport {
     } catch (error) {
       if (timeoutControl.didTimeout()) {
         const timeoutMinutes = Math.floor((request.timeoutMs || 0) / 60000);
-        const timeoutError = new Error(
+        const timeoutError: Error & { requestId?: string } = new Error(
           `请求超时（>${timeoutMinutes} 分钟）`
         );
         timeoutError.name = 'TimeoutError';
+        if (request.requestId) {
+          timeoutError.requestId = request.requestId;
+        }
         throw timeoutError;
       }
       throw error;

--- a/packages/drawnix/src/services/provider-routing/types.ts
+++ b/packages/drawnix/src/services/provider-routing/types.ts
@@ -181,6 +181,11 @@ export interface ProviderTransportRequest {
   timeoutMs?: number;
   credentials?: RequestCredentials;
   fetcher?: typeof fetch;
+  /**
+   * 若提供，会被写入 X-Request-Id 请求头，用于超时/失败场景兜底找回。
+   * 目前主要用于图片生成接口。
+   */
+  requestId?: string;
 }
 
 export interface PreparedProviderTransportRequest {

--- a/packages/drawnix/src/utils/canvas-insertion-layout.ts
+++ b/packages/drawnix/src/utils/canvas-insertion-layout.ts
@@ -93,9 +93,7 @@ export function shouldDebugCanvasInsertion(): boolean {
   }
 
   try {
-    const isDev =
-      typeof process !== 'undefined' && process.env.NODE_ENV !== 'production';
-    return isDev || window.localStorage?.getItem(CANVAS_INSERTION_DEBUG_FLAG) === '1';
+    return window.localStorage?.getItem(CANVAS_INSERTION_DEBUG_FLAG) === '1';
   } catch {
     return false;
   }


### PR DESCRIPTION
## 概述

本次 PR 主要完善图片生成失败后的找回与重试流程，补齐 `X-Request-Id` 相关调试能力，并修复若干图片锚点卡片与界面交互问题。

## 变更内容

- 在左侧工具区新增 `X-Request-Id` 找回入口
- 支持通过最近一次请求 ID 进行手动找回
- 新增找回结果预览面板，并支持关闭
- 精简控制台中的请求 ID 输出，便于直接复制
- 为失败任务补充 ID 复制按钮
- 优化找回失败时的用户提示文案
- 修复图片生成锚点中因任务状态变量异常导致的运行时报错
- 优化失败、取消、后处理失败等状态下的重试逻辑
- 改善图片锚点操作按钮的交互稳定性
- 在图片插入画布前优先完成远程图片缓存，避免因远程图片超时导致空白占位

## 修复问题

- 图片生成失败卡片中的“重试”按钮点击无响应
- 找回图片相关 UI 摆放不合理、占用界面空间
- 失败图片卡片缺少便捷的 ID 复制能力
- 图片已生成成功但因远程资源超时导致界面显示异常
- 找回失败时缺少清晰的失败原因提示

## 说明

- 已同步上游 `develop`
- 当前 PR 基于 `Jerry-George-Liang:develop` 提交到 `ljquan/opentu:develop`
- 本次改动包含功能代码、测试与配套文档