### PR TITLE
修复：恢复任务栏历史提示词虚化复用

### DIFF
--- a/apps/web-e2e/src/features/features.spec.ts
+++ b/apps/web-e2e/src/features/features.spec.ts
@@ -60,7 +60,11 @@ test.describe('@feature 功能测试', () => {
         .click();
       await expect(page.locator('.ai-input-bar--bound-image')).toBeVisible();
       const input = page.locator('[data-testid="ai-input-textarea"]');
-      await expect(input).toHaveValue(prompt);
+      await expect(input).toHaveValue('');
+      await expect(input).toHaveAttribute(
+        'placeholder',
+        `按空格或回车复用提示词：${prompt}`
+      );
       await expect(input).not.toBeFocused();
       expect(await hasImage(id)).toBe(true);
     };
@@ -69,6 +73,8 @@ test.describe('@feature 功能测试', () => {
     await selectImage('typing-delete-image', 'abc');
     const input = page.locator('[data-testid="ai-input-textarea"]');
     await input.focus();
+    await input.press('Enter');
+    await expect(input).toHaveValue('abc');
     await input.press('End');
     await input.press('Backspace');
     await expect(input).toHaveValue('ab');

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -205,6 +205,7 @@ import {
   collectBoundTargetElementIds,
   createBoundImageTargetStateKey,
   findBoundTargetElement,
+  formatBoundTargetPromptSuggestion,
   isBoundTargetReferenceOnly,
   pinBoundTargetReferenceContent,
   pruneStaleBoundTargetTaskbarDrafts,
@@ -213,6 +214,8 @@ import {
   recordBoundTargetDismiss,
   persistBoundTargetFollowEnabled,
   resolveBoundTargetForPosition,
+  resolveBoundTargetPromptSuggestion,
+  resolveBoundTargetPromptSuggestionAction,
   resolveBoundTargetTaskbarDraft,
   resolveBoundTargetSuppression,
   resolveTaskbarDraftAfterSubmission,
@@ -706,7 +709,7 @@ function createBoundImageInputDraft(prompt = ''): BoundImageInputDraft {
 
 function readImageGenerationPrompt(element: unknown): string {
   const record = element as Record<string, unknown> | null;
-  for (const key of ['generationPrompt', 'aiPrompt']) {
+  for (const key of ['generationPrompt', 'aiPrompt', 'prompt']) {
     const value = record?.[key];
     if (typeof value === 'string' && value.trim()) {
       return value.trim();
@@ -1421,6 +1424,9 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
 
     // State
     const [prompt, setPrompt] = useState('');
+    const [promptSuggestion, setPromptSuggestion] = useState<string | null>(
+      null
+    );
     const [isInspirationSendGuideActive, setIsInspirationSendGuideActive] =
       useState(false);
     const [isPromptOptimizeOpen, setIsPromptOptimizeOpen] = useState(false);
@@ -1432,6 +1438,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     const [boundImageTargetMode, setBoundImageTargetMode] =
       useState<BoundImageTargetMode>('follow');
     const boundImageTargetRef = useRef<BoundImageTarget | null>(null);
+    const dismissedPromptElementIdRef = useRef<string | null>(null);
     const [boundTargetDismissHintCount, setBoundTargetDismissHintCount] =
       useState(() => readBoundTargetDismissHintCount());
     const [boundTargetFollowEnabled, setBoundTargetFollowEnabled] = useState(
@@ -1657,6 +1664,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         : `${initialGenerationType}:${initialSelectedModelKey}`
     );
     const promptRef = useRef(prompt);
+    const promptSuggestionRef = useRef<string | null>(null);
     const selectedContentRef = useRef<SelectedContent[]>(selectedContent);
     const uploadedContentRef = useRef<SelectedContent[]>(uploadedContent);
     const knowledgeContextRefsRef = useRef(knowledgeContextRefs);
@@ -1722,6 +1730,15 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         collectBoundTargetElementIds(children)
       );
     }, [isDataReady]);
+    const updatePromptSuggestion = useCallback((suggestion: string | null) => {
+      promptSuggestionRef.current = suggestion;
+      setPromptSuggestion(suggestion);
+    }, []);
+    const dismissPromptSuggestion = useCallback(() => {
+      dismissedPromptElementIdRef.current =
+        boundImageTargetRef.current?.elementId || null;
+      updatePromptSuggestion(null);
+    }, [updatePromptSuggestion]);
     const resetBoundTaskbarDraftsForBoard = useCallback(
       (nextBoardId: string | null) => {
         if (activeTaskbarBoardIdRef.current === nextBoardId) return false;
@@ -1735,6 +1752,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         activeDraftBaselineRef.current = null;
         lastBoundImageTargetKeyRef.current = null;
         suppressedBoundImageElementIdRef.current = null;
+        dismissedPromptElementIdRef.current = null;
         lastPrunedBoardChildrenRef.current = null;
         boundImageTargetRef.current = null;
         selectedContentRef.current = [];
@@ -1743,11 +1761,12 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         setBoundImageTarget(null);
         setBoundImageTargetMode('follow');
         setBoundTargetError(null);
+        updatePromptSuggestion(null);
         setSelectedContent([]);
         applyTaskbarDraft(unboundTaskbarDraftRef.current);
         return true;
       },
-      [applyTaskbarDraft, readCurrentTaskbarDraft]
+      [applyTaskbarDraft, readCurrentTaskbarDraft, updatePromptSuggestion]
     );
     useEffect(() => {
       resetBoundTaskbarDraftsForBoard(currentBoardId ?? null);
@@ -2178,20 +2197,16 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                 if (
                   activeDraftElementIdRef.current ===
                     currentBoundTarget.elementId &&
-                  activeDraftBaselineRef.current
+                  promptRef.current.length === 0
                 ) {
-                  activeDraftBaselineRef.current = {
-                    ...activeDraftBaselineRef.current,
-                    prompt: nextTargetPrompt,
-                  };
+                  updatePromptSuggestion(
+                    resolveBoundTargetPromptSuggestion(
+                      nextTargetPrompt,
+                      currentBoundTarget.elementId,
+                      dismissedPromptElementIdRef.current
+                    )
+                  );
                 }
-                setPrompt((currentPrompt) => {
-                  if (currentPrompt !== currentBoundTarget.prompt) {
-                    return currentPrompt;
-                  }
-                  promptRef.current = nextTargetPrompt;
-                  return nextTargetPrompt;
-                });
               }
             }
           }
@@ -2320,7 +2335,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         });
 
       return () => subscription.unsubscribe();
-    }, [language, workflowControl]);
+    }, [language, updatePromptSuggestion, workflowControl]);
 
     // 当前后处理状态 ref
     const postProcessingStatusRef = useRef<PostProcessingStatus | undefined>(
@@ -2691,6 +2706,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         const nextKnowledgeContextRefs = normalizeKnowledgeContextRefs(
           detail.knowledgeContextRefs
         );
+        dismissPromptSuggestion();
         promptRef.current = nextPrompt;
         uploadedContentRef.current = nextUploadedContent;
         knowledgeContextRefsRef.current = nextKnowledgeContextRefs;
@@ -2727,6 +2743,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     }, [
       audioModels,
       confirmOverwriteInputIfNeeded,
+      dismissPromptSuggestion,
       focusInput,
       imageModels,
       language,
@@ -2746,6 +2763,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         title?: string;
         category?: string;
       }) => {
+        dismissPromptSuggestion();
         promptRef.current = info.prompt;
         setPrompt(info.prompt);
         setIsInspirationSendGuideActive(true);
@@ -2769,12 +2787,13 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           category: info.category,
         });
       },
