### PR TITLE
修复 AI 任务栏跟随尺寸与局域网图片插入

### DIFF
--- a/docs/2026-08-04-AI任务栏跟随尺寸与局域网图片插入-交接文档.md
+++ b/docs/2026-08-04-AI任务栏跟随尺寸与局域网图片插入-交接文档.md
@@ -1,0 +1,76 @@
+# AI 任务栏跟随尺寸与局域网图片插入交接文档
+
+**日期**: 2026-08-04
+**适用版本**: 基于 `origin/develop` `eedd3d90`（1.0.11）
+**关联 QA**: [2026-08-04-AI任务栏跟随尺寸与局域网图片插入测试](../qa/2026-08-04-AI任务栏跟随尺寸与局域网图片插入测试/2026-08-04-AI任务栏跟随尺寸与局域网图片插入测试.md)
+
+## 问题
+
+1. 任务栏跟随窄图片时，宽度会被目标图片宽度压缩到 `420px` 左右，模型、尺寸、数量等选项被挤压或裁切。
+2. 通过局域网 HTTP 地址访问 OpenTu 时，浏览器处于非安全上下文，Service Worker 不可用。画板保存的 `/__aitu_cache__/...` 图片无法由 Service Worker 返回，手动插入任务图片时连续提示“插入失败: 未知错误”。
+
+## 最终行为
+
+### 跟随任务栏
+
+- 目标图片只决定任务栏的吸附位置，不再决定任务栏宽度。
+- 桌面端继续使用原任务栏响应式尺寸，最大宽度 `720px`。
+- 跟随前后不写入额外的内联 `width` 或 `max-width`。
+- 任务栏仍优先显示在目标下方，空间不足时切换到上方，并保持视口内左右边界。
+- 移动端沿用既有底部全宽布局。
+
+### 局域网图片插入
+
+- 缓存图片继续在画板数据中保存稳定虚拟 URL，不写入临时 `blob:` 或大段 base64。
+- Service Worker 不可用时，插入链路直接从 IndexedDB Blob 缓存读取图片尺寸。
+- 画布渲染虚拟图片失败时，从 IndexedDB 读取 Blob 并创建临时 Object URL。
+- 图片 URL 变化或组件卸载时立即回收 Object URL，避免长期占用内存。
+- Service Worker 正常可用时继续使用原虚拟 URL 路径，不改变线上行为。
+
+## 关键实现
+
+- `packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx`
+  - 跟随定位读取任务栏实际宽度，仅计算左右边界，不覆盖任务栏布局宽度。
+- `packages/drawnix/src/components/ai-input-bar/bound-taskbar-layout.ts`
+  - 提供任务栏实际宽度与响应式兜底宽度计算。
+- `packages/drawnix/src/data/image.ts`
+  - 无 Service Worker 时，从统一缓存的 IndexedDB Blob 加载图片尺寸并执行插入。
+- `packages/drawnix/src/plugins/components/image.tsx`
+  - 虚拟 URL 加载失败时使用 IndexedDB Blob 渲染，并负责 Object URL 生命周期清理。
+
+## 数据与性能边界
+
+- 不新增图片副本到画板 JSON。
+- 不把缓存图片转为 base64 后持久化，避免白板数据和内存膨胀。
+- Object URL 只作为当前渲染会话的临时地址，并在换源或卸载时释放。
+- 现有 Cache Storage 与 IndexedDB 双写策略保持不变。
+- 修复不改变图片生成、任务队列、目标替换和素材库的数据结构。
+
+## 启动要求
+
+OpenTu 开发环境依赖 `sw.js`。标准启动应使用项目的 PWA 启动链路：
+
+```bash
+pnpm start
+```
+
+指定其他应用端口时，也必须先以 development 模式构建或监听 Service Worker：
+
+```bash
+./node_modules/.bin/vite build -c apps/web/vite.sw.config.ts --mode development
+pnpm exec vite --config apps/web/vite.config.ts --host 0.0.0.0 --port 7024 --strictPort
+```
+
+局域网 HTTP 地址即使无法启用 Service Worker，图片插入和画布渲染也必须通过 IndexedDB 回退正常工作。
+
+## 回归重点
+
+1. 窄图、宽图和缩放后的图片进入跟随态，任务栏宽度均与普通态一致。
+2. 模型、参数、数量、发送按钮保持可见，不出现横向裁切。
+3. `localhost` 有 Service Worker 时，虚拟缓存图片正常插入和显示。
+4. 局域网 HTTP 无 Service Worker 时，单图和多图均可插入并显示。
+5. 快速切换、删除图片或卸载组件后，没有遗留 Object URL 或异步回写旧图。
+
+## 一句话结论
+
+任务栏现在只跟随图片位置、不压缩自身；局域网 HTTP 即使没有 Service Worker，也能从 IndexedDB 缓存完成图片插入和渲染。

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -102,6 +102,7 @@ import {
   type WorkflowDefinition,
   type WorkflowStepOptions,
 } from './workflow-converter';
