### PR TITLE
fix(sw): 修复 Gemini 3.1 图片渲染失败

### DIFF
--- a/apps/web/src/sw/image-fetch-response.spec.ts
+++ b/apps/web/src/sw/image-fetch-response.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUsableImageFetchResponse } from './image-fetch-response';
+
+describe('isUsableImageFetchResponse', () => {
+  it('accepts successful CORS responses', () => {
+    expect(isUsableImageFetchResponse({ ok: true, type: 'cors' })).toBe(true);
+  });
+
+  it('accepts opaque no-cors responses', () => {
+    expect(isUsableImageFetchResponse({ ok: false, type: 'opaque' })).toBe(
+      true
+    );
+  });
+
+  it.each([403, 404, 500])(
+    'rejects an HTTP %s response so another fetch mode can be tried',
+    (status) => {
+      const response = new Response(null, { status });
+
+      expect(isUsableImageFetchResponse(response)).toBe(false);
+    }
+  );
+
+  it('rejects missing responses', () => {
+    expect(isUsableImageFetchResponse(undefined)).toBe(false);
+    expect(isUsableImageFetchResponse(null)).toBe(false);
+  });
+});

--- a/apps/web/src/sw/image-fetch-response.ts
+++ b/apps/web/src/sw/image-fetch-response.ts
@@ -1,0 +1,5 @@
+export function isUsableImageFetchResponse(
+  response: Pick<Response, 'ok' | 'type'> | null | undefined
+): boolean {
+  return Boolean(response && (response.ok || response.type === 'opaque'));
+}

--- a/apps/web/src/sw/index.ts
+++ b/apps/web/src/sw/index.ts
@@ -42,6 +42,7 @@ import {
   shouldUseOriginFirstPreload,
   shouldUseAppShellStrategy,
 } from './app-shell-routing';
+import { isUsableImageFetchResponse } from './image-fetch-response';
 
 // fix: self redeclaration error and type casting
 const sw = self as unknown as ServiceWorkerGlobalScope;
@@ -6429,7 +6430,7 @@ async function handleImageRequestInternal(
     }
 
     // 尝试多种获取方式，每种方式都支持重试和域名切换