-      []
+      [dismissPromptSuggestion]
     );
 
     // 处理历史提示词选择：将提示词回填到输入框并切换生成类型
     const handleSelectHistoryPrompt = useCallback(
       (info: { content: string; modelType?: PromptType }) => {
+        dismissPromptSuggestion();
         promptRef.current = info.content;
         setPrompt(info.content);
         setIsInspirationSendGuideActive(false);
@@ -2796,7 +2815,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
 
         inputRef.current?.focus();
       },
-      []
+      [dismissPromptSuggestion]
     );
 
     // 处理添加 Skill：打开知识库并定位到 Skill 目录，自动新建笔记
@@ -3203,6 +3222,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           setBoundImageTarget(referenceTarget);
           setBoundImageTargetMode('reference');
           setBoundTargetError(null);
+          updatePromptSuggestion(null);
           setSelectedContent([]);
           selectedFrameRef.current = null;
           suppressSelectionContentUrlsRef.current = new Set();
@@ -3210,7 +3230,6 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           return;
         }
 
-        const previousTarget = boundImageTargetRef.current;
         boundImageTargetRef.current = target;
         setBoundImageTarget(target);
         setBoundImageTargetMode('follow');
@@ -3224,6 +3243,8 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           pruneBoundTargetTaskbarDrafts();
           lastBoundImageTargetKeyRef.current = null;
           setBoundTargetError(null);
