### PR TITLE
fix(image): repair Tuzi routing and image endpoint fallback

### DIFF
--- a/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
+++ b/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
@@ -256,3 +256,7 @@ apps/web/src/sw/task-queue/
 ```
 
 `[+]` = 本次改动 / 新增
+
+## 十、故障复盘
+
+- [多供应商生图 CORS 预检失败排障经验](./PROVIDER_IMAGE_CORS_LESSONS.md)：记录 `X-Request-Id` 触发跨域预检失败的证据链、修复边界与上线检查清单。

--- a/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
+++ b/docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md
@@ -18,18 +18,19 @@
 
 ## 二、总体设计
 
-### 2.1 传输层统一注入 X-Request-Id
+### 2.1 传输层按能力注入 X-Request-Id
 
 - `ProviderTransport.send()` 是所有 provider 请求的最终出口
 - 新增 `ProviderTransportRequest.requestId` 可选字段
-- 若传入 → 自动写入 `X-Request-Id` 请求头
-- 超时抛出的 `TimeoutError` 上会挂载 `.requestId`（便于上层直接兜底）
+- 仅在受支持的 Tuzi 同源请求中写入 `X-Request-Id`
+- 跨域 Tuzi 与其他供应商不附带该头，避免 API 未在 `Access-Control-Allow-Headers` 放行时导致 `Failed to fetch`
+- 只有实际发送了请求头时，超时抛出的 `TimeoutError` 才会挂载 `.requestId`
 - **向后兼容**：不传 `requestId` 时行为完全不变
 
 ### 2.2 图片适配器自动生成 requestId
 
 - `sendAdapterRequest()`（`model-adapters/context.ts`）
-- 当 `context.operation === 'image'` 且 caller 未显式传入 `requestId` → **自动生成 UUID**
+- 当请求为 Tuzi 同源图片调用且 caller 未显式传入 `requestId` → **自动生成 UUID**
 - 通过 `AdapterContext.onRequestSent({ requestId })` 回调回传给 caller，便于日志/兜底
 
 ### 2.3 找回接口封装
@@ -159,10 +160,11 @@ pnpm exec nx run-many -t typecheck   # 5 个包全部通过 ✓
 ### 5.2 手动验证（浏览器）
 
 **场景 A - 正常路径**：
-1. 打开应用，用 `api.tu-zi.com` provider 正常生图
+1. 本地开发环境打开应用，用 `api.tu-zi.com` provider 正常生图
 2. F12 > Application > IndexedDB > `llm-api-logs` > `logs`
 3. 找到最新一条记录，字段 `requestId` 应为 UUID（如 `8c41eb26-a2d0-fcb1-01a6-f697e7d4e2ff`）
 4. F12 > Network 面板中找到 `/images/generations` 请求，Request Headers 应包含 `X-Request-Id: <UUID>`
+5. 改用跨域供应商域名时，Request Headers 不应包含 `X-Request-Id`，且生图仍能正常完成
 
 **场景 B - 超时找回成功**：
 1. 临时把 `IMAGE_GENERATION_TIMEOUT_MS`（`constants/TASK_CONSTANTS.ts`）改到 100ms
@@ -194,7 +196,7 @@ pnpm exec nx run-many -t typecheck   # 5 个包全部通过 ✓
 | **`?sw=0` 降级模式** | 已覆盖（fallback-executor 直连 + fallback-adapter-routes 两条分支）|
 | **`crypto.randomUUID`** | Chrome 92+ / 现代 SW 全部支持，含极端兜底 fallback |
 | **`baseUrlStrategy: 'trim-v1'`** | 已有能力，不新增基础设施 |
-| **`X-Request-Id` 与 `Authorization`** | 在 `applyAuthHeaders` 之后追加，不影响鉴权 |
+| **`X-Request-Id` 与 CORS** | 仅在 Tuzi 同源/代理请求中追加；其他请求省略，避免预检失败 |
 | **找回接口自身超时** | 15s 短超时，兜底不拖累主流程 |
 
 ## 七、注意事项

--- a/docs/PROVIDER_IMAGE_CORS_LESSONS.md
+++ b/docs/PROVIDER_IMAGE_CORS_LESSONS.md
@@ -1,0 +1,149 @@
+# 多供应商生图 CORS 预检失败排障经验
+
+更新日期：2026-07-19
+
+## 背景
+
+用户新增图片供应商、选择模型并提交提示词后，任务会进入生成状态，但随后失败并只显示：
+
+```text
+Failed to fetch
+```
+
+该错误没有 HTTP 状态码和业务错误体，说明浏览器未能把真实响应交给应用层。在多供应商前端直连 API 的架构中，这种现象应优先检查 CORS 预检、DNS/TLS、浏览器扩展拦截和请求中断，不应先归因于模型或提示词。
+
+## 根因
+
+项目为同步图片请求新增了 `X-Request-Id`，用于请求超时后通过 `/log/get-request` 找回已生成结果。
+
+但该请求头被无条件用到了所有图片供应商。浏览器对跨域 `POST` 请求发起 `OPTIONS` 预检时，API 的响应只允许：
+
+```text
+Authorization
+Content-Type
+```
+
+没有在 `Access-Control-Allow-Headers` 中放行 `X-Request-Id`。因此浏览器在正式生图请求发送之前就终止了调用，前端只能收到 `TypeError: Failed to fetch`。
+
+## 关键证据链
+
+### 1. 先验证凭据与 API 基线
+
+直接请求 `/v1/models`，能正常返回模型列表，说明 API Key、Base URL 和基础鉴权可用。
+
+再用不带 `X-Request-Id` 的 `/v1/images/generations` 请求生成图片，能获得正常结果，说明模型、请求体与响应解析链路正常。
+
+### 2. 单独比较 CORS 预检
+
+分别检查两组 `Access-Control-Request-Headers`：
+
+```text
+authorization,content-type
+authorization,content-type,x-request-id
+```
+
+两次 `OPTIONS` 响应都没有在 `Access-Control-Allow-Headers` 中返回 `X-Request-Id`。这就能解释为什么 curl 可以成功，而浏览器会失败：
+
+- curl 不执行浏览器 CORS 策略。
+- 浏览器会先预检，且会拦截未被服务端明确放行的自定义头。
+
+### 3. 在真实项目界面复验
+
+在本地项目中按完整用户路径验证：
+
+1. 新增供应商。
+2. 填写 Base URL 和 API Key。
+3. 获取并添加图片模型。
+4. 从 AI 输入栏选择该供应商模型。
+5. 提交提示词并等待任务完成。
+6. 检查任务队列、结果图片、链接和控制台。
+
+修复后任务成功完成，且没有出现 `Failed to fetch`。
+
+## 修复原则
+
+### 1. 自定义请求头必须是供应商能力
+
+`X-Request-Id` 不是 OpenAI 兼容协议的通用部分，而是特定供应商的找回能力。传输层不能因为操作类型是 `image` 就向所有供应商注入该头。
+
+能力判断至少应包含：
+
+- 当前 Base URL 是否属于支持找回接口的受信供应商。
+- 最终请求是否与当前页面同源，或是否已由开发代理转成同源请求。
+
+### 2. 找回逻辑必须与实际发送的头一致
+
+只有真正发送了 `X-Request-Id` 时，才能：
+
+- 记录 request ID 调试日志。
+- 通过 `onRequestSent` 回传 request ID。
+- 在 `TimeoutError` 上挂载 request ID。
+- 超时后调用 `/log/get-request` 找回结果。
+
+否则应按普通超时失败处理，避免用一个从未发送给服务端的 ID 做无效查询。
+
+### 3. 开发代理与生产跨域是两种环境
+
+本地 Vite 代理可以把指定 API 改写为同源路径，因此可以保留 `X-Request-Id` 找回能力。但生产站点直连外部 API 时，必须服从对方 CORS 声明。
+
+测试环境也不应被误判为开发代理环境，否则 URL 会被改写为相对路径，导致单元测试无法验证真实的生产跨域行为。
+
+## 容易误判的方向
+
+### 1. 把 `Failed to fetch` 当作 HTTP 500
+
+HTTP 4xx/5xx 已经进入应用响应处理，通常能获取 status 和 body。`Failed to fetch` 更像是网络层、安全策略或请求取消问题。
+
+### 2. 只用 curl 证明已修复
+
+curl 成功只能证明 API 基线可用，无法证明浏览器 CORS 正常。前端直连供应商的功能必须在真实浏览器中做端到端验证。
+
+### 3. 只修某一个 adapter
+
+图片生成同时存在 adapter、同步 API 门面、fallback executor 等路径。如果能力规则没有收口到 provider transport 与共享判断函数，其他执行路径仍会重现问题。
+
+### 4. 修图片结果缓存链路
+
+远程图片缓存失败也可能出现 fetch 错误，但本次故障发生在生图请求提交前的预检阶段。应先根据任务进度、Network 面板和服务端是否收到请求区分故障阶段。
+
+## 测试与上线检查清单
+
+### 自动测试
+
+- 自定义跨域供应商即使传入 request ID，也不应生成 `X-Request-Id` 请求头。
+- Tuzi 跨域请求不应启用 request ID 找回。
+- Tuzi 同源或代理请求应继续启用 request ID 找回。
+- 图片 API 响应解析仍应支持远程 URL 和 Base64。
+- `drawnix` 类型检查必须通过。
+- Web 主应用和 Service Worker 生产构建必须通过。
+
+### 真实浏览器验证
+
+- 新增供应商后可以获取模型。
+- 可以选择新供应商的图片模型。
+- 提交后任务从生成中进入已完成，不出现 `Failed to fetch`。
+- 任务队列可以展示结果图和远程链接。
+- 控制台没有本次请求的 CORS 或网络错误。
+
+### 安全检查
+
+- 不在源码、日志、文档、提交记录或 PR 描述中保留 API Key。
+- 测试完成后删除临时供应商配置与本地测试数据。
+- 已在对话、录屏或截图中暴露的 Key 应尽快轮换。
+
+## 长期经验规则
+
+- 协议兼容不等于请求头、CORS、超时找回和异步查询能力完全一致。
+- 自定义头必须与 provider capability 或 binding metadata 绑定，不能只按媒体类型全局注入。
+- 排查多供应商问题时，必须分别验证鉴权、协议、CORS、提交、轮询和结果缓存。
+- 命令行基线验证与浏览器端到端验证缺一不可。
+- 超时找回机制不能以破坏正常请求为代价；不支持找回的供应商应稳定降级为普通请求。
+
+## 相关代码
+
+- `packages/drawnix/src/services/provider-routing/provider-transport.ts`
+- `packages/drawnix/src/services/model-adapters/context.ts`
+- `packages/drawnix/src/services/media-api/image-api.ts`
+- `packages/drawnix/src/services/media-executor/fallback-executor.ts`
+- `packages/drawnix/src/services/__tests__/provider-routing.test.ts`
+- `docs/IMAGE_REQUEST_ID_RECOVERY_GUIDE.md`

--- a/docs/PROVIDER_IMAGE_ENDPOINT_404_LESSONS.md
+++ b/docs/PROVIDER_IMAGE_ENDPOINT_404_LESSONS.md
@@ -1,0 +1,94 @@
+# 多供应商生图 404 路径排障经验
+
+更新日期：2026-07-19
+
+## 现象
+
+新增供应商后，模型可以被正常发现和选择，但提交生图任务后返回：
+
+```text
+Tuzi GPT Image request failed: 404
+```
+
+这与浏览器的 `Failed to fetch` 不同。`404` 说明请求已经到达 HTTP 服务，但最终 URL 没有命中生图端点。
+
+## 根因
+
+OpenAI 兼容的生图端点通常是：
+
+```text
+POST /v1/images/generations
+```
+
+供应商配置将 `https://api.tu-zi.com/v1` 作为 Base URL 时，binding 应使用 `/images/generations`。如果 endpoint discovery、旧任务快照或手工 binding 又保留了 `/v1/images/generations`，普通字符串拼接会产生：
+
+```text
+https://api.tu-zi.com/v1/v1/images/generations
+```
+
+该路径会返回 `404`。
+
+## 验证方法
+
+排查时应将三个候选路径分开验证：
+
+```text
+/images/generations
+/v1/images/generations
+/v1/v1/images/generations
+```
+
+在 `api.tu-zi.com` 的本次验证中：
+
+- `/v1/images/generations` 是存在的正确 API；无凭据时返回 `401`，使用有效凭据可返回图片。
+- `/v1/v1/images/generations` 返回 `404`。
+- 主机根路径下的 `/images/generations` 可能返回站点 HTML，不能当作生图 API 成功。
+
+判断站点是否故障时，不能只看一次 `404`。应使用正确路径完成一次最小真实生成，并确认响应包含图片 URL 或 Base64 数据。
+
+## 修复原则
+
+### 1. 在统一传输层处理版本边界
+
+URL 合并时，如果 Base URL 的末尾版本段与 path 开头的版本段完全相同，只保留一个。
+
+例如：
+
+```text
+base: https://api.tu-zi.com/v1
+path: /v1/images/generations
+result: https://api.tu-zi.com/v1/images/generations
+```
+
+只折叠完全相同的版本段。`/v1` 和 `/v1beta` 不得合并，绝对 URL 也不得改写。
+
+Tuzi GPT 生图还应显式使用 `ensure-v1` 传输策略。站点测速或备用站切换只保存 origin 时，运行时会自动补上 `/v1`；Base URL 已经包含 `/v1` 时不重复追加。
+
+### 2. Base URL 与 endpoint path 职责必须清晰
+
+- Base URL 已包含 `/v1` 时，常规 OpenAI binding 使用 `/images/generations`。
+- endpoint 已经是完整绝对 URL 时，应直接使用，不再与 Base URL 拼接。
+- Google `v1beta`、Suno 根路径、Kling 专用路径应继续使用各自的 `baseUrlStrategy`。
+
+### 3. 错误必须携带可安全暴露的 endpoint
+
+供应商返回空响应或 HTML 错误页时，错误文案应包含最终 URL 的 pathname，但不包含 query、API Key 或 Authorization 请求头。
+
+## 回归清单
+
+- Base URL 为 `https://host/v1`，path 为 `/images/generations`。
+- Base URL 为 `https://host`，使用 `ensure-v1`，path 为 `/images/generations`。
+- Base URL 为 `https://host/v1`，path 为 `/v1/images/generations`。
+- Base URL 为 `https://host/v1`，path 为 `/v1`。
+- Base URL 为 `https://host/v1`，path 为 `/v1beta/...`，不应错误合并。
+- 绝对 endpoint URL 保持不变。
+- `404` 无 JSON 错误体时，用户可以看到最终 endpoint path。
+- 使用真实供应商完成一次生图，不只验证模型列表。
+
+## 相关代码
+
+- `packages/drawnix/src/services/provider-routing/provider-transport.ts`
+- `packages/drawnix/src/services/model-adapters/tuzi-gpt-image-adapter.ts`
+- `packages/drawnix/src/services/__tests__/provider-routing.test.ts`
+- `packages/drawnix/src/services/__tests__/tuzi-gpt-image-adapter.test.ts`
+- `docs/PROVIDER_IMAGE_CORS_LESSONS.md`