+import { getBoundTaskbarWidth } from './bound-taskbar-layout';
 import { SkillDropdown, type SkillOption } from './SkillDropdown';
 import {
   inferSkillMediaTypes,
@@ -5205,10 +5206,9 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       const targetTop =
         boardRect.top + (boundImageTarget.rect.y - originY) * zoom;
       const viewportMargin = 12;
-      const targetWidth = boundImageTarget.rect.width * zoom;
-      const barWidth = Math.min(
-        720,
-        Math.max(420, Math.min(window.innerWidth - 96, targetWidth))
+      const barWidth = getBoundTaskbarWidth(
+        containerRef.current?.getBoundingClientRect().width,
+        window.innerWidth
       );
       const left = Math.min(
         Math.max(targetCenterX, viewportMargin + barWidth / 2),
@@ -5221,7 +5221,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           ? belowTop
           : Math.max(viewportMargin, targetTop - estimatedHeight - 8);
 
-      return { left, top, width: barWidth };
+      return { left, top };
     }, [boundImageTarget, boundInputLayoutTick, shouldKeepExpanded]);
 
     const boundInputStyle = boundInputPosition
@@ -5229,8 +5229,6 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           left: `${boundInputPosition.left}px`,
           top: `${boundInputPosition.top}px`,
           bottom: 'auto',
-          width: `${boundInputPosition.width}px`,
-          maxWidth: `${boundInputPosition.width}px`,
         } as React.CSSProperties)
       : undefined;
 

--- a/packages/drawnix/src/components/ai-input-bar/__tests__/bound-taskbar-layout.test.ts
+++ b/packages/drawnix/src/components/ai-input-bar/__tests__/bound-taskbar-layout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getBoundTaskbarWidth } from '../bound-taskbar-layout';
+
+describe('getBoundTaskbarWidth', () => {
+  it('uses the taskbar current width for positioning', () => {
+    expect(getBoundTaskbarWidth(688, 1440)).toBe(688);
+  });
+
+  it('falls back to the original desktop responsive width', () => {
+    expect(getBoundTaskbarWidth(undefined, 1440)).toBe(720);
+    expect(getBoundTaskbarWidth(undefined, 700)).toBe(604);
+  });
+
+  it('does not return a negative width', () => {
+    expect(getBoundTaskbarWidth(undefined, 80)).toBe(0);
+  });
+});