+          dismissedPromptElementIdRef.current = null;
+          updatePromptSuggestion(null);
           return;
         }
 
@@ -3237,7 +3258,8 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         setGenerationType('image');
         if (activeDraftElementIdRef.current !== target.elementId) {
           saveActiveTaskbarDraft();
-          const fallback = createBoundImageInputDraft(target.prompt);
+          dismissedPromptElementIdRef.current = null;
+          const fallback = createBoundImageInputDraft();
           const restored = resolveBoundTargetTaskbarDraft(
             boundTargetDraftsRef.current,
             target.elementId,
@@ -3246,22 +3268,25 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           activeDraftElementIdRef.current = target.elementId;
           activeDraftBaselineRef.current = restored.baseline;
           applyTaskbarDraft(restored.draft);
-        } else if (
-          previousTarget?.elementId === target.elementId &&
-          activeDraftBaselineRef.current
-        ) {
-          const shouldApplyTargetPrompt =
-            promptRef.current === activeDraftBaselineRef.current.prompt;
-          activeDraftBaselineRef.current = {
-            ...activeDraftBaselineRef.current,
-            prompt: target.prompt,
-          };
-          if (shouldApplyTargetPrompt) {
-            applyTaskbarDraft({
-              ...readCurrentTaskbarDraft(),
-              prompt: target.prompt,
-            });
-          }
+          updatePromptSuggestion(
+            restored.draft.prompt
+              ? null
+              : resolveBoundTargetPromptSuggestion(
+                  target.prompt,
+                  target.elementId,
+                  dismissedPromptElementIdRef.current
+                )
+          );
+        } else if (activeDraftBaselineRef.current) {
+          updatePromptSuggestion(
+            promptRef.current
+              ? null
+              : resolveBoundTargetPromptSuggestion(
+                  target.prompt,
+                  target.elementId,
+                  dismissedPromptElementIdRef.current
+                )
+          );
         }
         pruneBoundTargetTaskbarDrafts();
         setSelectedContent([]);
@@ -3276,6 +3301,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         currentBoardId,
         resetBoundTaskbarDraftsForBoard,
         saveActiveTaskbarDraft,
+        updatePromptSuggestion,
       ]
     );
 
@@ -3335,6 +3361,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         setBoundImageTarget(nextTarget);
         setBoundImageTargetMode('reference');
         setBoundTargetError(null);
+        dismissPromptSuggestion();
         setBoundInputLayoutTick((tick) => tick + 1);
         setBoundTargetDismissHintCount(
           recordBoundTargetDismiss(boundTargetDismissHintCount)
@@ -3344,6 +3371,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         boundImageTarget,
         boundTargetDismissHintCount,
         detachTaskbarDraft,
+        dismissPromptSuggestion,
         language,
       ]
     );
@@ -5508,16 +5536,45 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           return;
         }
 