--- a/docs/PROVIDER_IMAGE_ENDPOINT_404_LESSONS.md
+++ b/docs/PROVIDER_IMAGE_ENDPOINT_404_LESSONS.md
@@ -70,6 +70,10 @@ Tuzi GPT 生图还应显式使用 `ensure-v1` 传输策略。站点测速或备�
 - endpoint 已经是完整绝对 URL 时，应直接使用，不再与 Base URL 拼接。
 - Google `v1beta`、Suno 根路径、Kling 专用路径应继续使用各自的 `baseUrlStrategy`。
 
+设置页中的 Tuzi 站点列表可以展示简洁的 origin，例如 `https://apicdn.tu-zi.com`，但选中或测速切换后写入供应商配置的必须立即是 `https://apicdn.tu-zi.com/v1`。重新打开设置时，应从已保存的 `/v1` Base URL 反查并唯一高亮对应站点。
+
+模型价格地址是独立配置，仍使用 origin 下的 `/api/pricing`，不应被改成 `/v1/api/pricing`。
+
 ### 3. 错误必须携带可安全暴露的 endpoint
 
 供应商返回空响应或 HTML 错误页时，错误文案应包含最终 URL 的 pathname，但不包含 query、API Key 或 Authorization 请求头。
@@ -82,6 +86,9 @@ Tuzi GPT 生图还应显式使用 `ensure-v1` 传输策略。站点测速或备�
 - Base URL 为 `https://host/v1`，path 为 `/v1`。
 - Base URL 为 `https://host/v1`，path 为 `/v1beta/...`，不应错误合并。
 - 绝对 endpoint URL 保持不变。
+- 设置页点击或自动选择备用站后，API 地址立即包含 `/v1`。
+- 关闭并重新打开设置后，已保存站点保持唯一高亮。
+- 价格地址仍为 `/api/pricing`，不追加 `/v1`。
 - `404` 无 JSON 错误体时，用户可以看到最终 endpoint path。
 - 使用真实供应商完成一次生图，不只验证模型列表。
 
@@ -89,6 +96,8 @@ Tuzi GPT 生图还应显式使用 `ensure-v1` 传输策略。站点测速或备�
 
 - `packages/drawnix/src/services/provider-routing/provider-transport.ts`
 - `packages/drawnix/src/services/model-adapters/tuzi-gpt-image-adapter.ts`
+- `packages/drawnix/src/components/settings-dialog/provider-endpoint-utils.ts`
+- `packages/drawnix/src/utils/provider-base-url.ts`
 - `packages/drawnix/src/services/__tests__/provider-routing.test.ts`
 - `packages/drawnix/src/services/__tests__/tuzi-gpt-image-adapter.test.ts`
 - `docs/PROVIDER_IMAGE_CORS_LESSONS.md`

--- a/docs/PROVIDER_IMAGE_ENDPOINT_404_LESSONS.md
+++ b/docs/PROVIDER_IMAGE_ENDPOINT_404_LESSONS.md
@@ -74,6 +74,12 @@ Tuzi GPT 生图还应显式使用 `ensure-v1` 传输策略。站点测速或备�
 
 模型价格地址是独立配置，仍使用 origin 下的 `/api/pricing`，不应被改成 `/v1/api/pricing`。
 
+Tuzi 的官方备用站不都使用 `tu-zi.com` 域名。美国、广州和深圳节点使用 `sydney-ai.com` 或 `ourzhishi.top`，路由判断必须基于受信站点列表，不能只检查 hostname 后缀。否则切换备用站后，同一个 `gpt-image-2` 会被误判为普通 OpenAI 兼容模型并选择错误 adapter。
+
+Tuzi `default` 分组的 GPT Image 简化 JSON 格式对文生图和参考图请求都使用 `/v1/images/generations`。旧任务或历史 binding 即使保存了 `/images/edits`，Tuzi JSON adapter 也必须修正回 `/images/generations`，不能把 JSON 请求发送到官方 multipart edits 接口。
+
+站点首页测速只能反映连通性，不能证明生图路由可用。可信 Tuzi 节点对图片 POST 返回 `404` 时，应保持相同 API 版本和请求体尝试其它官方节点；普通供应商、绝对 endpoint 和非图片请求不得触发该切换。
+
 ### 3. 错误必须携带可安全暴露的 endpoint
 
 供应商返回空响应或 HTML 错误页时，错误文案应包含最终 URL 的 pathname，但不包含 query、API Key 或 Authorization 请求头。
@@ -89,6 +95,9 @@ Tuzi GPT 生图还应显式使用 `ensure-v1` 传输策略。站点测速或备�
 - 设置页点击或自动选择备用站后，API 地址立即包含 `/v1`。
 - 关闭并重新打开设置后，已保存站点保持唯一高亮。
 - 价格地址仍为 `/api/pricing`，不追加 `/v1`。
+- 官方备用域名仍按 Tuzi GPT Image 兼容模式推断 binding。
+- 历史 `/images/edits` binding 在 Tuzi JSON adapter 中修正为 `/images/generations`。
+- 可信 Tuzi 图片路由返回 `404` 时自动尝试下一官方节点。
 - `404` 无 JSON 错误体时，用户可以看到最终 endpoint path。
 - 使用真实供应商完成一次生图，不只验证模型列表。
 