--- a/packages/drawnix/src/components/ai-input-bar/bound-taskbar-layout.ts
+++ b/packages/drawnix/src/components/ai-input-bar/bound-taskbar-layout.ts
@@ -1,0 +1,19 @@
+const DESKTOP_TASKBAR_MAX_WIDTH = 720;
+const DESKTOP_VIEWPORT_HORIZONTAL_GUTTER = 96;
+
+export function getBoundTaskbarWidth(
+  measuredWidth: number | undefined,
+  viewportWidth: number
+): number {
+  if (measuredWidth && measuredWidth > 0) {
+    return measuredWidth;
+  }
+
+  return Math.max(
+    0,
+    Math.min(
+      DESKTOP_TASKBAR_MAX_WIDTH,
+      viewportWidth - DESKTOP_VIEWPORT_HORIZONTAL_GUTTER
+    )
+  );
+}

--- a/packages/drawnix/src/data/image.ts
+++ b/packages/drawnix/src/data/image.ts
@@ -17,12 +17,14 @@ import {
   scrollToPointIfNeeded,
 } from '../utils/selection-utils';
 import { assetStorageService } from '../services/asset-storage-service';
+import { unifiedCacheService } from '../services/unified-cache-service';
 import { analytics } from '../utils/posthog-analytics';
 import { cacheRemoteUrl } from '../services/media-executor/fallback-utils';
 import { normalizeImageDataUrl } from '@aitu/utils';
 import { AssetSource, AssetType } from '../types/asset.types';
 import { getInsertionPointFromSavedSelection, calculateImageDisplayDimensions } from '../utils/canvas-insertion-layout';
 import { getSupportedImageFileMimeType } from './blob';
+import { isVirtualMediaUrl } from '../utils/virtual-media-url';
 
 export const loadHTMLImageElement = (dataURL: DataURL, crossOrigin = false) => {
   const normalizedURL = normalizeImageDataUrl(dataURL) as DataURL;
@@ -158,6 +160,25 @@ export const loadHTMLImageElementWithRetry = (
     tryLoad();
   });
 };