-        if (event.key === 'Enter' && (event.shiftKey || event.altKey)) {
-          return;
-        }
-
         if (
           (modelDropdownOpen || paramsDropdownOpen || countDropdownOpen) &&
           (event.key === 'Enter' || event.key === 'Tab')
         ) {
           // 下拉菜单打开时，回车交由菜单处理，避免触发表单提交
           event.preventDefault();
+          return;
+        }
+
+        const suggestion = promptSuggestionRef.current;
+        const suggestionAction = resolveBoundTargetPromptSuggestionAction({
+          suggestion,
+          currentPrompt: promptRef.current,
+          key: event.key,
+          code: event.code,
+          isComposing: event.nativeEvent.isComposing,
+          hasModifier:
+            event.shiftKey || event.altKey || event.ctrlKey || event.metaKey,
+        });
+        if (suggestionAction === 'reuse') {
+          event.preventDefault();
+          const nextPrompt = suggestion || '';
+          promptRef.current = nextPrompt;
+          setPrompt(nextPrompt);
+          dismissPromptSuggestion();
+          setIsInspirationSendGuideActive(false);
+          requestAnimationFrame(() => {
+            const input = inputRef.current;
+            if (!input) return;
+            input.selectionStart = input.value.length;
+            input.selectionEnd = input.value.length;
+          });
+          return;
+        }
+        if (suggestionAction === 'dismiss') {
+          dismissPromptSuggestion();
+        }
+
+        if (event.key === 'Enter' && (event.shiftKey || event.altKey)) {
           return;
         }
 
@@ -5534,7 +5591,13 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           return;
         }
       },
-      [countDropdownOpen, handleGenerate, modelDropdownOpen, paramsDropdownOpen]
+      [
+        countDropdownOpen,
+        dismissPromptSuggestion,
+        handleGenerate,
+        modelDropdownOpen,
+        paramsDropdownOpen,
+      ]
     );
 
     // Handle input focus
@@ -5567,6 +5630,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const newValue = e.target.value;
         const cursorPos = e.target.selectionStart || newValue.length;
+        dismissPromptSuggestion();
         promptRef.current = newValue;
         setPrompt(newValue);
         setIsInspirationSendGuideActive(false);
@@ -5587,7 +5651,18 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           }
         }
       },
-      []
+      [dismissPromptSuggestion]
+    );
+
+    const handleTaskbarControlPointerDown = useCallback(
+      (event: React.PointerEvent<HTMLDivElement>) => {
+        const target = event.target;
+        if (!(target instanceof Element) || target.closest('textarea')) return;
+        if (target.closest('button, [role="button"], input, select')) {
+          dismissPromptSuggestion();
+        }
+      },
+      [dismissPromptSuggestion]
     );
 
     const sendButtonTrackParams = useMemo(
@@ -5620,6 +5695,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
     );
     const hasUnsubmittedInputContent =
       prompt.length > 0 ||
+      Boolean(promptSuggestion) ||
       displayContent.length > 0 ||
       knowledgeContextRefs.length > 0;
     const shouldKeepExpanded =
@@ -5774,6 +5850,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
             }
           )}
           style={boundInputStyle}
+          onPointerDownCapture={handleTaskbarControlPointerDown}
           data-testid="ai-input-bar"
         >
           <SelectionWatcher
@@ -6164,6 +6241,8 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                       'ai-input-bar__input--focused': shouldKeepExpanded,
                       'ai-input-bar__input--long-text':
                         isPromptManuallyExpanded,
+                      'ai-input-bar__input--suggestion':
+                        Boolean(promptSuggestion),
                     })}
                     value={prompt}
                     onChange={handleInputChange}