--- a/packages/drawnix/src/components/settings-dialog/__tests__/provider-endpoint-utils.test.ts
+++ b/packages/drawnix/src/components/settings-dialog/__tests__/provider-endpoint-utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeEndpointApiBaseUrl,
+  normalizeEndpointUrl,
+  resolveEndpointSelectionUrl,
+} from '../provider-endpoint-utils';
+
+describe('provider endpoint utils', () => {
+  it('keeps endpoint cards on origins while storing versioned API bases', () => {
+    expect(normalizeEndpointUrl('https://apius.tu-zi.com/')).toBe(
+      'https://apius.tu-zi.com'
+    );
+    expect(normalizeEndpointApiBaseUrl('https://apius.tu-zi.com')).toBe(
+      'https://apius.tu-zi.com/v1'
+    );
+    expect(normalizeEndpointApiBaseUrl('https://apius.tu-zi.com/v1')).toBe(
+      'https://apius.tu-zi.com/v1'
+    );
+  });
+
+  it('maps a saved /v1 base URL back to the matching endpoint card', () => {
+    expect(
+      resolveEndpointSelectionUrl('https://apicdn.tu-zi.com/v1', [
+        'https://api.tu-zi.com',
+        'https://apius.tu-zi.com',
+        'https://apicdn.tu-zi.com',
+      ])
+    ).toBe('https://apicdn.tu-zi.com');
+  });
+
+  it('preserves custom path prefixes when normalizing endpoint bases', () => {
+    expect(
+      normalizeEndpointApiBaseUrl('https://gateway.example.com/openai')
+    ).toBe('https://gateway.example.com/openai/v1');
+    expect(
+      resolveEndpointSelectionUrl('https://gateway.example.com/openai/v1', [
+        'https://gateway.example.com/openai',
+      ])
+    ).toBe('https://gateway.example.com/openai');
+  });
+});

--- a/packages/drawnix/src/components/settings-dialog/provider-endpoint-utils.ts
+++ b/packages/drawnix/src/components/settings-dialog/provider-endpoint-utils.ts
@@ -1,0 +1,36 @@
+import { normalizeModelApiBaseUrl } from '../../utils/provider-base-url';
+
+export function normalizeEndpointUrl(url?: string | null): string {
+  const trimmed = (url || '').trim();
+  if (!trimmed) return normalizeModelApiBaseUrl('');
+  const withoutTrailingSlash = trimmed.replace(/\/+$/, '');
+
+  try {
+    const parsed = new URL(
+      /^[a-z][a-z\d+\-.]*:\/\//i.test(withoutTrailingSlash)
+        ? withoutTrailingSlash
+        : `https://${withoutTrailingSlash}`
+    );
+    const pathname = parsed.pathname.replace(/\/+$/, '');
+    return `${parsed.origin}${pathname === '/' ? '' : pathname}`;
+  } catch {
+    return withoutTrailingSlash || normalizeModelApiBaseUrl('');
+  }
+}
+
+export function normalizeEndpointApiBaseUrl(url?: string | null): string {
+  return normalizeModelApiBaseUrl(normalizeEndpointUrl(url));
+}
+
+export function resolveEndpointSelectionUrl(
+  baseUrl: string,
+  endpointUrls: readonly string[]
+): string {
+  const normalizedApiBaseUrl = normalizeEndpointApiBaseUrl(baseUrl);
+  const matchingEndpoint = endpointUrls.find(
+    (endpointUrl) =>
+      normalizeEndpointApiBaseUrl(endpointUrl) === normalizedApiBaseUrl
+  );
+
+  return normalizeEndpointUrl(matchingEndpoint || baseUrl);
+}

--- a/packages/drawnix/src/components/settings-dialog/settings-dialog.tsx
+++ b/packages/drawnix/src/components/settings-dialog/settings-dialog.tsx
@@ -48,10 +48,8 @@ import {
   useProfilePreferredModels,
   useRuntimeModelDiscoveryState,
 } from '../../hooks/use-runtime-models';