+
+async function loadImageElementForCanvas(
+  imageUrl: DataURL
+): Promise<HTMLImageElement> {
+  const canUseServiceWorker =
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    !!navigator.serviceWorker.controller;
+
+  if (isVirtualMediaUrl(imageUrl) && !canUseServiceWorker) {
+    const cachedBlob = await unifiedCacheService.getCachedBlob(imageUrl);
+    if (!cachedBlob || cachedBlob.size === 0) {
+      throw new Error('图片缓存不可用，请重新生成或上传');
+    }
+    return loadHTMLImageElementFromBlob(cachedBlob);
+  }
+
+  return loadHTMLImageElementWithRetry(imageUrl, true);
+}
 
 export const buildImage = (
   image: HTMLImageElement,
@@ -410,10 +431,7 @@ export const insertImageFromUrl = async (
   } else {
     // 使用带重试的图片加载函数，支持自动绕过 SW
     // console.log(`[insertImageFromUrl] Loading image with retry...`);
-    const image = await loadHTMLImageElementWithRetry(
-      resolvedUrl as DataURL,
-      true
-    ); // 使用 crossOrigin 以支持外部 URL
+    const image = await loadImageElementForCanvas(resolvedUrl as DataURL);
     imageItem = buildImage(
       image,
       resolvedUrl as DataURL,
@@ -535,7 +553,7 @@ function updateImageSizeAfterLoad(
   referenceDimensions: { width: number; height: number }
 ): void {
   // 使用带重试的加载函数，提高虚拟 URL 场景的可靠性
-  loadHTMLImageElementWithRetry(imageUrl as DataURL, true)
+  loadImageElementForCanvas(imageUrl as DataURL)
     .then((img) => {
       const naturalWidth = img.naturalWidth;
       const naturalHeight = img.naturalHeight;
@@ -617,7 +635,9 @@ export const insertImageFromUrlAndSelect = async (
     // 使用直接加载方式获取图片尺寸（不需要 CORS）
     // 图片会使用原始 URL 存储，浏览器渲染 <img> 标签时不需要 CORS
     // console.log('[insertImageFromUrlAndSelect] Loading image directly:', imageUrl);
-    image = await loadImageDirectly(imageUrl);
+    image = isVirtualMediaUrl(imageUrl)
+      ? await loadImageElementForCanvas(imageUrl as DataURL)
+      : await loadImageDirectly(imageUrl);
     // console.log('[insertImageFromUrlAndSelect] Load successful, dimensions:', image.width, 'x', image.height);
   } catch (error) {
     console.error('[insertImageFromUrlAndSelect] Failed to load image:', error);

--- a/packages/drawnix/src/plugins/components/image.tsx
+++ b/packages/drawnix/src/plugins/components/image.tsx
@@ -170,7 +170,7 @@ export const Image: React.FC<ImageProps> = (props: ImageProps) => {
     }
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     currentImageUrlRef.current = props.imageItem.url;
     fallbackAttemptedUrlRef.current = null;
     clearFallbackBlobUrl();

--- a/packages/drawnix/src/plugins/components/image.tsx
+++ b/packages/drawnix/src/plugins/components/image.tsx
@@ -16,6 +16,8 @@ import {
   clearVirtualUrlImageError,
   handleVirtualUrlImageError,
 } from '../../utils/asset-cleanup';
+import { unifiedCacheService } from '../../services/unified-cache-service';
+import { isVirtualMediaUrl } from '../../utils/virtual-media-url';
 import {
   getImage3DSourceRectangle,
   getImage3DSvgOverlayGeometry,
@@ -150,6 +152,8 @@ const isVideoElement = (imageItem: any): boolean => {
 export const Image: React.FC<ImageProps> = (props: ImageProps) => {
   const currentImageUrlRef = useRef(props.imageItem.url);
   const cleanupSWRecoveryRef = useRef<(() => void) | null>(null);
+  const fallbackBlobUrlRef = useRef<string | null>(null);
+  const fallbackAttemptedUrlRef = useRef<string | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const svgOverlayRef = useRef<Image3DOverlayRef | null>(null);
   const pptImageGenerationLockRef = useRef(false);
@@ -159,10 +163,22 @@ export const Image: React.FC<ImageProps> = (props: ImageProps) => {
     cleanupSWRecoveryRef.current = null;
   }, []);
 
+  const clearFallbackBlobUrl = useCallback(() => {
+    if (fallbackBlobUrlRef.current) {
+      URL.revokeObjectURL(fallbackBlobUrlRef.current);
+      fallbackBlobUrlRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     currentImageUrlRef.current = props.imageItem.url;
-    return clearSWRecovery;
-  }, [props.imageItem.url, clearSWRecovery]);
+    fallbackAttemptedUrlRef.current = null;
+    clearFallbackBlobUrl();
+    return () => {
+      clearSWRecovery();
+      clearFallbackBlobUrl();
+    };
+  }, [props.imageItem.url, clearFallbackBlobUrl, clearSWRecovery]);
 
   const retryImageAfterSWClaim = useCallback(
     (imageElement: HTMLImageElement) => {
@@ -226,9 +242,32 @@ export const Image: React.FC<ImageProps> = (props: ImageProps) => {
 
   // 处理图片加载失败
   const handleImageError = useCallback(
-    (event: any) => {
+    async (event: any) => {
       const imageElement = event.currentTarget as HTMLImageElement;
       imageElement.style.visibility = 'hidden';
+
+      if (
+        isVirtualMediaUrl(props.imageItem.url) &&
+        fallbackAttemptedUrlRef.current !== props.imageItem.url
+      ) {
+        fallbackAttemptedUrlRef.current = props.imageItem.url;
+        const cachedBlob = await unifiedCacheService.getCachedBlob(
+          props.imageItem.url
+        );
+        if (
+          cachedBlob &&
+          cachedBlob.size > 0 &&
+          imageElement.isConnected &&
+          currentImageUrlRef.current === props.imageItem.url
+        ) {
+          clearFallbackBlobUrl();
+          const blobUrl = URL.createObjectURL(cachedBlob);
+          fallbackBlobUrlRef.current = blobUrl;
+          imageElement.src = blobUrl;
+          return;
+        }
+      }
+
       retryImageAfterSWClaim(imageElement);
 
       const retry = handleVirtualUrlImageError(
@@ -245,7 +284,13 @@ export const Image: React.FC<ImageProps> = (props: ImageProps) => {
         }, retry.delay);
       }
     },
-    [props.board, props.element, props.imageItem.url, retryImageAfterSWClaim]
+    [
+      clearFallbackBlobUrl,
+      props.board,
+      props.element,
+      props.imageItem.url,
+      retryImageAfterSWClaim,
+    ]
   );
   const handleImageLoad = useCallback(
     (event: any) => {

--- a/qa/2026-08-04-AI任务栏跟随尺寸与局域网图片插入测试/2026-08-04-AI任务栏跟随尺寸与局域网图片插入测试.md
+++ b/qa/2026-08-04-AI任务栏跟随尺寸与局域网图片插入测试/2026-08-04-AI任务栏跟随尺寸与局域网图片插入测试.md
@@ -1,0 +1,141 @@
+# AI 任务栏跟随尺寸与局域网图片插入测试
+
+**日期**: 2026-08-04
+**测试版本**: `codex/fix-follow-taskbar-size`，基线 `origin/develop` `eedd3d90`
+**测试地址**: `http://192.168.50.225:7024/`
+**关联 Docs**: [AI 任务栏跟随尺寸与局域网图片插入交接文档](../../docs/2026-08-04-AI任务栏跟随尺寸与局域网图片插入-交接文档.md)
+
+## 验收范围
+
+- 跟随图片时任务栏保持原有尺寸。
+- 下方模型、参数、数量和发送操作不被挤压或裁切。
+- 局域网 HTTP 无 Service Worker 时，缓存图片仍可插入画板并正常显示。
+- 临时 Blob URL 仅用于渲染，不污染画板持久化数据。
+
+## 自动化验证结果
+
+### 任务栏宽度计算
+
+```bash
+pnpm exec vitest run \
+  packages/drawnix/src/components/ai-input-bar/__tests__/bound-taskbar-layout.test.ts \
+  packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.test.ts
+```
+
+结果：`2` 个测试文件、`7` 个测试全部通过。
+
+覆盖：
+
+- 使用任务栏当前实际宽度计算跟随边界。
+- 无法读取实际宽度时沿用桌面端响应式尺寸。
+- 极窄视口不产生负宽度。
+
+### 局域网缓存回退
+
+```bash
+pnpm exec vitest run \
+  packages/drawnix/src/services/unified-cache-service.test.ts \
+  --environment jsdom
+```
+
+结果：`1` 个测试文件、`3` 个测试全部通过。
+
+覆盖：
+
+- Cache Storage 不可用时，图片 Blob 写入并从 IndexedDB 恢复。
+- Cache Storage 因安全限制拒绝访问时正常回退。
+- 元数据存在但 Blob 缺失时可重新修复缓存。
+
+### 类型与格式检查
+
+```bash
+pnpm exec tsc -p apps/web/tsconfig.app.json --noEmit
+git diff --check
+```
+
+结果：通过。
+
+## 浏览器实测结果
+
+### 场景 1：跟随态保持任务栏原尺寸
+
+环境：Chrome，`1440 x 900`，局域网 HTTP。
+
+步骤：
+
+1. 打开空白画板并记录普通任务栏宽度。
+2. 插入一张图片并写入生成提示词元数据。
+3. 单选该图片，等待任务栏进入跟随态。
+4. 检查任务栏边界、内联样式和底部选项。
+
+结果：
+
+- 普通态宽度：`720px`。
+- 跟随态宽度：`720px`。
+- 跟随态 `style.width`：空。
+- 跟随态 `style.maxWidth`：空。
+- 图片类型、模型、参数和数量控件均在任务栏可视边界内。
+- 浏览器控制台无错误。
+
+### 场景 2：局域网 HTTP 无 Service Worker 单图插入
+
+环境检测：
+
+- `isSecureContext = false`
+- `serviceWorker in navigator = false`
+
+步骤：
+
+1. 通过统一缓存写入一张 PNG。
+2. 使用画布插入服务插入该稳定虚拟 URL。
+3. 检查画板节点与页面实际图片地址。
+
+结果：
+
+- 画板元素数量从 `0` 增至 `1`。
+- 插入结果 `success = true`。
+- 画板数据保存 `/__aitu_cache__/image/content-*.png`。
+- 页面渲染使用临时 `blob:http://192.168.50.225:7024/...`。
+- 图片可见，浏览器控制台无错误。
+
+### 场景 3：连续六张图片插入
+
+步骤：
+
+1. 使用 OpenTu 自带 PNG 资源写入统一缓存。
+2. 连续六次调用任务列表同类的 `insertImageFromUrl` 路径。
+3. 检查每次结果、画板节点和图片可见状态。
+
+结果：
+
+- `6/6` 次插入成功。
+- 画板新增 `6` 个图片元素。
+- `6/6` 张图片可见。
+- `6/6` 张图片在无 Service Worker 时使用 Blob URL 渲染。
+- 未出现“插入失败: 未知错误”。
+- 浏览器控制台无错误。
+
+## 人工回归清单
+
+### 跟随布局
+
+- [ ] 选择窄图片后，任务栏宽度与普通态一致。
+- [ ] 选择宽图片后，任务栏不随目标放大。
+- [ ] 缩放和平移画布后，任务栏只更新位置。
+- [ ] 图片靠近视口左右边缘时，任务栏不越界。
+- [ ] 图片下方空间不足时，任务栏切换到上方且尺寸不变。
+- [ ] 模型、参数、数量和发送按钮均可见、可点击。
+- [ ] 移动端继续使用底部全宽布局。
+
+### 图片插入
+
+- [ ] 局域网 HTTP 下，从任务队列插入单张生成图片成功。
+- [ ] 局域网 HTTP 下，批量结果逐张插入成功。
+- [ ] 刷新后稳定虚拟 URL 仍能从 IndexedDB 恢复显示。
+- [ ] `localhost` 有 Service Worker 时继续使用原虚拟 URL 路径。
+- [ ] 切换图片或关闭画板后，临时 Blob URL 被释放。
+- [ ] 不出现连续“插入失败: 未知错误”提示。
+
+## 结论
+
+自动化检查和局域网浏览器实测均通过。任务栏跟随不再压缩，局域网 HTTP 无 Service Worker 时图片可通过 IndexedDB Blob 回退插入和显示。


### PR DESCRIPTION
## 问题描述

- AI 任务栏跟随窄图片时会按目标图片宽度压缩，导致模型、参数、数量等控件被挤压或裁切。
- 局域网 HTTP 环境无法启用 Service Worker，画板虚拟缓存图片无法插入或渲染。

## 修复思路

- 跟随态只根据目标图片更新任务栏位置，任务栏宽度继续使用当前实际尺寸或原桌面响应式尺寸。
- 无 Service Worker 时，从统一缓存的 IndexedDB Blob 读取图片尺寸；画布渲染失败时使用临时 Blob URL，并在换源或卸载时释放。

## 更新代码架构

- 抽出 bound-taskbar-layout 统一计算跟随定位使用的任务栏宽度。
- 图片插入与画布渲染复用统一缓存 Blob 回退，不新增持久化实体或 base64 副本。
- 新增功能范围 Docs/QA。

## 验证

- 任务栏布局与跟随状态测试：7/7 通过
- 统一缓存 jsdom 测试：3/3 通过
- Drawnix TypeScript 检查：通过
- git diff --check：通过
- LAN HTTP 实测：任务栏普通态/跟随态均为 720px；单图和连续 6 图插入全部成功