@@ -6171,7 +6250,12 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     placeholder={
-                      generationType === 'agent'
+                      promptSuggestion
+                        ? formatBoundTargetPromptSuggestion(
+                            promptSuggestion,
+                            language === 'zh' ? 'zh' : 'en'
+                          )
+                        : generationType === 'agent'
                         ? language === 'zh'
                           ? '输入指令，让 Agent 为你工作...'
                           : 'Type instructions for Agent...'
@@ -6228,6 +6312,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
                           setIsFocused(true);
                         }}
                         onApply={(optimizedPrompt) => {
+                          dismissPromptSuggestion();
                           promptRef.current = optimizedPrompt;
                           setPrompt(optimizedPrompt);
                           setIsFocused(true);

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -219,6 +219,7 @@ import {
   resolveBoundTargetTaskbarDraft,
   resolveBoundTargetSuppression,
   resolveTaskbarDraftAfterSubmission,
+  shouldReleaseBoundTargetPromptDismissal,
   shouldUseBoundTargetForSubmission,
   storeBoundTargetTaskbarDraft,
   type BoundTargetTaskbarDraft,
@@ -1439,6 +1440,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       useState<BoundImageTargetMode>('follow');
     const boundImageTargetRef = useRef<BoundImageTarget | null>(null);
     const dismissedPromptElementIdRef = useRef<string | null>(null);
+    const dismissedPromptGenerationTaskIdRef = useRef<string | null>(null);
     const [boundTargetDismissHintCount, setBoundTargetDismissHintCount] =
       useState(() => readBoundTargetDismissHintCount());
     const [boundTargetFollowEnabled, setBoundTargetFollowEnabled] = useState(
@@ -1735,8 +1737,10 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
       setPromptSuggestion(suggestion);
     }, []);
     const dismissPromptSuggestion = useCallback(() => {
-      dismissedPromptElementIdRef.current =
-        boundImageTargetRef.current?.elementId || null;
+      const target = boundImageTargetRef.current;
+      dismissedPromptElementIdRef.current = target?.elementId || null;
+      dismissedPromptGenerationTaskIdRef.current =
+        target?.generationTaskId || null;
       updatePromptSuggestion(null);
     }, [updatePromptSuggestion]);
     const resetBoundTaskbarDraftsForBoard = useCallback(
@@ -1753,6 +1757,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         lastBoundImageTargetKeyRef.current = null;
         suppressedBoundImageElementIdRef.current = null;
         dismissedPromptElementIdRef.current = null;
+        dismissedPromptGenerationTaskIdRef.current = null;
         lastPrunedBoardChildrenRef.current = null;
         boundImageTargetRef.current = null;
         selectedContentRef.current = [];
@@ -2177,6 +2182,17 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
               if (task.status === TaskStatus.COMPLETED) {
                 const nextTargetPrompt =
                   task.params.prompt || currentBoundTarget.prompt;
+                if (
+                  shouldReleaseBoundTargetPromptDismissal(
+                    currentBoundTarget.elementId,
+                    task.id,
+                    dismissedPromptElementIdRef.current,
+                    dismissedPromptGenerationTaskIdRef.current
+                  )
+                ) {
+                  dismissedPromptElementIdRef.current = null;
+                  dismissedPromptGenerationTaskIdRef.current = null;
+                }
                 setBoundImageTarget((current) =>
                   current?.elementId === currentBoundTarget.elementId
                     ? {
@@ -3244,6 +3260,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
           lastBoundImageTargetKeyRef.current = null;
           setBoundTargetError(null);
           dismissedPromptElementIdRef.current = null;
+          dismissedPromptGenerationTaskIdRef.current = null;
           updatePromptSuggestion(null);
           return;
         }
@@ -3259,6 +3276,7 @@ export const AIInputBar: React.FC<AIInputBarProps> = React.memo(
         if (activeDraftElementIdRef.current !== target.elementId) {
           saveActiveTaskbarDraft();
           dismissedPromptElementIdRef.current = null;
+          dismissedPromptGenerationTaskIdRef.current = null;
           const fallback = createBoundImageInputDraft();
           const restored = resolveBoundTargetTaskbarDraft(
             boundTargetDraftsRef.current,

--- a/packages/drawnix/src/components/ai-input-bar/ai-input-bar.scss
+++ b/packages/drawnix/src/components/ai-input-bar/ai-input-bar.scss
@@ -894,6 +894,11 @@ $ai-input-small-expanded-max-height: $ai-input-small-line-height * 6 +
       color: $gray-medium;
     }
 
+    &--suggestion::placeholder {
+      color: rgba($gray-medium, 0.78);
+      font-style: italic;
+    }
+
     &:focus {
       outline: none;
       border: none !important;

--- a/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.test.ts
+++ b/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.test.ts
@@ -22,6 +22,7 @@ import {
   resolveBoundTargetTaskbarDraft,
   resolveBoundTargetSuppression,
   resolveTaskbarDraftAfterSubmission,
+  shouldReleaseBoundTargetPromptDismissal,
   shouldUseBoundTargetForSubmission,
   storeBoundTargetTaskbarDraft,
 } from './target-bound-taskbar-state';
@@ -60,6 +61,33 @@ describe('target-bound-taskbar-state', () => {
     expect(
       resolveBoundTargetPromptSuggestion('海边日落', 'image-a', null)
     ).toBe('海边日落');
+  });
+
+  it('同一图片完成新一轮生成时解除旧提示词候选屏蔽', () => {
+    expect(
+      shouldReleaseBoundTargetPromptDismissal(
+        'image-a',
+        'task-new',
+        'image-a',
+        'task-old'
+      )
+    ).toBe(true);
+    expect(
+      shouldReleaseBoundTargetPromptDismissal(
+        'image-a',
+        'task-old',
+        'image-a',
+        'task-old'
+      )
+    ).toBe(false);
+    expect(
+      shouldReleaseBoundTargetPromptDismissal(
+        'image-b',
+        'task-new',
+        'image-a',
+        'task-old'
+      )
+    ).toBe(false);
   });
 
   it('空输入按空格或回车时只复用候选提示词', () => {

--- a/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.test.ts
+++ b/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.test.ts
@@ -7,7 +7,9 @@ import {
   collectBoundTargetElementIds,
   createBoundImageTargetStateKey,
   findBoundTargetElement,
+  formatBoundTargetPromptSuggestion,
   isBoundTargetReferenceOnly,
+  normalizeBoundTargetPromptSuggestion,
   pinBoundTargetReferenceContent,
   pruneStaleBoundTargetTaskbarDrafts,
   readBoundTargetDismissHintCount,
@@ -15,6 +17,8 @@ import {
   recordBoundTargetDismiss,
   persistBoundTargetFollowEnabled,
   resolveBoundTargetForPosition,
+  resolveBoundTargetPromptSuggestion,
+  resolveBoundTargetPromptSuggestionAction,
   resolveBoundTargetTaskbarDraft,
   resolveBoundTargetSuppression,
   resolveTaskbarDraftAfterSubmission,
@@ -45,6 +49,88 @@ function createFollowStorage(initialValue?: string) {
 }
 
 describe('target-bound-taskbar-state', () => {
+  it('将历史提示词规范化为候选，并抑制已取消目标的异步回显', () => {
+    expect(normalizeBoundTargetPromptSuggestion('  海边日落  ')).toBe(
+      '海边日落'
+    );
+    expect(normalizeBoundTargetPromptSuggestion('   ')).toBeNull();
+    expect(
+      resolveBoundTargetPromptSuggestion('海边日落', 'image-a', 'image-a')
+    ).toBeNull();
+    expect(
+      resolveBoundTargetPromptSuggestion('海边日落', 'image-a', null)
+    ).toBe('海边日落');
+  });
+
+  it('空输入按空格或回车时只复用候选提示词', () => {
+    for (const input of [
+      { key: ' ', code: 'Space' },
+      { key: 'Spacebar' },
+      { key: 'Enter' },
+    ]) {
+      expect(
+        resolveBoundTargetPromptSuggestionAction({
+          suggestion: '兔子',
+          currentPrompt: '',
+          ...input,
+        })
+      ).toBe('reuse');
+    }
+  });
+
+  it('直接输入、已有正文和组合键都会取消候选', () => {
+    expect(
+      resolveBoundTargetPromptSuggestionAction({
+        suggestion: '兔子',
+        currentPrompt: '',
+        key: 'a',
+      })
+    ).toBe('dismiss');
+    expect(
+      resolveBoundTargetPromptSuggestionAction({
+        suggestion: '兔子',
+        currentPrompt: '已有内容',
+        key: 'Enter',
+      })
+    ).toBe('dismiss');
+    expect(
+      resolveBoundTargetPromptSuggestionAction({
+        suggestion: '兔子',
+        currentPrompt: '',
+        key: 'Enter',
+        hasModifier: true,
+      })
+    ).toBe('dismiss');
+  });
+
+  it('输入法组合和下拉菜单操作期间不处理候选', () => {
+    expect(
+      resolveBoundTargetPromptSuggestionAction({
+        suggestion: '兔子',
+        currentPrompt: '',
+        key: 'Enter',
+        isComposing: true,
+      })
+    ).toBe('none');
+    expect(
+      resolveBoundTargetPromptSuggestionAction({
+        suggestion: '兔子',
+        currentPrompt: '',
+        key: 'Enter',
+        menuOpen: true,
+      })
+    ).toBe('none');
+  });
+
+  it('提示文案明确说明空格和回车复用', () => {
+    expect(formatBoundTargetPromptSuggestion('兔子', 'zh')).toBe(
+      '按空格或回车复用提示词：兔子'
+    );
+    expect(formatBoundTargetPromptSuggestion('rabbit', 'en')).toBe(
+      'Press Space or Enter to reuse: rabbit'
+    );
+  });
+
   it('仅把显式标记的图片视为永久参考图模式', () => {
     expect(isBoundTargetReferenceOnly({ aiTaskbarReferenceOnly: true })).toBe(
       true

--- a/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.ts
+++ b/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.ts
@@ -12,6 +12,65 @@ interface BoundTargetGenerationMetadata {
   generationAnchorId?: string;
 }
 
+export type BoundTargetPromptSuggestionAction = 'reuse' | 'dismiss' | 'none';
+
+export interface BoundTargetPromptSuggestionInput {
+  suggestion: string | null;
+  currentPrompt: string;
+  key: string;
+  code?: string;
+  isComposing?: boolean;
+  hasModifier?: boolean;
+  menuOpen?: boolean;
+}
+
+export function normalizeBoundTargetPromptSuggestion(
+  prompt: string | null | undefined
+): string | null {
+  const normalizedPrompt = prompt?.trim() || '';
+  return normalizedPrompt || null;
+}
+
+export function resolveBoundTargetPromptSuggestion(
+  prompt: string | null | undefined,
+  elementId: string,
+  dismissedElementId: string | null
+): string | null {
+  if (elementId === dismissedElementId) return null;
+  return normalizeBoundTargetPromptSuggestion(prompt);
+}
+
+export function resolveBoundTargetPromptSuggestionAction({
+  suggestion,
+  currentPrompt,
+  key,
+  code,
+  isComposing = false,
+  hasModifier = false,
+  menuOpen = false,
+}: BoundTargetPromptSuggestionInput): BoundTargetPromptSuggestionAction {
+  if (!suggestion || isComposing || menuOpen) return 'none';
+
+  if (
+    currentPrompt.length === 0 &&
+    !hasModifier &&
+    (key === 'Enter' || key === ' ' || key === 'Spacebar' || code === 'Space')
+  ) {
+    return 'reuse';
+  }
+
+  return 'dismiss';
+}
+
+export function formatBoundTargetPromptSuggestion(
+  suggestion: string,
+  language: 'zh' | 'en'
+): string {
+  return language === 'zh'
+    ? `按空格或回车复用提示词：${suggestion}`
+    : `Press Space or Enter to reuse: ${suggestion}`;
+}
+
 export type BoundImageTargetMode = 'follow' | 'reference';
 
 export function createBoundImageTargetStateKey(

--- a/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.ts
+++ b/packages/drawnix/src/components/ai-input-bar/target-bound-taskbar-state.ts
@@ -40,6 +40,18 @@ export function resolveBoundTargetPromptSuggestion(
   return normalizeBoundTargetPromptSuggestion(prompt);
 }
 
+export function shouldReleaseBoundTargetPromptDismissal(
+  targetElementId: string,
+  completedTaskId: string,
+  dismissedElementId: string | null,
+  dismissedGenerationTaskId: string | null
+): boolean {
+  return (
+    targetElementId === dismissedElementId &&
+    completedTaskId !== dismissedGenerationTaskId
+  );
+}
+
 export function resolveBoundTargetPromptSuggestionAction({
   suggestion,
   currentPrompt,

--- a/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
+++ b/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => {
     retryTask: vi.fn(),
     updateAnchor: vi.fn(),
     setNode: vi.fn(),
+    notifySelectionRefresh: vi.fn(),
   };
 });
 
@@ -139,7 +140,7 @@ vi.mock('../../services/media-result-handler', () => ({
 
 vi.mock('../../utils/selection-utils', () => ({
   getInsertionPointBelowBottommostElement: vi.fn(() => [100, 100]),
-  notifyAISelectionContentRefresh: vi.fn(),
+  notifyAISelectionContentRefresh: mocks.notifySelectionRefresh,
 }));
 
 vi.mock('../../utils/frame-insertion-utils', () => ({
@@ -243,6 +244,7 @@ describe('useAutoInsertToCanvas', () => {
     mocks.retryTask.mockReset();
     mocks.updateAnchor.mockReset();
     mocks.setNode.mockReset();
+    mocks.notifySelectionRefresh.mockReset();
   });
 
   afterEach(() => {
@@ -276,6 +278,19 @@ describe('useAutoInsertToCanvas', () => {
     });
 
     expect(mocks.quickInsert).toHaveBeenCalledTimes(1);
+    expect(mocks.quickInsert).toHaveBeenCalledWith(
+      'image',
+      '/__aitu_cache__/image/task-1.png',
+      [100, 100],
+      { width: 512, height: 512 },
+      expect.objectContaining({
+        prompt: '生成一张图',
+        aiPrompt: '生成一张图',
+        generationPrompt: '生成一张图',
+        generationTaskId: 'task-1',
+      })
+    );
+    expect(mocks.notifySelectionRefresh).toHaveBeenCalledTimes(1);
     expect(mocks.markAsInserted).toHaveBeenCalledWith(task.id, 'auto_insert');
     expect(mocks.completePostProcessing).toHaveBeenCalledWith(
       task.id,
@@ -386,6 +401,7 @@ describe('useAutoInsertToCanvas', () => {
       expect.objectContaining({ generationTaskId: 'task-batch-2' }),
       [1]
     );
+    expect(mocks.notifySelectionRefresh).toHaveBeenCalledTimes(1);
     expect(mocks.completePostProcessing).toHaveBeenCalledWith(
       'task-batch-1',
       1,

--- a/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
+++ b/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
@@ -789,7 +789,12 @@ export function useAutoInsertToCanvas(
                     clipIds: task.result?.clipIds,
                   }
                 : undefined;
-            const metadata = type === 'audio' ? audioMetadata : undefined;
+            const metadata =
+              type === 'image'
+                ? buildImageGenerationElementPatch(task)
+                : type === 'audio'
+                ? audioMetadata
+                : undefined;
             // 展开多图：优先使用 urls 数组
             const allUrls =
               type === 'text'
@@ -932,7 +937,9 @@ export function useAutoInsertToCanvas(
                   url: u,
                   dimensions,
                   metadata:
-                    type === 'audio'
+                    type === 'image'
+                      ? buildImageGenerationElementPatch(task, imageAnchor)
+                      : type === 'audio'
                       ? {
                           ...audioMetadata,
                           title:
@@ -1124,6 +1131,7 @@ export function useAutoInsertToCanvas(
                 insertedElementId,
                 allUrls[0]
               );
+              notifyAISelectionContentRefresh();
             }
 
             workflowCompletionService.completePostProcessing(
@@ -1475,6 +1483,7 @@ export function useAutoInsertToCanvas(
                   insertedImageItemByTaskId.set(item.task.id, insertedItem);
                 }
               });
+              notifyAISelectionContentRefresh();
             }
 
             for (const { task } of inserts) {


### PR DESCRIPTION
## 问题描述

草稿持久化重构后，选中带历史提示词的生成图片时，不再显示虚化候选，也无法按空格或回车复用；目标异步更新还可能把历史提示词重新写回输入框。

## 修复思路

- 历史提示词只作为一次性虚化候选，不覆盖可编辑输入值。
- 空输入按空格或回车只回填提示词，不立即发送。
- 普通输入、组合键和任务栏控件会取消候选。
- 候选取消后，同目标异步刷新不会重新回显。
- 保留每张图片独立草稿、仅作参考、跟随开关和现有生成绑定行为。
- 兼容历史图元的 generationPrompt、aiPrompt 和 prompt 字段。

## 更新代码架构

复用 target-bound-taskbar-state 管理候选规范化、键盘动作与异步回显抑制；AIInputBar 只负责候选状态、草稿协作和展示；同步更新既有状态单测与功能测试，不新增后端接口、持久化字段或画布结构。

## 验证

- Vitest：27/27 通过
- Drawnix 类型检查通过
- Web 类型检查通过
- Web E2E TypeScript 检查通过
- Prettier 与 git diff --check 通过
- ESLint：0 error，18 个基线 warning
- Chrome 桌面实测：虚化显示、空格/回车复用且不发送、普通输入取消、按钮取消、同目标刷新抑制、独立草稿恢复均通过
- Chrome 390x844：无横向溢出，候选文案保持在输入栏内