-    let response;
+    let response: Response | undefined;
     const fetchOptions = [
       // 1. 优先尝试cors模式（可以缓存响应）
       {
@@ -6479,6 +6480,7 @@ async function handleImageRequestInternal(
       }
 
       for (const options of fetchOptions) {
+        response = undefined;
         try {
           // console.log(`Service Worker [${requestId}]: Trying fetch with options (${isUsingFallback ? 'fallback' : 'original'} URL, mode: ${options.mode || 'default'}):`, options);
 
@@ -6488,16 +6490,21 @@ async function handleImageRequestInternal(
           for (let attempt = 0; attempt <= 2; attempt++) {
             try {
               // console.log(`Service Worker [${requestId}]: Fetch attempt ${attempt + 1}/3 with options on ${isUsingFallback ? 'fallback' : 'original'} URL`);
-              response = await fetch(currentUrl, options);
+              const fetchedResponse = await fetch(currentUrl, options);
 
-              // 成功条件：status !== 0 或者是 opaque 响应（no-cors 模式）
-              if (
-                response &&
-                (response.status !== 0 || response.type === 'opaque')
-              ) {
+              if (isUsableImageFetchResponse(fetchedResponse)) {
+                response = fetchedResponse;
                 // console.log(`Service Worker [${requestId}]: Fetch successful with status: ${response.status}, type: ${response.type} from ${isUsingFallback ? 'fallback' : 'original'} URL`);
                 break;
               }
+
+              // 4xx/5xx 是有效的 HTTP 响应，但不能作为图片返回。
+              // 同一模式重试不会改变结果，直接切换到下一种 fetch 模式。
+              lastError = new Error(
+                `HTTP ${fetchedResponse.status}: ${fetchedResponse.statusText}`
+              );
+              finalError = lastError;
+              break;
             } catch (fetchError: any) {
               // console.warn(`Service Worker [${requestId}]: Fetch attempt ${attempt + 1} failed on ${isUsingFallback ? 'fallback' : 'original'} URL:`, fetchError);
               lastError = fetchError;
@@ -6565,11 +6572,7 @@ async function handleImageRequestInternal(
             });
           }
 
-          // 成功条件：status !== 0 或者是 opaque 响应（no-cors 模式）
-          if (
-            response &&
-            (response.status !== 0 || response.type === 'opaque')
-          ) {
+          if (isUsableImageFetchResponse(response)) {
             break;
           }
 
@@ -6585,8 +6588,7 @@ async function handleImageRequestInternal(
       }
 
       // 如果当前URL成功获取到响应，跳出URL循环
-      // 成功条件：status !== 0 或者是 opaque 响应（no-cors 模式）
-      if (response && (response.status !== 0 || response.type === 'opaque')) {
+      if (isUsableImageFetchResponse(response)) {
         break;
       } else {
         // 如果是配置的域名且是第一次尝试（原始URL），标记为失败域名
@@ -6606,8 +6608,8 @@ async function handleImageRequestInternal(
       }
     }
 
-    // 检查是否获取失败（排除 opaque 响应，那是 no-cors 模式的正常结果）
-    if (!response || (response.status === 0 && response.type !== 'opaque')) {
+    // 检查是否获取失败（opaque 响应是 no-cors 模式的正常结果）
+    if (!response || !isUsableImageFetchResponse(response)) {
       let errorMessage = 'All fetch attempts failed';
 
       if (domainConfig && domainConfig.fallbackDomain) {


### PR DESCRIPTION
## 问题背景

使用 `gemini-3.1-flash-image-preview`（nano-banana-2）生成图片时，生成任务能够正常完成并返回图片地址，但画布和任务列表中的图片显示“无法加载”。其他图片模型不受影响。

## 根因

该模型返回的 OSS 图片地址在 Service Worker 的 CORS 请求下会返回 HTTP 403。原有图片请求逻辑将所有 `status !== 0` 的响应都视为成功，因此 403 响应会提前终止后续 fetch 模式与原生 `<img>` 回退流程，最终把不可用的错误响应交给渲染层。

这个问题只在该模型上稳定出现，是因为它的图片交付地址和跨域响应行为与其他模型不同，而不是生成任务本身失败。

## 修复内容

- 新增统一的图片响应可用性判断：仅接受 `response.ok` 或 `opaque` 响应。
- HTTP 4xx/5xx 响应不再被误判为成功，直接切换到下一种 fetch 模式。
- 每次切换 fetch 策略前清空旧响应，避免失败响应污染后续判断。
- 统一 URL 循环、fallback 和最终返回前的响应校验规则。
- 当所有 Service Worker fetch 模式都不可用时，保留现有失败域名标记与原生 `<img>` 透传机制，让浏览器按图片标签方式加载资源。

## 行为变化

- CORS 2xx 响应：继续正常返回并缓存。
- `no-cors` opaque 响应：继续视为可用。
- HTTP 403/404/500：不再作为图片响应返回，继续执行下一种加载策略。
- 网络异常和所有策略失败：继续沿用现有 fallback/原生图片加载流程。

## 测试

新增 `isUsableImageFetchResponse` 单元测试，覆盖：

- 成功的 CORS 响应
- opaque `no-cors` 响应
- HTTP 403、404、500
- `null` / `undefined` 响应

本地验证结果：

- `pnpm exec vitest run apps/web/src/sw/image-fetch-response.spec.ts`：6/6 通过
- `pnpm nx run web:typecheck`：通过
- `pnpm nx run web:build-sw`：通过
- 完整 `pnpm nx run web:build` 生产构建：通过
- ESLint、Prettier、`git diff --check`：通过

## 风险评估

改动仅收紧 Service Worker 对图片 fetch 响应的成功判定，不改变生成接口、任务状态或缓存数据结构。正常 2xx 与 opaque 响应行为保持不变，影响范围集中在此前被误判为成功的 HTTP 错误响应。

## CI 状态说明

- Netlify Deploy Preview 已成功生成，Header/Redirect 检查通过。
- GitHub `main` 检查中的 `drawnix:test` 失败来自 AI 输入解析、工作流生成和 Gemini 消息工具等未改动模块；相关失败文件在本 PR 与 `develop` 中完全一致。
- Bundle Size 失败来自既有 `AI Chat` 包体积超过 `.size-limit.json` 阈值，本 PR 未修改 AI Chat bundle 或体积配置。
- Vercel 状态为仓库集成需要授权（Authorization required to deploy），不是应用构建错误。
- 本次变更直接相关的单元测试、Web TypeScript、Service Worker 生产构建和完整 Web 生产构建均已通过。