### PR TITLE
fix(image): 修复新增供应商生图请求的 CORS 失败

### DIFF
--- a/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
+++ b/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
@@ -256,3 +256,7 @@ apps/web/src/sw/task-queue/
 ```
 
 `[+]` = 本次改动 / 新增
+
+## 十、故障复盘
+
+- [多供应商生图 CORS 预检失败排障经验](./PROVIDER_IMAGE_CORS_LESSONS.md)：记录 `X-Request-Id` 触发跨域预检失败的证据链、修复边界与上线检查清单。

--- a/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
+++ b/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
@@ -18,18 +18,19 @@
 
 ## 二、总体设计
 
-### 2.1 传输层统一注入 X-Request-Id
+### 2.1 传输层按能力注入 X-Request-Id
 
 - `ProviderTransport.send()` 是所有 provider 请求的最终出口
 - 新增 `ProviderTransportRequest.requestId` 可选字段
-- 若传入 → 自动写入 `X-Request-Id` 请求头
-- 超时抛出的 `TimeoutError` 上会挂载 `.requestId`（便于上层直接兜底）
+- 仅在受支持的 Tuzi 同源请求中写入 `X-Request-Id`
+- 跨域 Tuzi 与其他供应商不附带该头，避免 API 未在 `Access-Control-Allow-Headers` 放行时导致 `Failed to fetch`
+- 只有实际发送了请求头时，超时抛出的 `TimeoutError` 才会挂载 `.requestId`
 - **向后兼容**：不传 `requestId` 时行为完全不变
 
 ### 2.2 图片适配器自动生成 requestId
 
 - `sendAdapterRequest()`（`model-adapters/context.ts`）
-- 当 `context.operation === 'image'` 且 caller 未显式传入 `requestId` → **自动生成 UUID**
+- 当请求为 Tuzi 同源图片调用且 caller 未显式传入 `requestId` → **自动生成 UUID**
 - 通过 `AdapterContext.onRequestSent({ requestId })` 回调回传给 caller，便于日志/兜底
 
 ### 2.3 找回接口封装
@@ -159,10 +160,11 @@ pnpm exec nx run-many -t typecheck   # 5 个包全部通过 ✓
 ### 5.2 手动验证（浏览器）
 
 **场景 A - 正常路径**：
-1. 打开应用，用 `api.tu-zi.com` provider 正常生图
+1. 本地开发环境打开应用，用 `api.tu-zi.com` provider 正常生图
 2. F12 > Application > IndexedDB > `llm-api-logs` > `logs`
 3. 找到最新一条记录，字段 `requestId` 应为 UUID（如 `8c41eb26-a2d0-fcb1-01a6-f697e7d4e2ff`）
 4. F12 > Network 面板中找到 `/images/generations` 请求，Request Headers 应包含 `X-Request-Id: <UUID>`
+5. 改用跨域供应商域名时，Request Headers 不应包含 `X-Request-Id`，且生图仍能正常完成
 
 **场景 B - 超时找回成功**：
 1. 临时把 `IMAGE_GENERATION_TIMEOUT_MS`（`constants/TASK_CONSTANTS.ts`）改到 100ms
@@ -194,7 +196,7 @@ pnpm exec nx run-many -t typecheck   # 5 个包全部通过 ✓
 | **`?sw=0` 降级模式** | 已覆盖（fallback-executor 直连 + fallback-adapter-routes 两条分支）|
 | **`crypto.randomUUID`** | Chrome 92+ / 现代 SW 全部支持，含极端兜底 fallback |
 | **`baseUrlStrategy: 'trim-v1'`** | 已有能力，不新增基础设施 |
-| **`X-Request-Id` 与 `Authorization`** | 在 `applyAuthHeaders` 之后追加，不影响鉴权 |
+| **`X-Request-Id` 与 CORS** | 仅在 Tuzi 同源/代理请求中追加；其他请求省略，避免预检失败 |
 | **找回接口自身超时** | 15s 短超时，兜底不拖累主流程 |
 
 ## 七、注意事项

--- a/docs/PROVIDER_IMAGE_CORS_LESSONS.md
+++ b/docs/PROVIDER_IMAGE_CORS_LESSONS.md
@@ -1,0 +1,149 @@
+# 多供应商生图 CORS 预检失败排障经验
+
+更新日期：2026-07-19
+
+## 背景
+
+用户新增图片供应商、选择模型并提交提示词后，任务会进入生成状态，但随后失败并只显示：
+
+```text
+Failed to fetch
+```
+
+该错误没有 HTTP 状态码和业务错误体，说明浏览器未能把真实响应交给应用层。在多供应商前端直连 API 的架构中，这种现象应优先检查 CORS 预检、DNS/TLS、浏览器扩展拦截和请求中断，不应先归因于模型或提示词。
+
+## 根因
+
+项目为同步图片请求新增了 `X-Request-Id`，用于请求超时后通过 `/log/get-request` 找回已生成结果。
+
+但该请求头被无条件用到了所有图片供应商。浏览器对跨域 `POST` 请求发起 `OPTIONS` 预检时，API 的响应只允许：
+
+```text
+Authorization
+Content-Type
+```
+
+没有在 `Access-Control-Allow-Headers` 中放行 `X-Request-Id`。因此浏览器在正式生图请求发送之前就终止了调用，前端只能收到 `TypeError: Failed to fetch`。
+
+## 关键证据链
+
+### 1. 先验证凭据与 API 基线
+
+直接请求 `/v1/models`，能正常返回模型列表，说明 API Key、Base URL 和基础鉴权可用。
+
+再用不带 `X-Request-Id` 的 `/v1/images/generations` 请求生成图片，能获得正常结果，说明模型、请求体与响应解析链路正常。
+
+### 2. 单独比较 CORS 预检
+
+分别检查两组 `Access-Control-Request-Headers`：
+
+```text
+authorization,content-type
+authorization,content-type,x-request-id
+```
+
+两次 `OPTIONS` 响应都没有在 `Access-Control-Allow-Headers` 中返回 `X-Request-Id`。这就能解释为什么 curl 可以成功，而浏览器会失败：
+
+- curl 不执行浏览器 CORS 策略。
+- 浏览器会先预检，且会拦截未被服务端明确放行的自定义头。
+
+### 3. 在真实项目界面复验
+
+在本地项目中按完整用户路径验证：
+
+1. 新增供应商。
+2. 填写 Base URL 和 API Key。
+3. 获取并添加图片模型。
+4. 从 AI 输入栏选择该供应商模型。
+5. 提交提示词并等待任务完成。
+6. 检查任务队列、结果图片、链接和控制台。
+
+修复后任务成功完成，且没有出现 `Failed to fetch`。
+
+## 修复原则
+
+### 1. 自定义请求头必须是供应商能力
+
+`X-Request-Id` 不是 OpenAI 兼容协议的通用部分，而是特定供应商的找回能力。传输层不能因为操作类型是 `image` 就向所有供应商注入该头。
+
+能力判断至少应包含：
+
+- 当前 Base URL 是否属于支持找回接口的受信供应商。
+- 最终请求是否与当前页面同源，或是否已由开发代理转成同源请求。
+
+### 2. 找回逻辑必须与实际发送的头一致
+
+只有真正发送了 `X-Request-Id` 时，才能：
+
+- 记录 request ID 调试日志。
+- 通过 `onRequestSent` 回传 request ID。
+- 在 `TimeoutError` 上挂载 request ID。
+- 超时后调用 `/log/get-request` 找回结果。
+
+否则应按普通超时失败处理，避免用一个从未发送给服务端的 ID 做无效查询。
+
+### 3. 开发代理与生产跨域是两种环境
+
+本地 Vite 代理可以把指定 API 改写为同源路径，因此可以保留 `X-Request-Id` 找回能力。但生产站点直连外部 API 时，必须服从对方 CORS 声明。
+
+测试环境也不应被误判为开发代理环境，否则 URL 会被改写为相对路径，导致单元测试无法验证真实的生产跨域行为。
+
+## 容易误判的方向
+
+### 1. 把 `Failed to fetch` 当作 HTTP 500
+
+HTTP 4xx/5xx 已经进入应用响应处理，通常能获取 status 和 body。`Failed to fetch` 更像是网络层、安全策略或请求取消问题。
+
+### 2. 只用 curl 证明已修复
+
+curl 成功只能证明 API 基线可用，无法证明浏览器 CORS 正常。前端直连供应商的功能必须在真实浏览器中做端到端验证。
+
+### 3. 只修某一个 adapter
+
+图片生成同时存在 adapter、同步 API 门面、fallback executor 等路径。如果能力规则没有收口到 provider transport 与共享判断函数，其他执行路径仍会重现问题。
+
+### 4. 修图片结果缓存链路
+
+远程图片缓存失败也可能出现 fetch 错误，但本次故障发生在生图请求提交前的预检阶段。应先根据任务进度、Network 面板和服务端是否收到请求区分故障阶段。
+
+## 测试与上线检查清单
+
+### 自动测试
+
+- 自定义跨域供应商即使传入 request ID，也不应生成 `X-Request-Id` 请求头。
+- Tuzi 跨域请求不应启用 request ID 找回。
+- Tuzi 同源或代理请求应继续启用 request ID 找回。
+- 图片 API 响应解析仍应支持远程 URL 和 Base64。
+- `drawnix` 类型检查必须通过。
+- Web 主应用和 Service Worker 生产构建必须通过。
+
+### 真实浏览器验证
+
+- 新增供应商后可以获取模型。
+- 可以选择新供应商的图片模型。
+- 提交后任务从生成中进入已完成，不出现 `Failed to fetch`。
+- 任务队列可以展示结果图和远程链接。
+- 控制台没有本次请求的 CORS 或网络错误。
+
+### 安全检查
+
+- 不在源码、日志、文档、提交记录或 PR 描述中保留 API Key。
+- 测试完成后删除临时供应商配置与本地测试数据。
+- 已在对话、录屏或截图中暴露的 Key 应尽快轮换。
+
+## 长期经验规则
+
+- 协议兼容不等于请求头、CORS、超时找回和异步查询能力完全一致。
+- 自定义头必须与 provider capability 或 binding metadata 绑定，不能只按媒体类型全局注入。
+- 排查多供应商问题时，必须分别验证鉴权、协议、CORS、提交、轮询和结果缓存。
+- 命令行基线验证与浏览器端到端验证缺一不可。
+- 超时找回机制不能以破坏正常请求为代价；不支持找回的供应商应稳定降级为普通请求。
+
+## 相关代码
+
+- `packages/drawnix/src/services/provider-routing/provider-transport.ts`
+- `packages/drawnix/src/services/model-adapters/context.ts`
+- `packages/drawnix/src/services/media-api/image-api.ts`
+- `packages/drawnix/src/services/media-executor/fallback-executor.ts`
+- `packages/drawnix/src/services/__tests__/provider-routing.test.ts`
+- `docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md`

--- a/packages/drawnix/src/services/__tests__/provider-routing.test.ts
+++ b/packages/drawnix/src/services/__tests__/provider-routing.test.ts
@@ -7,6 +7,7 @@ import {
   supportsTextBindingImageInput,
 } from '../provider-routing';
 import { providerTransport } from '../provider-routing';
+import { canAttachProviderRequestIdHeader } from '../provider-routing';
 import type {
   InvocationPlannerRepositories,
   ProviderModelBinding,
@@ -277,6 +278,53 @@ describe('provider routing', () => {
     expect(prepared.url).toBe('https://api.example.com/v1/images/generations');
     expect(prepared.headers.Authorization).toBe('Bearer secret');
     expect(prepared.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('omits X-Request-Id for custom cross-origin providers', () => {
+    const prepared = providerTransport.prepareRequest(
+      {
+        profileId: 'provider-custom',
+        profileName: 'Custom Provider',
+        providerType: 'openai-compatible',
+        baseUrl: 'https://images.example.com/v1',
+        apiKey: 'secret',
+        authType: 'bearer',
+      },
+      {
+        path: '/images/generations',
+        method: 'POST',
+        requestId: 'request-id-that-would-trigger-preflight',
+      }
+    );
+
+    expect(prepared.headers['X-Request-Id']).toBeUndefined();
+  });
+
+  it('only enables Tuzi request-id recovery for same-origin requests', () => {
+    const context: ProviderProfileSnapshot = {
+      id: 'provider-tuzi',
+      name: 'Tuzi',
+      providerType: 'openai-compatible',
+      baseUrl: 'https://api.tu-zi.com/v1',
+      apiKey: 'secret',
+      authType: 'bearer',
+    };
+    const request = { path: '/images/generations' };
+
+    expect(
+      canAttachProviderRequestIdHeader(
+        context,
+        request,
+        'https://opentu.example.com'
+      )
+    ).toBe(false);
+    expect(
+      canAttachProviderRequestIdHeader(
+        context,
+        request,
+        'https://api.tu-zi.com'
+      )
+    ).toBe(true);
   });
 
   it('prepares query-auth transport requests', () => {

--- a/packages/drawnix/src/services/media-api/image-api.ts
+++ b/packages/drawnix/src/services/media-api/image-api.ts
@@ -22,7 +22,10 @@ import {
   sleep,
   buildProviderContextFromApiConfig,
 } from './utils';
-import { providerTransport } from '../provider-routing/provider-transport';
+import {
+  canAttachProviderRequestIdHeader,
+  providerTransport,
+} from '../provider-routing/provider-transport';
 import { IMAGE_GENERATION_TIMEOUT_MS } from '../../constants/TASK_CONSTANTS';
 import { emitImageRequestIdDebugLog } from './request-id-debug';
 
@@ -269,29 +272,33 @@ export async function generateImageSync(
     model,
   });
 
-  const requestId = generateRequestId();
-  emitImageRequestIdDebugLog(requestId, {
-    model,
-    endpoint: '/images/generations',
-    source: 'generateImageSync',
-  });
+  const providerContext = buildProviderContextFromApiConfig(config);
+  const requestId = canAttachProviderRequestIdHeader(providerContext, {
+    path: '/images/generations',
+  })
+    ? generateRequestId()
+    : undefined;
+  if (requestId) {
+    emitImageRequestIdDebugLog(requestId, {
+      model,
+      endpoint: '/images/generations',
+      source: 'generateImageSync',
+    });
+  }
 
   try {
-    const response = await providerTransport.send(
-      buildProviderContextFromApiConfig(config),
-      {
-        path: '/images/generations',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
-        signal,
-        timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
-        fetcher: fetchFn,
-        requestId,
-      }
-    );
+    const response = await providerTransport.send(providerContext, {
+      path: '/images/generations',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+      signal,
+      timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
+      fetcher: fetchFn,
+      requestId,
+    });
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -304,7 +311,7 @@ export async function generateImageSync(
     return parseImageResponse(data);
   } catch (error) {
     // 超时兜底：尝试通过 /log/get-request 找回已经生成成功的结果
-    if (isTimeoutError(error)) {
+    if (isTimeoutError(error) && requestId) {
       console.warn(
         `[ImageAPI] 生图请求超时，尝试通过 X-Request-Id 找回结果: ${requestId}`
       );

--- a/packages/drawnix/src/services/media-executor/fallback-executor.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-executor.ts
@@ -25,6 +25,7 @@ import {
   type ModelRef,
 } from '../../utils/settings-manager';
 import {
+  canAttachProviderRequestIdHeader,
   providerTransport,
   resolveInvocationPlanFromRoute,
   type ProviderAuthStrategy,
@@ -356,13 +357,19 @@ export class FallbackMediaExecutor implements IMediaExecutor {
       );
     }
 
-    // 为本次请求生成 X-Request-Id，用于超时时通过 /log/get-request 找回结果
-    const requestId = generateRequestIdForImage();
-    emitImageRequestIdDebugLog(requestId, {
-      model: modelName,
-      endpoint: '/images/generations',
-      source: 'fallbackExecutor',
-    });
+    const imageProviderContext = buildProviderContext(config.imageConfig);
+    const requestId = canAttachProviderRequestIdHeader(imageProviderContext, {
+      path: '/images/generations',
+    })
+      ? generateRequestIdForImage()
+      : undefined;
+    if (requestId) {
+      emitImageRequestIdDebugLog(requestId, {
+        model: modelName,
+        endpoint: '/images/generations',
+        source: 'fallbackExecutor',
+      });
+    }
 
     // 开始记录 LLM API 调用
     const logId = startLLMApiLog({
@@ -408,20 +415,17 @@ export class FallbackMediaExecutor implements IMediaExecutor {
       let httpStatus = 200;
       try {
         // 直接调用 API
-        const response = await providerTransport.send(
-          buildProviderContext(config.imageConfig),
-          {
-            path: '/images/generations',
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(requestBody),
-            signal: options?.signal,
-            timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
-            requestId,
-          }
-        );
+        const response = await providerTransport.send(imageProviderContext, {
+          path: '/images/generations',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+          signal: options?.signal,
+          timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
+          requestId,
+        });
 
         if (!response.ok) {
           const duration = Date.now() - startTime;
@@ -450,7 +454,7 @@ export class FallbackMediaExecutor implements IMediaExecutor {
         httpStatus = response.status;
       } catch (sendError) {
         // 超时兜底：尝试通过 /log/get-request 找回已经生成成功的结果
-        if (isTimeoutErrorForRecover(sendError)) {
+        if (isTimeoutErrorForRecover(sendError) && requestId) {
           console.warn(
             `[FallbackMediaExecutor] 生图请求超时，尝试通过 X-Request-Id 找回: ${requestId}`
           );

--- a/packages/drawnix/src/services/model-adapters/context.ts
+++ b/packages/drawnix/src/services/model-adapters/context.ts
@@ -1,4 +1,5 @@
 import {
+  canAttachProviderRequestIdHeader,
   providerTransport,
   type ProviderTransportRequest,
   type ResolvedProviderContext,
@@ -82,10 +83,17 @@ export function sendAdapterRequest(
     request.timeoutMs ??
     (context.operation === 'image' ? IMAGE_GENERATION_TIMEOUT_MS : undefined);
 
-  // 图片操作自动附带 X-Request-Id，用于超时时通过 /log/get-request 找回结果。
-  // 若 caller 已显式传入 requestId 则复用，避免重复生成。
-  let requestId = request.requestId;
-  if (!requestId && context.operation === 'image') {
+  const providerContext = buildProviderContextFromAdapterContext(
+    context,
+    baseUrlOverride
+  );
+  const supportsRequestId =
+    context.operation === 'image' &&
+    canAttachProviderRequestIdHeader(providerContext, request);
+
+  // 只有受支持的同源 Tuzi 请求才附带 X-Request-Id。
+  let requestId = supportsRequestId ? request.requestId : undefined;
+  if (!requestId && supportsRequestId) {
     requestId = generateRequestId();
   }
 
@@ -105,15 +113,12 @@ export function sendAdapterRequest(
     }
   }
 
-  return providerTransport.send(
-    buildProviderContextFromAdapterContext(context, baseUrlOverride),
-    {
-      ...request,
-      requestId,
-      timeoutMs,
-      fetcher: context.fetcher || request.fetcher,
-    }
-  );
+  return providerTransport.send(providerContext, {
+    ...request,
+    requestId,
+    timeoutMs,
+    fetcher: context.fetcher || request.fetcher,
+  });
 }
 
 function generateRequestId(): string {

--- a/packages/drawnix/src/services/model-adapters/types.ts
+++ b/packages/drawnix/src/services/model-adapters/types.ts
@@ -23,8 +23,8 @@ export interface AdapterContext {
   binding?: ProviderModelBinding | null;
   fetcher?: typeof fetch;
   /**
-   * sendAdapterRequest 发起图片类请求时会自动生成 requestId 并通过此回调回传。
-   * 用于 caller（如 runImageAdapter）在超时时通过 /log/get-request 找回结果。
+   * sendAdapterRequest 仅在 Tuzi 同源图片请求中生成 requestId 并回传。
+   * caller 可在超时时通过 /log/get-request 找回结果。
    */
   onRequestSent?: (info: { requestId: string }) => void;
 }

--- a/packages/drawnix/src/services/provider-routing/provider-transport.ts
+++ b/packages/drawnix/src/services/provider-routing/provider-transport.ts
@@ -27,7 +27,8 @@ function rewriteBaseUrlForDevProxy(baseUrl: string): string {
   try {
     const isDev =
       typeof import.meta !== 'undefined' &&
-      (import.meta as { env?: { DEV?: boolean } }).env?.DEV;
+      (import.meta as { env?: { DEV?: boolean; MODE?: string } }).env?.DEV &&
+      (import.meta as { env?: { MODE?: string } }).env?.MODE !== 'test';
     if (!isDev) return baseUrl;
     if (!/^https?:\/\//i.test(baseUrl)) return baseUrl;
 
@@ -223,12 +224,53 @@ function createTimeoutSignal(
 
 function applyRequestIdHeader(
   headers: Record<string, string>,
-  requestId: string | undefined
+  requestId: string | undefined,
+  enabled: boolean
 ): Record<string, string> {
-  if (!requestId) {
+  if (!requestId || !enabled) {
     return headers;
   }
   return { ...headers, 'X-Request-Id': requestId };
+}
+
+function getRuntimeOrigin(): string | undefined {
+  const origin = globalThis.location?.origin;
+  return typeof origin === 'string' && origin !== 'null' ? origin : undefined;
+}
+
+/**
+ * X-Request-Id recovery is a Tuzi-specific capability. Cross-origin browser
+ * requests must not carry the header because the public API does not include
+ * it in Access-Control-Allow-Headers, which makes the preflight fail before
+ * the image request is submitted.
+ */
+export function canAttachProviderRequestIdHeader(
+  context: ResolvedProviderContext,
+  request: Pick<ProviderTransportRequest, 'path' | 'baseUrlStrategy'>,
+  runtimeOrigin: string | undefined = getRuntimeOrigin()
+): boolean {
+  if (!isTrustedTuziApiBaseUrl(context.baseUrl)) {
+    return false;
+  }
+
+  const resolvedBaseUrl = applyBaseUrlStrategy(
+    context.baseUrl,
+    request.baseUrlStrategy
+  );
+  const requestUrl = joinUrl(resolvedBaseUrl, request.path);
+
+  if (!/^https?:\/\//i.test(requestUrl)) {
+    return true;
+  }
+  if (!runtimeOrigin) {
+    return false;
+  }
+
+  try {
+    return new URL(requestUrl).origin === new URL(runtimeOrigin).origin;
+  } catch {
+    return false;
+  }
 }
 
 export class ProviderTransport {
@@ -236,20 +278,20 @@ export class ProviderTransport {
     context: ResolvedProviderContext,
     request: ProviderTransportRequest
   ): PreparedProviderTransportRequest {
-    const mergedHeaders = mergeHeaders(context.extraHeaders, request.headers);
-    const authenticatedHeaders = applyAuthHeaders(context, mergedHeaders);
-    const finalHeaders = applyRequestIdHeader(
-      authenticatedHeaders,
-      request.requestId
-    );
-    const query = applyAuthQuery(context, request.query || {});
     const resolvedBaseUrl = applyBaseUrlStrategy(
       context.baseUrl,
       request.baseUrlStrategy
     );
     const url = `${joinUrl(resolvedBaseUrl, request.path)}${buildQueryString(
-      query
+      applyAuthQuery(context, request.query || {})
     )}`;
+    const mergedHeaders = mergeHeaders(context.extraHeaders, request.headers);
+    const authenticatedHeaders = applyAuthHeaders(context, mergedHeaders);
+    const finalHeaders = applyRequestIdHeader(
+      authenticatedHeaders,
+      request.requestId,
+      canAttachProviderRequestIdHeader(context, request)
+    );
 
     return {
       url,
@@ -277,6 +319,9 @@ export class ProviderTransport {
       signal: timeoutControl.signal,
     });
     const fetcher = request.fetcher || fetch;
+    const requestIdHeaderApplied = Boolean(
+      prepared.headers['X-Request-Id'] || prepared.headers['x-request-id']
+    );
 
     try {
       return await fetcher(prepared.url, prepared.init);
@@ -287,7 +332,7 @@ export class ProviderTransport {
           `请求超时（>${timeoutMinutes} 分钟）`
         );
         timeoutError.name = 'TimeoutError';
-        if (request.requestId) {
+        if (request.requestId && requestIdHeaderApplied) {
           timeoutError.requestId = request.requestId;
         }
         throw timeoutError;

--- a/packages/drawnix/src/services/provider-routing/types.ts
+++ b/packages/drawnix/src/services/provider-routing/types.ts
@@ -182,8 +182,8 @@ export interface ProviderTransportRequest {
   credentials?: RequestCredentials;
   fetcher?: typeof fetch;
   /**
-   * 若提供，会被写入 X-Request-Id 请求头，用于超时/失败场景兜底找回。
-   * 目前主要用于图片生成接口。
+   * Tuzi 同源请求会将其写入 X-Request-Id，用于超时兜底找回。
+   * 其他供应商或跨域请求会忽略该字段，避免触发 CORS 预检失败。
    */
   requestId?: string;
 }


### PR DESCRIPTION
## 问题背景

用户新增图片供应商、选择模型并提交提示词后，任务进入生成状态，但随后报错：

`Failed to fetch`

API Key、模型列表及不带额外请求头的图片生成接口均可正常调用，问题只发生在浏览器环境。

## 根因

图片生成链路此前会无条件向所有图片供应商请求添加 `X-Request-Id`，用于请求超时后的结果找回。

跨域供应商的 CORS 响应没有在 `Access-Control-Allow-Headers` 中放行该自定义请求头，导致浏览器 `OPTIONS` 预检失败。正式生图请求尚未发送，前端就收到 `TypeError: Failed to fetch`。

curl 不执行浏览器 CORS 策略，因此命令行调用成功不能证明浏览器链路正常。

## 修复内容

- 将 `X-Request-Id` 限定为供应商能力，不再对所有图片供应商全局注入。
- 仅在受信任的 Tuzi 同源请求或本地开发代理请求中保留 request ID。
- 跨域 Tuzi 与其他自定义供应商自动省略该请求头，避免 CORS 预检失败。
- 仅在请求头实际发送时：
  - 记录 request ID 日志；
  - 回传 `onRequestSent`；
  - 在超时错误中附带 request ID；
  - 调用 `/log/get-request` 执行结果找回。
- 同步图片 API、图片适配器和 fallback executor 使用一致的能力判断。
- 测试模式不再误触发 Vite 开发代理 URL 改写。
- 更新 request ID 机制文档，并新增完整故障复盘。

## 回归测试

新增测试覆盖：

- 自定义跨域供应商不会发送 `X-Request-Id`。
- Tuzi 跨域请求不会启用 request ID 找回。
- Tuzi 同源请求仍保留 request ID 找回能力。

## 验证结果

- [x] 相关 Vitest：35 项通过
- [x] `drawnix` TypeScript 类型检查通过
- [x] Web 主应用生产构建通过
- [x] Service Worker 生产构建通过
- [x] `git diff --check` 通过
- [x] API Key 敏感信息扫描通过
- [x] 真实浏览器新增供应商并获取模型成功
- [x] 真实选择 `gpt-image-2` 生图成功
- [x] 任务状态正常进入“已完成”
- [x] 控制台未出现本次请求的 `Failed to fetch`

## 兼容性

- 不改变模型路由、请求体或图片响应解析。
- 不影响异步图片、视频和音频任务。
- 不支持 request ID 找回的供应商稳定降级为普通请求。
- Tuzi 同源/开发代理环境继续保留超时找回能力。

## 已知仓库基线问题

仓库全量测试仍有既存的音频测试 mock 缺失导出问题；全量 lint 也存在历史错误。这些问题不在本 PR 修改文件和功能范围内，不影响本次定向测试、类型检查及生产构建结果。