-import {
-  normalizeModelApiBaseUrl,
-  runtimeModelDiscovery,
-} from '../../utils/runtime-model-discovery';
+import { runtimeModelDiscovery } from '../../utils/runtime-model-discovery';
+import { normalizeModelApiBaseUrl } from '../../utils/provider-base-url';
 import { compareModelsByDisplayPriority } from '../../utils/model-sort';
 import {
   createModelRef,
@@ -99,6 +97,11 @@ import {
 import { modelBenchmarkService } from '../../services/model-benchmark-service';
 import { HoverTip } from '../shared/hover';
 import { createProviderProfileDraft } from './provider-profile-draft';
+import {
+  normalizeEndpointApiBaseUrl,
+  normalizeEndpointUrl,
+  resolveEndpointSelectionUrl,
+} from './provider-endpoint-utils';
 import { MessagePlugin } from '../../utils/message-plugin';
 import {
   isTrustedTuziApiBaseUrl,
@@ -678,23 +681,6 @@ function buildPresetRouteModels(
   );
 }
 
-function normalizeEndpointUrl(url?: string | null): string {
-  const trimmed = (url || '').trim();
-  if (!trimmed) return TUZI_PROVIDER_DEFAULT_BASE_URL;
-  const withoutTrailingSlash = trimmed.replace(/\/+$/, '');
-  try {
-    const parsed = new URL(
-      /^[a-z][a-z\d+\-.]*:\/\//i.test(withoutTrailingSlash)
-        ? withoutTrailingSlash
-        : `https://${withoutTrailingSlash}`
-    );
-    const pathname = parsed.pathname.replace(/\/+$/, '');
-    return `${parsed.origin}${pathname === '/' ? '' : pathname}`;
-  } catch {
-    return withoutTrailingSlash || TUZI_PROVIDER_DEFAULT_BASE_URL;
-  }
-}
-
 function createEndpointOption(
   endpoint:
     | string
@@ -1197,8 +1183,15 @@ export const SettingsDialog = ({
     if (!selectedProfile) {
       return;
     }
-    const normalizedUrl = normalizeEndpointUrl(selectedProfile.baseUrl);
-    setSelectedEndpointUrl(normalizedUrl);
+    setSelectedEndpointUrl(
+      resolveEndpointSelectionUrl(
+        selectedProfile.baseUrl,
+        endpointOptions.map((endpoint) => endpoint.url)
+      )
+    );
+  }, [endpointOptions, selectedProfile?.baseUrl, selectedProfile?.id]);
+
+  useEffect(() => {
     setEndpointSelectionMode('auto');
   }, [selectedProfile?.id]);
 
@@ -1230,16 +1223,17 @@ export const SettingsDialog = ({
         return;
       }
       const normalizedUrl = normalizeEndpointUrl(url);
+      const normalizedApiBaseUrl = normalizeEndpointApiBaseUrl(normalizedUrl);
       setEndpointSelectionMode(mode);
       setSelectedEndpointUrl(normalizedUrl);
       updateProfile(selectedProfile.id, (profile) => ({
         ...profile,
-        baseUrl: normalizedUrl,
+        baseUrl: normalizedApiBaseUrl,
       }));
       if (selectedProfile.id === LEGACY_DEFAULT_PROVIDER_PROFILE_ID) {
         void geminiSettings.update({
           ...geminiSettings.get(),
-          baseUrl: normalizedUrl,
+          baseUrl: normalizedApiBaseUrl,
         });
       }
     },
@@ -2684,10 +2678,7 @@ export const SettingsDialog = ({
 
                   <div className="settings-dialog__endpoint-list">
                     {endpointOptions.map((endpoint) => {
-                      const selected =
-                        endpoint.url === activeEndpoint.url ||
-                        (endpointSelectionMode === 'auto' &&
-                          endpoint.url === bestEndpoint.url);
+                      const selected = endpoint.url === activeEndpoint.url;
                       const latency = endpointLatencies[endpoint.url];
                       const latencyText =
                         typeof latency === 'number'

--- a/packages/drawnix/src/services/__tests__/image-routing-adapter-integration.test.ts
+++ b/packages/drawnix/src/services/__tests__/image-routing-adapter-integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ModelVendor, type ModelConfig } from '../../constants/model-config';
 import { fluxImageAdapter } from '../model-adapters/flux-adapter';
 import { gptImageAdapter } from '../model-adapters/gpt-image-adapter';
@@ -133,6 +133,98 @@ describe('image routing to default registered adapters', () => {
     expect(binding.requestSchema).toBe('tuzi.image.gpt-generation-json');
     expect(resolveAdapterForBinding(binding, 'image')?.id).toBe(
       'tuzi-gpt-image-adapter'
+    );
+  });
+
+  it('executes legacy versioned Tuzi image bindings without duplicating /v1', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [{ url: 'https://example.com/generated.png' }],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+    );
+
+    const result = await tuziGPTImageAdapter.generateImage(
+      {
+        baseUrl: 'https://api.tu-zi.com/v1',
+        apiKey: 'test-key',
+        authType: 'bearer',
+        fetcher,
+        binding: {
+          id: 'legacy-versioned-binding',
+          profileId: 'tuzi',
+          modelId: 'gpt-image-2',
+          operation: 'image',
+          protocol: 'openai.images.generations',
+          requestSchema: 'tuzi.image.gpt-generation-json',
+          responseSchema: 'openai.image.data',
+          submitPath: '/v1/images/generations',
+          priority: 320,
+          confidence: 'high',
+          source: 'manual',
+        },
+      },
+      {
+        model: 'gpt-image-2',
+        prompt: 'Draw a clean product photo',
+      }
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher.mock.calls[0]?.[0]).toBe(
+      'https://api.tu-zi.com/v1/images/generations'
+    );
+    expect(result.url).toBe('https://example.com/generated.png');
+  });
+
+  it('executes Tuzi image requests when endpoint selection stores an origin', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [{ url: 'https://example.com/generated.png' }],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+    );
+
+    await tuziGPTImageAdapter.generateImage(
+      {
+        baseUrl: 'https://api.tu-zi.com',
+        apiKey: 'test-key',
+        authType: 'bearer',
+        fetcher,
+        binding: {
+          id: 'origin-binding',
+          profileId: 'tuzi',
+          modelId: 'gpt-image-2',
+          operation: 'image',
+          protocol: 'openai.images.generations',
+          requestSchema: 'tuzi.image.gpt-generation-json',
+          responseSchema: 'openai.image.data',
+          submitPath: '/images/generations',
+          priority: 320,
+          confidence: 'high',
+          source: 'template',
+        },
+      },
+      {
+        model: 'gpt-image-2',
+        prompt: 'Draw a clean product photo',
+      }
+    );
+
+    expect(fetcher.mock.calls[0]?.[0]).toBe(
+      'https://api.tu-zi.com/v1/images/generations'
     );
   });
 

--- a/packages/drawnix/src/services/__tests__/model-health-service.test.ts
+++ b/packages/drawnix/src/services/__tests__/model-health-service.test.ts
@@ -77,9 +77,11 @@ describe('model-health-service', () => {
     );
   });
 
-  it('detects tu-zi.com hostnames only', () => {
+  it('detects Tuzi primary and trusted alternate hostnames', () => {
     expect(isTuziApiUrl('https://api.tu-zi.com/v1')).toBe(true);
     expect(isTuziApiUrl('apistatus.tu-zi.com/api')).toBe(true);
+    expect(isTuziApiUrl('https://api.sydney-ai.com/v1')).toBe(true);
+    expect(isTuziApiUrl('https://api.ourzhishi.top/v1')).toBe(true);
     expect(isTuziApiUrl('https://not-tu-zi.com/v1')).toBe(false);
   });
 

--- a/packages/drawnix/src/services/__tests__/provider-routing.test.ts
+++ b/packages/drawnix/src/services/__tests__/provider-routing.test.ts
@@ -7,6 +7,7 @@ import {
   supportsTextBindingImageInput,
 } from '../provider-routing';
 import { providerTransport } from '../provider-routing';
+import { canAttachProviderRequestIdHeader } from '../provider-routing';
 import type {
   InvocationPlannerRepositories,
   ProviderModelBinding,
@@ -277,6 +278,53 @@ describe('provider routing', () => {
     expect(prepared.url).toBe('https://api.example.com/v1/images/generations');
     expect(prepared.headers.Authorization).toBe('Bearer secret');
     expect(prepared.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('omits X-Request-Id for custom cross-origin providers', () => {
+    const prepared = providerTransport.prepareRequest(
+      {
+        profileId: 'provider-custom',
+        profileName: 'Custom Provider',
+        providerType: 'openai-compatible',
+        baseUrl: 'https://images.example.com/v1',
+        apiKey: 'secret',
+        authType: 'bearer',
+      },
+      {
+        path: '/images/generations',
+        method: 'POST',
+        requestId: 'request-id-that-would-trigger-preflight',
+      }
+    );
+
+    expect(prepared.headers['X-Request-Id']).toBeUndefined();
+  });
+
+  it('only enables Tuzi request-id recovery for same-origin requests', () => {
+    const context: ProviderProfileSnapshot = {
+      id: 'provider-tuzi',
+      name: 'Tuzi',
+      providerType: 'openai-compatible',
+      baseUrl: 'https://api.tu-zi.com/v1',
+      apiKey: 'secret',
+      authType: 'bearer',
+    };
+    const request = { path: '/images/generations' };
+
+    expect(
+      canAttachProviderRequestIdHeader(
+        context,
+        request,
+        'https://opentu.example.com'
+      )
+    ).toBe(false);
+    expect(
+      canAttachProviderRequestIdHeader(
+        context,
+        request,
+        'https://api.tu-zi.com'
+      )
+    ).toBe(true);
   });
 
   it('prepares query-auth transport requests', () => {

--- a/packages/drawnix/src/services/__tests__/provider-routing.test.ts
+++ b/packages/drawnix/src/services/__tests__/provider-routing.test.ts
@@ -477,6 +477,101 @@ describe('provider routing', () => {
     );
   });
 
+  it('retries Tuzi image 404 responses on a trusted fallback endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: {
+                api_address_list: [
+                  { url: 'https://api.tu-zi.com' },
+                  { url: 'https://apius.tu-zi.com' },
+                ],
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+      )
+    );
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('<!doctype html><title>Not Found</title>', {
+          status: 404,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [{ url: 'fallback.png' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    try {
+      const response = await providerTransport.send(
+        {
+          profileId: 'provider-tuzi',
+          profileName: 'Tuzi',
+          providerType: 'openai-compatible',
+          baseUrl: 'https://api.tu-zi.com/v1',
+          apiKey: 'secret',
+          authType: 'bearer',
+        },
+        {
+          path: '/images/generations',
+          baseUrlStrategy: 'ensure-v1',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: 'gpt-image-2', prompt: 'test' }),
+          fetcher,
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect(fetcher).toHaveBeenNthCalledWith(
+        1,
+        'https://api.tu-zi.com/v1/images/generations',
+        expect.any(Object)
+      );
+      expect(fetcher).toHaveBeenNthCalledWith(
+        2,
+        'https://apius.tu-zi.com/v1/images/generations',
+        expect.any(Object)
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('treats trusted Tuzi alternate domains as Tuzi GPT Image providers', () => {
+    const model: ModelConfig = {
+      id: 'gpt-image-2',
+      label: 'GPT Image 2',
+      type: 'image',
+      vendor: ModelVendor.GPT,
+    };
+
+    const bindings = inferBindingsForProviderModel(
+      {
+        id: 'provider-tuzi-alt',
+        name: 'Tuzi Alternate',
+        providerType: 'openai-compatible',
+        baseUrl: 'https://api.ourzhishi.top/v1',
+        apiKey: 'secret',
+        authType: 'bearer',
+        imageApiCompatibility: 'auto',
+      },
+      model
+    );
+
+    expect(bindings.map((binding) => binding.requestSchema)).toEqual([
+      'tuzi.image.gpt-generation-json',
+      'tuzi.image.gpt-edit-json',
+    ]);
+  });
+
   it('infers different bindings for the same model across provider types', () => {
     const model: ModelConfig = {
       id: 'gemini-3-pro-image-preview',

--- a/packages/drawnix/src/services/__tests__/provider-routing.test.ts
+++ b/packages/drawnix/src/services/__tests__/provider-routing.test.ts
@@ -280,6 +280,82 @@ describe('provider routing', () => {
     expect(prepared.headers['Content-Type']).toBe('application/json');
   });
 
+  it('collapses a duplicated API version at the URL join boundary', () => {
+    const prepared = providerTransport.prepareRequest(
+      {
+        profileId: 'provider-tuzi',
+        profileName: 'Tuzi',
+        providerType: 'openai-compatible',
+        baseUrl: 'https://api.tu-zi.com/v1',
+        apiKey: 'secret',
+        authType: 'bearer',
+      },
+      {
+        path: '/v1/images/generations',
+        method: 'POST',
+      }
+    );
+
+    expect(prepared.url).toBe('https://api.tu-zi.com/v1/images/generations');
+  });
+
+  it('keeps different API version segments when joining provider URLs', () => {
+    const prepared = providerTransport.prepareRequest(
+      {
+        profileId: 'provider-custom',
+        profileName: 'Custom Provider',
+        providerType: 'custom',
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'secret',
+        authType: 'bearer',
+      },
+      {
+        path: '/v1beta/models/test:generateContent',
+      }
+    );
+
+    expect(prepared.url).toBe(
+      'https://api.example.com/v1/v1beta/models/test:generateContent'
+    );
+  });
+
+  it('collapses an exact duplicate API version path', () => {
+    const prepared = providerTransport.prepareRequest(
+      {
+        profileId: 'provider-custom',
+        profileName: 'Custom Provider',
+        providerType: 'custom',
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'secret',
+        authType: 'bearer',
+      },
+      {
+        path: '/v1',
+      }
+    );
+
+    expect(prepared.url).toBe('https://api.example.com/v1');
+  });
+
+  it('adds /v1 when a versioned API receives a provider origin', () => {
+    const prepared = providerTransport.prepareRequest(
+      {
+        profileId: 'provider-tuzi',
+        profileName: 'Tuzi',
+        providerType: 'openai-compatible',
+        baseUrl: 'https://api.tu-zi.com',
+        apiKey: 'secret',
+        authType: 'bearer',
+      },
+      {
+        path: '/images/generations',
+        baseUrlStrategy: 'ensure-v1',
+      }
+    );
+
+    expect(prepared.url).toBe('https://api.tu-zi.com/v1/images/generations');
+  });
+
   it('omits X-Request-Id for custom cross-origin providers', () => {
     const prepared = providerTransport.prepareRequest(
       {

--- a/packages/drawnix/src/services/__tests__/tuzi-api-endpoints.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-api-endpoints.test.ts
@@ -4,7 +4,7 @@ describe('tuzi-api-endpoints', () => {
   it('只把内置 tuzi-api 上游 origin 视为可信', async () => {
     vi.resetModules();
 
-    const { isTrustedTuziApiBaseUrl } = await import(
+    const { isTrustedTuziApiBaseUrl, isTuziCompatibleBaseUrl } = await import(
       '../provider-routing/tuzi-api-endpoints'
     );
 
@@ -14,6 +14,12 @@ describe('tuzi-api-endpoints', () => {
     );
     expect(isTrustedTuziApiBaseUrl('https://api.openai.com/v1')).toBe(false);
     expect(isTrustedTuziApiBaseUrl('https://evil.tu-zi.com/v1')).toBe(false);
+    expect(isTuziCompatibleBaseUrl('https://api.sydney-ai.com/v1')).toBe(true);
+    expect(isTuziCompatibleBaseUrl('https://api.ourzhishi.top/v1')).toBe(true);
+    expect(isTuziCompatibleBaseUrl('https://apisz.ourzhishi.top/v1')).toBe(
+      true
+    );
+    expect(isTuziCompatibleBaseUrl('https://api.openai.com/v1')).toBe(false);
   });
 
   it('解析 tuzi-api 状态接口中的站点列表，并过滤非上游站点', async () => {

--- a/packages/drawnix/src/services/__tests__/tuzi-gpt-image-adapter.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-gpt-image-adapter.test.ts
@@ -98,6 +98,7 @@ describe('tuzi GPT image adapter', () => {
     expect(mocks.sendAdapterRequest).toHaveBeenCalledTimes(1);
     const request = mocks.sendAdapterRequest.mock.calls[0]?.[1];
     expect(request.path).toBe('/images/generations');
+    expect(request.baseUrlStrategy).toBe('ensure-v1');
     expect(JSON.parse(request.body)).toMatchObject({
       size: '1360x768',
       quality: 'high',
@@ -152,6 +153,7 @@ describe('tuzi GPT image adapter', () => {
 
     const request = mocks.sendAdapterRequest.mock.calls[0]?.[1];
     expect(request.path).toBe('/images/generations');
+    expect(request.baseUrlStrategy).toBe('ensure-v1');
     expect(JSON.parse(request.body)).toEqual({
       model: 'gpt-image-2',
       prompt: 'Edit this image',
@@ -207,5 +209,43 @@ describe('tuzi GPT image adapter', () => {
       image: ['data:image/png;base64,source'],
     });
     expect(JSON.parse(request.body).response_format).toBeUndefined();
+  });
+
+  it('includes the final endpoint when a 404 response has no JSON error', async () => {
+    mocks.sendAdapterRequest.mockResolvedValue({
+      ok: false,
+      status: 404,
+      url: 'https://api.tu-zi.com/v1/v1/images/generations?token=hidden',
+      text: async () => '<!doctype html><title>Not Found</title>',
+    });
+
+    await expect(
+      tuziGPTImageAdapter.generateImage(
+        {
+          baseUrl: 'https://api.tu-zi.com/v1',
+          apiKey: 'test-key',
+          authType: 'bearer',
+          binding: {
+            id: 'binding',
+            profileId: 'tuzi',
+            modelId: 'gpt-image-2',
+            operation: 'image',
+            protocol: 'openai.images.generations',
+            requestSchema: 'tuzi.image.gpt-generation-json',
+            responseSchema: 'openai.image.data',
+            submitPath: '/v1/images/generations',
+            priority: 10,
+            confidence: 'high',
+            source: 'manual',
+          },
+        },
+        {
+          model: 'gpt-image-2',
+          prompt: 'Draw a clean product photo',
+        }
+      )
+    ).rejects.toThrow(
+      'Tuzi GPT Image request failed: 404 (/v1/v1/images/generations)'
+    );
   });
 });

--- a/packages/drawnix/src/services/__tests__/tuzi-gpt-image-adapter.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-gpt-image-adapter.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildTuziGPTImageRequestBody,
+  tuziGPTImageAdapter,
+} from '../model-adapters/tuzi-gpt-image-adapter';
 
 const mocks = vi.hoisted(() => ({
   sendAdapterRequest: vi.fn(),
@@ -7,11 +11,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../model-adapters/context', () => ({
   sendAdapterRequest: mocks.sendAdapterRequest,
 }));
-
-import {
-  buildTuziGPTImageRequestBody,
-  tuziGPTImageAdapter,
-} from '../model-adapters/tuzi-gpt-image-adapter';
 
 describe('tuzi GPT image adapter', () => {
   afterEach(() => {
@@ -164,7 +163,7 @@ describe('tuzi GPT image adapter', () => {
     });
   });
 
-  it('preserves explicit GPT Image pixel size for Tuzi edit requests', async () => {
+  it('repairs legacy Tuzi edit bindings to the JSON generations endpoint', async () => {
     mocks.sendAdapterRequest.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -201,7 +200,8 @@ describe('tuzi GPT image adapter', () => {
     );
 
     const request = mocks.sendAdapterRequest.mock.calls[0]?.[1];
-    expect(request.path).toBe('/images/edits');
+    expect(request.path).toBe('/images/generations');
+    expect(request.baseUrlStrategy).toBe('ensure-v1');
     expect(JSON.parse(request.body)).toMatchObject({
       model: 'gpt-image-2',
       prompt: 'Continue this PPT slide style',
@@ -245,7 +245,7 @@ describe('tuzi GPT image adapter', () => {
         }
       )
     ).rejects.toThrow(
-      'Tuzi GPT Image request failed: 404 (/v1/v1/images/generations)'
+      'Tuzi GPT Image request failed: 404 (api.tu-zi.com/v1/v1/images/generations)'
     );
   });
 });

--- a/packages/drawnix/src/services/media-api/image-api.ts
+++ b/packages/drawnix/src/services/media-api/image-api.ts
@@ -22,7 +22,10 @@ import {
   sleep,
   buildProviderContextFromApiConfig,
 } from './utils';
-import { providerTransport } from '../provider-routing/provider-transport';
+import {
+  canAttachProviderRequestIdHeader,
+  providerTransport,
+} from '../provider-routing/provider-transport';
 import { IMAGE_GENERATION_TIMEOUT_MS } from '../../constants/TASK_CONSTANTS';
 import { emitImageRequestIdDebugLog } from './request-id-debug';
 
@@ -269,29 +272,33 @@ export async function generateImageSync(
     model,
   });
 
-  const requestId = generateRequestId();
-  emitImageRequestIdDebugLog(requestId, {
-    model,
-    endpoint: '/images/generations',
-    source: 'generateImageSync',
-  });
+  const providerContext = buildProviderContextFromApiConfig(config);
+  const requestId = canAttachProviderRequestIdHeader(providerContext, {
+    path: '/images/generations',
+  })
+    ? generateRequestId()
+    : undefined;
+  if (requestId) {
+    emitImageRequestIdDebugLog(requestId, {
+      model,
+      endpoint: '/images/generations',
+      source: 'generateImageSync',
+    });
+  }
 
   try {
-    const response = await providerTransport.send(
-      buildProviderContextFromApiConfig(config),
-      {
-        path: '/images/generations',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
-        signal,
-        timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
-        fetcher: fetchFn,
-        requestId,
-      }
-    );
+    const response = await providerTransport.send(providerContext, {
+      path: '/images/generations',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+      signal,
+      timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
+      fetcher: fetchFn,
+      requestId,
+    });
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -304,7 +311,7 @@ export async function generateImageSync(
     return parseImageResponse(data);
   } catch (error) {
     // 超时兜底：尝试通过 /log/get-request 找回已经生成成功的结果
-    if (isTimeoutError(error)) {
+    if (isTimeoutError(error) && requestId) {
       console.warn(
         `[ImageAPI] 生图请求超时，尝试通过 X-Request-Id 找回结果: ${requestId}`
       );

--- a/packages/drawnix/src/services/media-executor/fallback-executor.ts
+++ b/packages/drawnix/src/services/media-executor/fallback-executor.ts
@@ -25,6 +25,7 @@ import {
   type ModelRef,
 } from '../../utils/settings-manager';
 import {
+  canAttachProviderRequestIdHeader,
   providerTransport,
   resolveInvocationPlanFromRoute,
   type ProviderAuthStrategy,
@@ -356,13 +357,19 @@ export class FallbackMediaExecutor implements IMediaExecutor {
       );
     }
 
-    // 为本次请求生成 X-Request-Id，用于超时时通过 /log/get-request 找回结果
-    const requestId = generateRequestIdForImage();
-    emitImageRequestIdDebugLog(requestId, {
-      model: modelName,
-      endpoint: '/images/generations',
-      source: 'fallbackExecutor',
-    });
+    const imageProviderContext = buildProviderContext(config.imageConfig);
+    const requestId = canAttachProviderRequestIdHeader(imageProviderContext, {
+      path: '/images/generations',
+    })
+      ? generateRequestIdForImage()
+      : undefined;
+    if (requestId) {
+      emitImageRequestIdDebugLog(requestId, {
+        model: modelName,
+        endpoint: '/images/generations',
+        source: 'fallbackExecutor',
+      });
+    }
 
     // 开始记录 LLM API 调用
     const logId = startLLMApiLog({
@@ -408,20 +415,17 @@ export class FallbackMediaExecutor implements IMediaExecutor {
       let httpStatus = 200;
       try {
         // 直接调用 API
-        const response = await providerTransport.send(
-          buildProviderContext(config.imageConfig),
-          {
-            path: '/images/generations',
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(requestBody),
-            signal: options?.signal,
-            timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
-            requestId,
-          }
-        );
+        const response = await providerTransport.send(imageProviderContext, {
+          path: '/images/generations',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+          signal: options?.signal,
+          timeoutMs: IMAGE_GENERATION_TIMEOUT_MS,
+          requestId,
+        });
 
         if (!response.ok) {
           const duration = Date.now() - startTime;
@@ -450,7 +454,7 @@ export class FallbackMediaExecutor implements IMediaExecutor {
         httpStatus = response.status;
       } catch (sendError) {
         // 超时兜底：尝试通过 /log/get-request 找回已经生成成功的结果
-        if (isTimeoutErrorForRecover(sendError)) {
+        if (isTimeoutErrorForRecover(sendError) && requestId) {
           console.warn(
             `[FallbackMediaExecutor] 生图请求超时，尝试通过 X-Request-Id 找回: ${requestId}`
           );

--- a/packages/drawnix/src/services/model-adapters/context.ts
+++ b/packages/drawnix/src/services/model-adapters/context.ts
@@ -1,4 +1,5 @@
 import {
+  canAttachProviderRequestIdHeader,
   providerTransport,
   type ProviderTransportRequest,
   type ResolvedProviderContext,
@@ -82,10 +83,17 @@ export function sendAdapterRequest(
     request.timeoutMs ??
     (context.operation === 'image' ? IMAGE_GENERATION_TIMEOUT_MS : undefined);
 
-  // 图片操作自动附带 X-Request-Id，用于超时时通过 /log/get-request 找回结果。
-  // 若 caller 已显式传入 requestId 则复用，避免重复生成。
-  let requestId = request.requestId;
-  if (!requestId && context.operation === 'image') {
+  const providerContext = buildProviderContextFromAdapterContext(
+    context,
+    baseUrlOverride
+  );
+  const supportsRequestId =
+    context.operation === 'image' &&
+    canAttachProviderRequestIdHeader(providerContext, request);
+
+  // 只有受支持的同源 Tuzi 请求才附带 X-Request-Id。
+  let requestId = supportsRequestId ? request.requestId : undefined;
+  if (!requestId && supportsRequestId) {
     requestId = generateRequestId();
   }
 
@@ -105,15 +113,12 @@ export function sendAdapterRequest(
     }
   }
 
-  return providerTransport.send(
-    buildProviderContextFromAdapterContext(context, baseUrlOverride),
-    {
-      ...request,
-      requestId,
-      timeoutMs,
-      fetcher: context.fetcher || request.fetcher,
-    }
-  );
+  return providerTransport.send(providerContext, {
+    ...request,
+    requestId,
+    timeoutMs,
+    fetcher: context.fetcher || request.fetcher,
+  });
 }
 
 function generateRequestId(): string {

--- a/packages/drawnix/src/services/model-adapters/registry.ts
+++ b/packages/drawnix/src/services/model-adapters/registry.ts
@@ -9,6 +9,7 @@ import {
   resolveInvocationPlanFromRoute,
   type ProviderModelBinding,
 } from '../provider-routing';
+import { isTuziCompatibleBaseUrl } from '../provider-routing/tuzi-api-endpoints';
 
 const adapterRegistry = new Map<string, ModelAdapter>();
 
@@ -154,8 +155,7 @@ function resolveGPTImageAdapterForLegacyRoute(
   }
 
   const route = resolveInvocationRoute('image', modelRef || modelId);
-  const baseUrl = route.baseUrl.toLowerCase();
-  if (baseUrl.includes('.tu-zi.com')) {
+  if (isTuziCompatibleBaseUrl(route.baseUrl)) {
     return findImageAdapterBySchema('tuzi.image.gpt-generation-json');
   }
 

--- a/packages/drawnix/src/services/model-adapters/tuzi-gpt-image-adapter.ts
+++ b/packages/drawnix/src/services/model-adapters/tuzi-gpt-image-adapter.ts
@@ -139,7 +139,7 @@ async function readErrorMessage(response: Response): Promise<string> {
   let endpoint = '';
   try {
     const url = new URL(response.url);
-    endpoint = url.pathname;
+    endpoint = `${url.hostname}${url.pathname}`;
   } catch {
     endpoint = (response.url || '').split(/[?#]/, 1)[0];
   }
@@ -152,7 +152,15 @@ async function readErrorMessage(response: Response): Promise<string> {
 function resolveTuziGPTImagePath(context: {
   binding?: { submitPath?: string } | null;
 }): string {
-  return context.binding?.submitPath || '/images/generations';
+  const submitPath = context.binding?.submitPath?.trim();
+  if (submitPath && /\/images\/generations\/?$/i.test(submitPath)) {
+    return '/images/generations';
+  }
+
+  // Tuzi's simplified GPT Image JSON schema uses the generations endpoint
+  // for both text-to-image and reference-image requests. Old persisted
+  // bindings can still point at the official multipart edits endpoint.
+  return '/images/generations';
 }
 
 export const tuziGPTImageAdapter: ImageModelAdapter = {

--- a/packages/drawnix/src/services/model-adapters/tuzi-gpt-image-adapter.ts
+++ b/packages/drawnix/src/services/model-adapters/tuzi-gpt-image-adapter.ts
@@ -36,9 +36,12 @@ function getResolvedOfficialSize(
   return resolveOfficialGPTImageSize(model, requestedSize, request.params);
 }
 
-function getRequestedCount(request: ImageGenerationRequest): number | undefined {
+function getRequestedCount(
+  request: ImageGenerationRequest
+): number | undefined {
   const count =
-    getNumberParam(request.params, 'n') ?? getNumberParam(request.params, 'count');
+    getNumberParam(request.params, 'n') ??
+    getNumberParam(request.params, 'count');
 
   return count !== undefined && count >= 1 && count <= 10 ? count : undefined;
 }
@@ -108,7 +111,16 @@ export function buildTuziGPTImageRequestBody(
 }
 
 async function readErrorMessage(response: Response): Promise<string> {
-  const data = await response.json().catch(() => null);
+  const rawText = await response.text().catch(() => '');
+  const data = rawText
+    ? (() => {
+        try {
+          return JSON.parse(rawText);
+        } catch {
+          return null;
+        }
+      })()
+    : null;
   if (typeof data?.error === 'string') {
     return data.error;
   }
@@ -118,12 +130,28 @@ async function readErrorMessage(response: Response): Promise<string> {
   if (typeof data?.message === 'string') {
     return data.message;
   }
-  return `Tuzi GPT Image request failed: ${response.status}`;
+
+  const plainText = rawText.trim();
+  if (plainText && !/^<!doctype|^<html/i.test(plainText)) {
+    return plainText.slice(0, 300);
+  }
+
+  let endpoint = '';
+  try {
+    const url = new URL(response.url);
+    endpoint = url.pathname;
+  } catch {
+    endpoint = (response.url || '').split(/[?#]/, 1)[0];
+  }
+
+  return `Tuzi GPT Image request failed: ${response.status}${
+    endpoint ? ` (${endpoint})` : ''
+  }`;
 }
 
-function resolveTuziGPTImagePath(
-  context: { binding?: { submitPath?: string } | null }
-): string {
+function resolveTuziGPTImagePath(context: {
+  binding?: { submitPath?: string } | null;
+}): string {
   return context.binding?.submitPath || '/images/generations';
 }
 
@@ -140,6 +168,7 @@ export const tuziGPTImageAdapter: ImageModelAdapter = {
   async generateImage(context, request) {
     const response = await sendAdapterRequest(context, {
       path: resolveTuziGPTImagePath(context),
+      baseUrlStrategy: 'ensure-v1',
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/drawnix/src/services/model-adapters/types.ts
+++ b/packages/drawnix/src/services/model-adapters/types.ts
@@ -23,8 +23,8 @@ export interface AdapterContext {
   binding?: ProviderModelBinding | null;
   fetcher?: typeof fetch;
   /**
-   * sendAdapterRequest 发起图片类请求时会自动生成 requestId 并通过此回调回传。
-   * 用于 caller（如 runImageAdapter）在超时时通过 /log/get-request 找回结果。
+   * sendAdapterRequest 仅在 Tuzi 同源图片请求中生成 requestId 并回传。
+   * caller 可在超时时通过 /log/get-request 找回结果。
    */
   onRequestSent?: (info: { requestId: string }) => void;
 }

--- a/packages/drawnix/src/services/model-health-service.ts
+++ b/packages/drawnix/src/services/model-health-service.ts
@@ -5,6 +5,8 @@
  * 使用单例模式控制接口调用频率（最小间隔 1 分钟）
  */
 
+import { isTuziCompatibleBaseUrl } from './provider-routing/tuzi-api-endpoints';
+
 // 健康状态响应类型
 export interface ModelHealthResponse {
     rule_id: string;
@@ -66,11 +68,13 @@ class ModelHealthFetcher {
     // 缓存的数据
     private cachedData: ModelHealthResponse[] = [];
     // 上次成功请求的时间
-    private lastFetchTime: number = 0;
+    private lastFetchTime = 0;
     // 当前进行中的请求 Promise（用于防止并发）
     private pendingFetch: Promise<ModelHealthResponse[]> | null = null;
 
-    private constructor() {}
+    private constructor() {
+        // Singleton instance only.
+    }
 
     static getInstance(): ModelHealthFetcher {
         if (!ModelHealthFetcher.instance) {
@@ -84,7 +88,7 @@ class ModelHealthFetcher {
      * @param intervalMinutes 查询的时间范围（分钟），默认 5 分钟
      * @param force 是否强制刷新（忽略缓存间隔限制）
      */
-    async fetch(intervalMinutes: number = 5, force: boolean = false): Promise<ModelHealthResponse[]> {
+    async fetch(intervalMinutes = 5, force = false): Promise<ModelHealthResponse[]> {
         const now = Date.now();
         
         // 检查是否在最小间隔内（非强制模式）
@@ -272,22 +276,7 @@ export function buildHealthMap(
  * 检查 baseUrl 是否为 tu-zi.com
  */
 export function isTuziApiUrl(baseUrl: string): boolean {
-    const trimmed = baseUrl.trim();
-    if (!trimmed) {
-        return false;
-    }
-
-    try {
-        const url = new URL(
-            /^[a-z][a-z\d+\-.]*:\/\//i.test(trimmed)
-                ? trimmed
-                : `https://${trimmed}`
-        );
-        const hostname = url.hostname.toLowerCase();
-        return hostname === 'tu-zi.com' || hostname.endsWith('.tu-zi.com');
-    } catch {
-        return false;
-    }
+    return isTuziCompatibleBaseUrl(baseUrl);
 }
 
 export function shouldFetchModelHealthForSelections(

--- a/packages/drawnix/src/services/provider-routing/binding-inference.ts
+++ b/packages/drawnix/src/services/provider-routing/binding-inference.ts
@@ -9,6 +9,7 @@ import {
   OFFICIAL_GPT_IMAGE_EDIT_REQUEST_SCHEMA,
   TUZI_GPT_IMAGE_EDIT_REQUEST_SCHEMA,
 } from '../model-adapters/image-request-schemas';
+import { isTuziCompatibleBaseUrl } from './tuzi-api-endpoints';
 import { inferAllBindingHintsFromEndpoints } from './endpoint-binding-inference';
 import type { ProviderModelBinding, ProviderProfileSnapshot } from './types';
 
@@ -207,22 +208,7 @@ function isTuziProfile(profile: ProviderProfileSnapshot): boolean {
 }
 
 function isTuziBaseUrl(baseUrl: string): boolean {
-  const normalizedBaseUrl = baseUrl.trim().toLowerCase();
-  if (!normalizedBaseUrl) {
-    return false;
-  }
-
-  try {
-    const url = new URL(
-      /^[a-z][a-z\d+\-.]*:\/\//i.test(normalizedBaseUrl)
-        ? normalizedBaseUrl
-        : `https://${normalizedBaseUrl}`
-    );
-    const hostname = url.hostname.toLowerCase();
-    return hostname === 'tu-zi.com' || hostname.endsWith('.tu-zi.com');
-  } catch {
-    return false;
-  }
+  return isTuziCompatibleBaseUrl(baseUrl);
 }
 
 function normalizeImageApiCompatibilityMode(

--- a/packages/drawnix/src/services/provider-routing/provider-transport.ts
+++ b/packages/drawnix/src/services/provider-routing/provider-transport.ts
@@ -27,7 +27,8 @@ function rewriteBaseUrlForDevProxy(baseUrl: string): string {
   try {
     const isDev =
       typeof import.meta !== 'undefined' &&
-      (import.meta as { env?: { DEV?: boolean } }).env?.DEV;
+      (import.meta as { env?: { DEV?: boolean; MODE?: string } }).env?.DEV &&
+      (import.meta as { env?: { MODE?: string } }).env?.MODE !== 'test';
     if (!isDev) return baseUrl;
     if (!/^https?:\/\//i.test(baseUrl)) return baseUrl;
 
@@ -223,12 +224,53 @@ function createTimeoutSignal(
 
 function applyRequestIdHeader(
   headers: Record<string, string>,
-  requestId: string | undefined
+  requestId: string | undefined,
+  enabled: boolean
 ): Record<string, string> {
-  if (!requestId) {
+  if (!requestId || !enabled) {
     return headers;
   }
   return { ...headers, 'X-Request-Id': requestId };
+}
+
+function getRuntimeOrigin(): string | undefined {
+  const origin = globalThis.location?.origin;
+  return typeof origin === 'string' && origin !== 'null' ? origin : undefined;
+}
+
+/**
+ * X-Request-Id recovery is a Tuzi-specific capability. Cross-origin browser
+ * requests must not carry the header because the public API does not include
+ * it in Access-Control-Allow-Headers, which makes the preflight fail before
+ * the image request is submitted.
+ */
+export function canAttachProviderRequestIdHeader(
+  context: ResolvedProviderContext,
+  request: Pick<ProviderTransportRequest, 'path' | 'baseUrlStrategy'>,
+  runtimeOrigin: string | undefined = getRuntimeOrigin()
+): boolean {
+  if (!isTrustedTuziApiBaseUrl(context.baseUrl)) {
+    return false;
+  }
+
+  const resolvedBaseUrl = applyBaseUrlStrategy(
+    context.baseUrl,
+    request.baseUrlStrategy
+  );
+  const requestUrl = joinUrl(resolvedBaseUrl, request.path);
+
+  if (!/^https?:\/\//i.test(requestUrl)) {
+    return true;
+  }
+  if (!runtimeOrigin) {
+    return false;
+  }
+
+  try {
+    return new URL(requestUrl).origin === new URL(runtimeOrigin).origin;
+  } catch {
+    return false;
+  }
 }
 
 export class ProviderTransport {
@@ -236,20 +278,20 @@ export class ProviderTransport {
     context: ResolvedProviderContext,
     request: ProviderTransportRequest
   ): PreparedProviderTransportRequest {
-    const mergedHeaders = mergeHeaders(context.extraHeaders, request.headers);
-    const authenticatedHeaders = applyAuthHeaders(context, mergedHeaders);
-    const finalHeaders = applyRequestIdHeader(
-      authenticatedHeaders,
-      request.requestId
-    );
-    const query = applyAuthQuery(context, request.query || {});
     const resolvedBaseUrl = applyBaseUrlStrategy(
       context.baseUrl,
       request.baseUrlStrategy
     );
     const url = `${joinUrl(resolvedBaseUrl, request.path)}${buildQueryString(
-      query
+      applyAuthQuery(context, request.query || {})
     )}`;
+    const mergedHeaders = mergeHeaders(context.extraHeaders, request.headers);
+    const authenticatedHeaders = applyAuthHeaders(context, mergedHeaders);
+    const finalHeaders = applyRequestIdHeader(
+      authenticatedHeaders,
+      request.requestId,
+      canAttachProviderRequestIdHeader(context, request)
+    );
 
     return {
       url,
@@ -277,6 +319,9 @@ export class ProviderTransport {
       signal: timeoutControl.signal,
     });
     const fetcher = request.fetcher || fetch;
+    const requestIdHeaderApplied = Boolean(
+      prepared.headers['X-Request-Id'] || prepared.headers['x-request-id']
+    );
 
     try {
       return await fetcher(prepared.url, prepared.init);
@@ -287,7 +332,7 @@ export class ProviderTransport {
           `请求超时（>${timeoutMinutes} 分钟）`
         );
         timeoutError.name = 'TimeoutError';
-        if (request.requestId) {
+        if (request.requestId && requestIdHeaderApplied) {
           timeoutError.requestId = request.requestId;
         }
         throw timeoutError;

--- a/packages/drawnix/src/services/provider-routing/provider-transport.ts
+++ b/packages/drawnix/src/services/provider-routing/provider-transport.ts
@@ -104,6 +104,20 @@ function isFetchNetworkError(error: unknown): boolean {
   return /Failed to fetch|Load failed|NetworkError/i.test(error.message);
 }
 
+function shouldRetryTuziResponse(
+  context: ResolvedProviderContext,
+  request: ProviderTransportRequest,
+  response: Response
+): boolean {
+  return (
+    response.status === 404 &&
+    isTrustedTuziApiBaseUrl(context.baseUrl) &&
+    !/^https?:\/\//i.test(request.path) &&
+    (request.method || 'GET').toUpperCase() === 'POST' &&
+    /\/images\/(?:generations|edits)\/?$/i.test(request.path)
+  );
+}
+
 async function getTuziFallbackBaseUrls(baseUrl: string): Promise<string[]> {
   if (!isTrustedTuziApiBaseUrl(baseUrl)) {
     return [];
@@ -345,7 +359,36 @@ export class ProviderTransport {
     );
 
     try {
-      return await fetcher(prepared.url, prepared.init);
+      const response = await fetcher(prepared.url, prepared.init);
+      if (!shouldRetryTuziResponse(context, request, response)) {
+        return response;
+      }
+
+      const fallbackBaseUrls = await getTuziFallbackBaseUrls(context.baseUrl);
+      for (const fallbackBaseUrl of fallbackBaseUrls) {
+        const fallbackPrepared = this.prepareRequest(
+          { ...context, baseUrl: fallbackBaseUrl },
+          { ...request, signal: timeoutControl.signal }
+        );
+        try {
+          const fallbackResponse = await fetcher(
+            fallbackPrepared.url,
+            fallbackPrepared.init
+          );
+          if (!shouldRetryTuziResponse(context, request, fallbackResponse)) {
+            return fallbackResponse;
+          }
+        } catch (fallbackError) {
+          if (
+            timeoutControl.didTimeout() ||
+            !isFetchNetworkError(fallbackError)
+          ) {
+            throw fallbackError;
+          }
+        }
+      }
+
+      return response;
     } catch (error) {
       if (timeoutControl.didTimeout()) {
         const timeoutMinutes = Math.floor((request.timeoutMs || 0) / 60000);

--- a/packages/drawnix/src/services/provider-routing/provider-transport.ts
+++ b/packages/drawnix/src/services/provider-routing/provider-transport.ts
@@ -51,6 +51,10 @@ function applyBaseUrlStrategy(
   switch (strategy) {
     case 'trim-v1':
       return normalizedBaseUrl.replace(/\/v1$/i, '');
+    case 'ensure-v1':
+      return /\/v1$/i.test(normalizedBaseUrl)
+        ? normalizedBaseUrl
+        : `${normalizedBaseUrl}/v1`;
     case 'preserve':
     default:
       return normalizedBaseUrl;
@@ -63,7 +67,24 @@ function joinUrl(baseUrl: string, path: string): string {
   }
 
   const normalizedBase = trimTrailingSlashes(baseUrl);
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  let normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  // Endpoint discovery and manually persisted bindings can include the API
+  // version even when the provider base URL already ends with it. Collapse
+  // only the shared version segment at the join boundary so a valid
+  // /v1/images/generations request never becomes /v1/v1/images/generations.
+  const baseVersionMatch = normalizedBase.match(/\/(v\d+(?:beta\d*)?)$/i);
+  const pathVersionMatch = normalizedPath.match(
+    /^\/(v\d+(?:beta\d*)?)(?:\/|$)/i
+  );
+  if (
+    baseVersionMatch &&
+    pathVersionMatch &&
+    baseVersionMatch[1].toLowerCase() === pathVersionMatch[1].toLowerCase()
+  ) {
+    normalizedPath = normalizedPath.slice(pathVersionMatch[1].length + 1);
+  }
+
   return `${normalizedBase}${normalizedPath}`;
 }
 

--- a/packages/drawnix/src/services/provider-routing/settings-repository.ts
+++ b/packages/drawnix/src/services/provider-routing/settings-repository.ts
@@ -24,6 +24,7 @@ import {
 } from '../../utils/settings-manager';
 import { InvocationPlanner } from './invocation-planner';
 import { inferBindingsForProviderCatalog } from './binding-inference';
+import { isTuziCompatibleBaseUrl } from './tuzi-api-endpoints';
 import { modelPricingService } from '../../utils/model-pricing-service';
 import type {
   InvocationPlan,
@@ -67,22 +68,7 @@ function inferProviderTypeFromBaseUrl(
 }
 
 function isTuziBaseUrl(baseUrl: string): boolean {
-  const normalizedBaseUrl = baseUrl.trim().toLowerCase();
-  if (!normalizedBaseUrl) {
-    return false;
-  }
-
-  try {
-    const url = new URL(
-      /^[a-z][a-z\d+\-.]*:\/\//i.test(normalizedBaseUrl)
-        ? normalizedBaseUrl
-        : `https://${normalizedBaseUrl}`
-    );
-    const hostname = url.hostname.toLowerCase();
-    return hostname === 'tu-zi.com' || hostname.endsWith('.tu-zi.com');
-  } catch {
-    return false;
-  }
+  return isTuziCompatibleBaseUrl(baseUrl);
 }
 
 function inferAuthType(

--- a/packages/drawnix/src/services/provider-routing/tuzi-api-endpoints.ts
+++ b/packages/drawnix/src/services/provider-routing/tuzi-api-endpoints.ts
@@ -65,6 +65,24 @@ export function isTrustedTuziApiBaseUrl(url?: string | null): boolean {
   return TRUSTED_TUZI_API_ORIGINS.has(normalizeTuziApiEndpointUrl(url));
 }
 
+export function isTuziCompatibleBaseUrl(url?: string | null): boolean {
+  if (isTrustedTuziApiBaseUrl(url)) {
+    return true;
+  }
+
+  const normalized = normalizeTuziApiEndpointUrl(url);
+  if (!normalized) {
+    return false;
+  }
+
+  try {
+    const hostname = new URL(normalized).hostname.toLowerCase();
+    return hostname === 'tu-zi.com' || hostname.endsWith('.tu-zi.com');
+  } catch {
+    return false;
+  }
+}
+
 function normalizeJsonLikeString(value: string): string {
   return value
     .replace(/([{,]\s*)([A-Za-z_$][\w$]*)(\s*:)/g, '$1"$2"$3')

--- a/packages/drawnix/src/services/provider-routing/types.ts
+++ b/packages/drawnix/src/services/provider-routing/types.ts
@@ -182,8 +182,8 @@ export interface ProviderTransportRequest {
   credentials?: RequestCredentials;
   fetcher?: typeof fetch;
   /**
-   * 若提供，会被写入 X-Request-Id 请求头，用于超时/失败场景兜底找回。
-   * 目前主要用于图片生成接口。
+   * Tuzi 同源请求会将其写入 X-Request-Id，用于超时兜底找回。
+   * 其他供应商或跨域请求会忽略该字段，避免触发 CORS 预检失败。
    */
   requestId?: string;
 }

--- a/packages/drawnix/src/services/provider-routing/types.ts
+++ b/packages/drawnix/src/services/provider-routing/types.ts
@@ -27,7 +27,7 @@ export type ProviderBindingConfidence = 'high' | 'medium' | 'low';
 export type ProviderBindingSource = 'discovered' | 'template' | 'manual';
 
 export type ProviderAuthStrategy = 'bearer' | 'header' | 'query' | 'custom';
-export type ProviderBaseUrlStrategy = 'preserve' | 'trim-v1';
+export type ProviderBaseUrlStrategy = 'preserve' | 'trim-v1' | 'ensure-v1';
 export type ProviderVideoDurationMode = 'request-param' | 'model-alias';
 export type ProviderVideoResultMode = 'inline-url' | 'download-content';
 export type ProviderTextImageInputMode =

--- a/packages/drawnix/src/types/shared/core.types.ts
+++ b/packages/drawnix/src/types/shared/core.types.ts
@@ -95,7 +95,7 @@ export interface TaskInvocationBindingSnapshot {
   responseSchema?: string;
   submitPath?: string;
   pollPathTemplate?: string;
-  baseUrlStrategy?: 'preserve' | 'trim-v1';
+  baseUrlStrategy?: 'preserve' | 'trim-v1' | 'ensure-v1';
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/drawnix/src/utils/__tests__/model-pricing-service.test.ts
+++ b/packages/drawnix/src/utils/__tests__/model-pricing-service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildPricingSourceSignature,
+  derivePricingUrl,
   formatModelPrice,
   getPricingCacheTtlMs,
   isPricingCacheEligibleForWarmup,
@@ -50,14 +51,20 @@ describe('model-pricing-service', () => {
     expect(
       getPricingCacheTtlMs('https://api.tu-zi.com/api/pricing?group=default')
     ).toBe(TUZI_PRICING_CACHE_TTL_MS);
-    expect(
-      getPricingCacheTtlMs('https://business.tu-zi.com/api/pricing')
-    ).toBe(TUZI_PRICING_CACHE_TTL_MS);
+    expect(getPricingCacheTtlMs('https://business.tu-zi.com/api/pricing')).toBe(
+      TUZI_PRICING_CACHE_TTL_MS
+    );
   });
 
   it('对非 Tuzi 价格接口保持默认短缓存', () => {
     expect(getPricingCacheTtlMs('https://example.com/api/pricing')).toBe(
       MODEL_PRICING_CACHE_TTL_MS
+    );
+  });
+
+  it('从带 /v1 的模型 Base URL 推导独立的价格地址', () => {
+    expect(derivePricingUrl('https://api.tu-zi.com/v1')).toBe(
+      'https://api.tu-zi.com/api/pricing'
     );
   });
 
@@ -76,7 +83,9 @@ describe('model-pricing-service', () => {
       groups: [],
       prices: {},
     };
-    expect(isPricingCacheEligibleForWarmup(manualReadyCache, sourceSignature)).toBe(true);
+    expect(
+      isPricingCacheEligibleForWarmup(manualReadyCache, sourceSignature)
+    ).toBe(true);
 
     const explicitlyDisabledCache: ProviderPricingCache = {
       ...manualReadyCache,
@@ -90,7 +99,9 @@ describe('model-pricing-service', () => {
       ...manualReadyCache,
       autoRefreshSourceSignature: undefined,
     };
-    expect(isPricingCacheEligibleForWarmup(legacyCache, sourceSignature)).toBe(true);
+    expect(isPricingCacheEligibleForWarmup(legacyCache, sourceSignature)).toBe(
+      true
+    );
 
     expect(isPricingCacheEligibleForWarmup(null, sourceSignature)).toBe(false);
   });

--- a/packages/drawnix/src/utils/provider-base-url.ts
+++ b/packages/drawnix/src/utils/provider-base-url.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_MODEL_API_BASE_URL = 'https://api.tu-zi.com/v1';
+
+export function normalizeModelApiBaseUrl(baseUrl: string): string {
+  const trimmed = (baseUrl || '').trim();
+  if (!trimmed) return DEFAULT_MODEL_API_BASE_URL;
+
+  let normalized = trimmed.replace(/\/+$/, '');
+  normalized = normalized.replace(/\/models$/i, '');
+  if (!/\/v1$/i.test(normalized)) {
+    normalized = `${normalized}/v1`;
+  }
+  return normalized;
+}

--- a/packages/drawnix/src/utils/runtime-model-discovery.ts
+++ b/packages/drawnix/src/utils/runtime-model-discovery.ts
@@ -12,7 +12,7 @@ import {
   getStaticModelConfig,
   setRuntimeModelConfigs,
 } from '../constants/model-config';
-import { normalizeApiBase } from '../services/media-api/utils';
+import { normalizeModelApiBaseUrl } from './provider-base-url';
 import {
   LEGACY_DEFAULT_PROVIDER_PROFILE_ID,
   providerCatalogsSettings,
@@ -89,18 +89,7 @@ function hashString(input: string): string {
   return Math.abs(hash >>> 0).toString(16);
 }
 
-export function normalizeModelApiBaseUrl(baseUrl: string): string {
-  const trimmed = (baseUrl || '').trim();
-  const fallback = 'https://api.tu-zi.com/v1';
-  if (!trimmed) return fallback;
-
-  let normalized = trimmed.replace(/\/+$/, '');
-  normalized = normalized.replace(/\/models$/i, '');
-  if (!/\/v1$/i.test(normalized)) {
-    normalized = `${normalizeApiBase(normalized)}/v1`;
-  }
-  return normalized;
-}
+export { normalizeModelApiBaseUrl } from './provider-base-url';
 
 function buildDiscoverySignature(baseUrl: string, apiKey: string): string {
   return `${normalizeModelApiBaseUrl(baseUrl)}::${hashString(apiKey.trim())}`;


### PR DESCRIPTION
## 背景

新增供应商并选择 `gpt-image-2` 后，图片生成可能在等待一段时间后报错：

```text
Tuzi GPT Image request failed: 404 (/v1/images...)
```

本 PR 修复从跨域请求、API 版本路径、历史 binding 到 Tuzi 多节点识别与回退的完整链路。

## 最终定位

使用相同 API Key 直接请求：

```text
POST https://api.tu-zi.com/v1/images/generations
model=gpt-image-2
```

供应商返回 HTTP 200 和有效图片。因此 API Key、Tuzi 主站和 `/v1/images/generations` 均正常，截图中的 404 来自项目内部路由，而不是站点不可用。

实际根因包括：

1. Tuzi adapter 盲目信任历史 `binding.submitPath`，旧配置可能把简化 JSON 请求发到 `/images/edits`。
2. Tuzi `default` 分组的简化 JSON 格式，无论文生图还是带参考图，都应使用 `/images/generations`。
3. 美国、广州、深圳等官方备用节点使用 `sydney-ai.com` 或 `ourzhishi.top`，旧逻辑只识别 `*.tu-zi.com`，会把备用节点误判为普通 OpenAI 兼容供应商并选错 adapter。
4. 设置页的站点测速只验证首页连通性，不能证明图片 POST 路由可用。
5. 供应商 Base URL、endpoint path 和历史 binding 对 `/v1` 的表达不一致，可能造成根路径请求或重复 `/v1/v1`。
6. 跨域图片请求曾无条件附加 `X-Request-Id`，可能因供应商未放行该自定义头而触发 CORS 预检失败。

## 修改内容

- 新增统一的 Tuzi 兼容地址识别：
  - 识别可信的六个官方节点。
  - 继续识别合法的 `tu-zi.com` 子域名。
  - 不把任意伪造域名加入可信 404 回退范围。
- Tuzi GPT Image JSON adapter 始终把图片请求规范化到 `/images/generations`，自动修复历史 `/images/edits` binding。
- Tuzi GPT Image 显式使用 `ensure-v1`：
  - `https://host` + `/images/generations` -> `/v1/images/generations`
  - `https://host/v1` + `/images/generations` -> `/v1/images/generations`
  - `https://host/v1` + `/v1/images/generations` -> `/v1/images/generations`
- 可信 Tuzi 节点的图片 POST 返回 404 时，保持请求体、鉴权和 API 版本，尝试其它官方节点。
- 404 节点回退仅用于可信 Tuzi、相对图片 endpoint 和 POST 请求，不影响普通供应商、绝对 URL 或其它协议。
- 路由推断、设置仓库、legacy adapter 选择和模型健康状态统一使用 Tuzi 兼容地址识别。
- 错误消息包含安全的 hostname + pathname，便于区分具体失败节点，同时不暴露 query、Authorization 或 API Key。
- 设置页继续展示简洁 origin，但保存和切换 Tuzi 节点时规范化为带 `/v1` 的模型 API Base URL。
- 保持价格 API 为 origin 下的 `/api/pricing`，不会错误追加 `/v1`。
- 仅为受信 Tuzi 同源或开发代理图片请求附加 `X-Request-Id`，避免跨域供应商额外的 CORS 预检失败。
- 更新 `docs/PROVIDER_IMAGE_ENDPOINT_404_LESSONS.md`，记录备用域名、历史 binding 修复、测速边界与回退规则。

## 验证

### 自动化

- 6 个相关测试文件、64 条测试通过：
  - provider routing
  - Tuzi endpoint discovery
  - Tuzi GPT Image adapter
  - image adapter integration
  - settings repository
  - model health
- `pnpm nx typecheck drawnix` 通过。
- `pnpm nx build drawnix` 通过。
- `pnpm nx build web` 通过，包括主应用和 Service Worker 生产构建。
- 精确 ESLint 检查为 0 error，仅剩测试文件中 2 条既有 `no-explicit-any` warning。
- `git diff --check` 和 API Key 精确扫描通过，敏感信息未写入源码、文档或提交。

### 真实 API 与浏览器

- 真实 API 请求 `/v1/images/generations` 返回 HTTP 200 和有效图片。
- 本地生产构建中，默认 Tuzi 分组成功获取 447 个模型，选择 `gpt-image-2` 后生成并插入一张 `1254 x 1254` 图片。
- 按用户原始场景新建独立 Tuzi 供应商，填写 API 地址和 Key、获取模型、添加并明确选择该供应商的 `gpt-image-2`，再次成功生成并插入第二张 `1254 x 1254` 图片。
- 两轮生成均未出现本次请求相关的 404 或 CORS 错误。
- 临时供应商已删除，浏览器中的测试凭据已覆盖清理。

## 兼容性与风险控制

- URL 版本段折叠仅在 Base URL 尾部和 path 头部版本段完全相同时发生。
- `ensure-v1` 只由 Tuzi GPT Image adapter 显式启用。
- 404 回退严格限制在可信官方 Tuzi 节点和图片 POST 请求。
- 普通 OpenAI、Gemini、Google、Suno、Kling、绝对 endpoint 等现有协议不受影响。
- 生产构建仍会显示仓库既有的 Sass deprecation、Browserslist、动态导入和大 chunk 警告，本次未新增构建错误。

## CI 说明

旧提交上的 CI 失败包含仓库基线测试环境问题和 Vercel 授权失败；Netlify deploy preview 成功。最新推送会重新触发远程检查，本 PR 的相关测试、类型检查、生产构建和真实浏览器出图均已在本地通过。
